### PR TITLE
CAS3 V2 Bedspace occupancy report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspacesEntity.kt
@@ -31,8 +31,8 @@ data class Cas3BedspacesEntity(
   var reference: String,
   var notes: String?,
   val startDate: LocalDate,
-  val endDate: LocalDate?,
-  val createdAt: OffsetDateTime,
+  var endDate: LocalDate?,
+  var createdAt: OffsetDateTime,
   val createdDate: LocalDate,
 
   @ManyToMany

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/BedspaceOccupancyReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/BedspaceOccupancyReportGenerator.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.properties.BedspaceOccupancyReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.util.toShortBase58
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.earliestDateOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilInclusive
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.latestDateOf
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
+import java.util.UUID
+
+class BedspaceOccupancyReportGenerator(
+  private val workingDayService: WorkingDayService,
+) : ReportGenerator<BedspaceOccupancyReportData, BedspaceOccupancyReportRow, BedspaceOccupancyReportProperties>(
+  BedspaceOccupancyReportRow::class,
+) {
+  override fun filter(properties: BedspaceOccupancyReportProperties): (BedspaceOccupancyReportData) -> Boolean = {
+    true
+  }
+
+  override val convert: BedspaceOccupancyReportData.(properties: BedspaceOccupancyReportProperties) -> List<BedspaceOccupancyReportRow> =
+    { properties ->
+      var bookedDaysActiveAndClosed = 0
+      var confirmedDays = 0
+      var provisionalDays = 0
+      var scheduledTurnaroundDays = 0
+      var effectiveTurnaroundDays = 0
+      var voidDays = 0
+
+      val bedspace = this.bedspaceReportData
+      val nonCancelledBookings =
+        this.bookingsReportData
+          .filterNot { bookingCancellationReportData.map { it.bookingId }.contains(it.bookingId) }
+          .groupBy { it.bookingId }
+          .mapValues { it.value.sortedByDescending { it.arrivalCreatedAt }.take(1) }
+          .map { it.value.first() }
+      val nonCancelledVoids = this.voidBedspaceReportData.filter { it.cancellationId == null }
+
+      nonCancelledBookings
+        .forEach { booking ->
+          val daysOfBookingInMonth = latestDateOf(booking.arrivalDate, properties.startDate)
+            .getDaysUntilInclusive(earliestDateOf(booking.departureDate, properties.endDate))
+            .count()
+
+          when {
+            booking.arrivalId != null -> bookedDaysActiveAndClosed += daysOfBookingInMonth
+            booking.confirmationId != null && booking.arrivalId == null -> confirmedDays += daysOfBookingInMonth
+            booking.confirmationId == null -> provisionalDays += daysOfBookingInMonth
+          }
+
+          val bookingTurnaround =
+            this.bookingTurnaroundReportData.filter { it.bookingId == booking.bookingId }.maxByOrNull { it.createdAt }
+          if (bookingTurnaround != null) {
+            val turnaroundStartDate = booking.departureDate.plusDays(1)
+            val turnaroundEndDate =
+              workingDayService.addWorkingDays(booking.departureDate, bookingTurnaround.workingDayCount)
+            val firstDayOfTurnaroundInMonth = latestDateOf(turnaroundStartDate, properties.startDate)
+            val lastDayOfTurnaroundInMonth = earliestDateOf(turnaroundEndDate, properties.endDate)
+
+            scheduledTurnaroundDays += workingDayService.getWorkingDaysCount(
+              firstDayOfTurnaroundInMonth,
+              lastDayOfTurnaroundInMonth,
+            )
+            effectiveTurnaroundDays += firstDayOfTurnaroundInMonth
+              .getDaysUntilInclusive(lastDayOfTurnaroundInMonth)
+              .count()
+          }
+        }
+
+      nonCancelledVoids.forEach { void ->
+        val daysOfVoidInMonth = latestDateOf(void.startDate, properties.startDate)
+          .getDaysUntilInclusive(earliestDateOf(void.endDate, properties.endDate))
+          .count()
+
+        voidDays += daysOfVoidInMonth
+      }
+
+      val totalBookedDays = bookedDaysActiveAndClosed
+      val bedspaceOnlineDaysStartDate =
+        if (bedspace.bedspaceStartDate == null) {
+          properties.startDate
+        } else {
+          latestDateOf(
+            bedspace.bedspaceStartDate!!.toLocalDate(),
+            properties.startDate,
+          )
+        }
+
+      val bedspaceOnlineDaysEndDate =
+        if (bedspace.bedspaceEndDate == null) {
+          properties.endDate
+        } else {
+          earliestDateOf(
+            bedspace.bedspaceEndDate!!,
+            properties.endDate,
+          )
+        }
+
+      val bedspaceOnlineDays = bedspaceOnlineDaysStartDate
+        .getDaysUntilInclusive(bedspaceOnlineDaysEndDate)
+        .count()
+
+      listOf(
+        BedspaceOccupancyReportRow(
+          probationRegion = bedspace.probationRegionName,
+          pdu = bedspace.probationDeliveryUnitName,
+          localAuthority = bedspace.localAuthorityName,
+          propertyRef = bedspace.premisesName,
+          addressLine1 = bedspace.addressLine1,
+          town = bedspace.town,
+          postCode = bedspace.postCode,
+          bedspaceRef = bedspace.roomName,
+          bookedDaysActiveAndClosed = bookedDaysActiveAndClosed,
+          confirmedDays = confirmedDays,
+          provisionalDays = provisionalDays,
+          scheduledTurnaroundDays = scheduledTurnaroundDays,
+          effectiveTurnaroundDays = effectiveTurnaroundDays,
+          voidDays = voidDays,
+          totalBookedDays = totalBookedDays,
+          bedspaceStartDate = if (bedspace.bedspaceStartDate == null) null else bedspace.bedspaceStartDate!!.toLocalDate(),
+          bedspaceEndDate = bedspace.bedspaceEndDate,
+          bedspaceOnlineDays = bedspaceOnlineDays,
+          occupancyRate = totalBookedDays.toDouble() / bedspaceOnlineDays,
+          uniquePropertyRef = UUID.fromString(bedspace.premisesId).toShortBase58(),
+          uniqueBedspaceRef = UUID.fromString(bedspace.bedspaceId).toShortBase58(),
+        ),
+      )
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/BedspaceUsageReportGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/generator/BedspaceUsageReportGenerator.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3Boo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getDaysUntilExclusiveEnd
 
-class Cas3BedspaceUsageReportGenerator(
+class BedspaceUsageReportGenerator(
   private val bookingTransformer: Cas3BookingTransformer,
   private val bookingRepository: Cas3v2BookingRepository,
   private val cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/BedspaceOccupancyReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/BedspaceOccupancyReportData.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model
+
+import java.time.Instant
+import java.time.LocalDate
+
+data class BedspaceOccupancyReportData(
+  val bedspaceReportData: BedspaceOccupancyBedspaceReportData,
+  val bookingsReportData: List<BedspaceOccupancyBookingReportData>,
+  val bookingCancellationReportData: List<BedspaceOccupancyBookingCancellationReportData>,
+  val bookingTurnaroundReportData: List<BedspaceOccupancyBookingTurnaroundReportData>,
+  val voidBedspaceReportData: List<BedspaceOccupancyVoidBedspaceReportData>,
+)
+
+interface BedspaceOccupancyBedspaceReportData {
+  val bedspaceId: String
+  val probationRegionName: String?
+  val probationDeliveryUnitName: String?
+  val localAuthorityName: String?
+  val premisesName: String
+  val addressLine1: String
+  val town: String?
+  val postCode: String
+  val roomName: String
+  val bedspaceStartDate: Instant?
+  val bedspaceEndDate: LocalDate?
+  val premisesId: String
+}
+
+interface BedspaceOccupancyBookingReportData {
+  val bookingId: String
+  val arrivalDate: LocalDate
+  val departureDate: LocalDate
+  val bedspaceId: String
+  val arrivalId: String?
+  val arrivalCreatedAt: Instant?
+  val confirmationId: String?
+}
+
+interface BedspaceOccupancyBookingCancellationReportData {
+  val cancellationId: String
+  val bedspaceId: String
+  val bookingId: String
+  val createdAt: Instant
+}
+
+interface BedspaceOccupancyBookingTurnaroundReportData {
+  val turnaroundId: String
+  val bedspaceId: String
+  val bookingId: String
+  val workingDayCount: Int
+  val createdAt: Instant
+}
+
+interface BedspaceOccupancyVoidBedspaceReportData {
+  val bedspaceId: String
+  val startDate: LocalDate
+  val endDate: LocalDate
+  val cancellationId: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/BedspaceOccupancyReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/model/BedspaceOccupancyReportRow.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model
+
+import java.time.LocalDate
+
+data class BedspaceOccupancyReportRow(
+  val probationRegion: String?,
+  val pdu: String?,
+  val localAuthority: String?,
+  val propertyRef: String,
+  val addressLine1: String,
+  val town: String?,
+  val postCode: String,
+  val bedspaceRef: String,
+  val bookedDaysActiveAndClosed: Int,
+  val confirmedDays: Int,
+  val provisionalDays: Int,
+  val scheduledTurnaroundDays: Int,
+  val effectiveTurnaroundDays: Int,
+  val voidDays: Int,
+  val totalBookedDays: Int,
+  val bedspaceStartDate: LocalDate?,
+  val bedspaceEndDate: LocalDate?,
+  val bedspaceOnlineDays: Int,
+  val occupancyRate: Double,
+  val uniquePropertyRef: String,
+  val uniqueBedspaceRef: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/properties/BedspaceOccupancyReportProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/reporting/properties/BedspaceOccupancyReportProperties.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.properties
+
+import java.time.LocalDate
+import java.util.UUID
+
+data class BedspaceOccupancyReportProperties(
+  val probationRegionId: UUID?,
+  val startDate: LocalDate,
+  val endDate: LocalDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/BedspaceOccupancyReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/BedspaceOccupancyReportRepository.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBookingCancellationReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBookingTurnaroundReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyVoidBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
+import java.time.LocalDate
+import java.util.UUID
+
+interface BedspaceOccupancyReportRepository : JpaRepository<BedEntity, UUID> {
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedspaceId,
+        CAST(p.id AS VARCHAR) AS premisesId,
+        pr.name AS probationRegionName,
+        pdu.name AS probationDeliveryUnitName,
+        laa.name AS localAuthorityName,
+        p.name AS premisesName,
+        p.address_line1 AS addressLine1,
+        p.town AS town,
+        p.postcode AS postCode,
+        b.reference AS roomName,
+        b.created_at AS bedspaceStartDate,
+        b.end_date AS bedspaceEndDate
+    FROM cas3_bedspaces b
+    LEFT JOIN cas3_premises p ON b.premises_id = p.id
+    LEFT JOIN probation_delivery_units pdu ON p.probation_delivery_unit_id = pdu.id
+    LEFT JOIN probation_regions pr ON pdu.probation_region_id = pr.id
+    LEFT JOIN local_authority_areas laa ON p.local_authority_area_id = laa.id
+    WHERE (CAST(:probationRegionId AS UUID) IS NULL OR pdu.probation_region_id = :probationRegionId)
+      AND ((b.created_at IS NULL OR b.created_at <= :endDate) AND (b.end_date IS NULL OR b.end_date >= :startDate))
+    ORDER BY b.reference
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBedspaces(
+    probationRegionId: UUID?,
+    startDate: LocalDate,
+    endDate: LocalDate,
+  ): List<BedspaceOccupancyBedspaceReportData>
+
+  @Query(
+    """
+    SELECT
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      booking.arrival_date AS arrivalDate,
+      booking.departure_date AS departureDate,
+      CAST(bedspace.id AS VARCHAR) AS bedspaceId,
+      CAST(arrival.id AS VARCHAR) AS arrivalId,
+      arrival.created_at AS arrivalCreatedAt,
+      CAST(confirmation.id AS VARCHAR) AS confirmationId
+    From bookings booking
+    INNER JOIN cas3_bedspaces bedspace ON bedspace.id = booking.bed_id
+    INNER JOIN cas3_premises premises ON booking.premises_id = premises.id
+    INNER JOIN probation_delivery_units pdu ON premises.probation_delivery_unit_id = pdu.id
+    INNER JOIN probation_regions probation_region ON probation_region.id = pdu.probation_region_id
+    LEFT JOIN arrivals arrival ON booking.id = arrival.booking_id
+    LEFT JOIN cas3_confirmations confirmation ON booking.id = confirmation.booking_id
+    WHERE (CAST(:probationRegionId AS UUID) IS NULL OR pdu.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingsByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedspaceOccupancyBookingReportData>
+
+  @Query(
+    """
+    SELECT
+      CAST(cancellation.id AS VARCHAR) AS cancellationId,
+      CAST(bedspace.id AS VARCHAR) AS bedspaceId,
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      cancellation.created_at AS createdAt
+    From cancellations cancellation
+    INNER JOIN bookings booking ON cancellation.booking_id = booking.id
+    INNER JOIN cas3_bedspaces bedspace ON bedspace.id = booking.bed_id
+    INNER JOIN cas3_premises premises ON booking.premises_id = premises.id
+    INNER JOIN probation_delivery_units pdu ON premises.probation_delivery_unit_id = pdu.id
+    INNER JOIN probation_regions probation_region ON probation_region.id = pdu.probation_region_id
+    WHERE (CAST(:probationRegionId AS UUID) IS NULL OR pdu.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingCancellationsByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedspaceOccupancyBookingCancellationReportData>
+
+  @Query(
+    """
+    SELECT
+      CAST(turnaround.Id AS VARCHAR) AS turnaroundId,
+      CAST(bedspace.id AS VARCHAR) AS bedspaceId,
+      CAST(booking.id AS VARCHAR) AS bookingId,
+      turnaround.created_at AS CreatedAt,
+      working_day_count AS workingDayCount
+    From cas3_turnarounds turnaround
+    INNER JOIN bookings booking ON booking.id = turnaround.booking_id
+    INNER JOIN cas3_bedspaces bedspace ON bedspace.id = booking.bed_id
+    INNER JOIN cas3_premises premises ON booking.premises_id = premises.id
+    INNER JOIN probation_delivery_units pdu ON premises.probation_delivery_unit_id = pdu.id
+    INNER JOIN probation_regions probation_region ON probation_region.id = pdu.probation_region_id
+    WHERE (CAST(:probationRegionId AS UUID) IS NULL OR pdu.probation_region_id = :probationRegionId)
+      AND booking.arrival_date <= :endDate AND booking.departure_date >= :startDate
+    """,
+    nativeQuery = true,
+  )
+  fun findAllBookingTurnaroundByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedspaceOccupancyBookingTurnaroundReportData>
+
+  @Query(
+    """
+    SELECT
+        CAST(b.id AS VARCHAR) AS bedspaceId,
+        vb.start_date AS startDate,
+        vb.end_date AS endDate,
+        null AS cancellationId
+    From cas3_void_bedspaces vb
+    LEFT JOIN cas3_bedspaces b ON vb.bedspace_id = b.id
+    LEFT JOIN cas3_premises p ON b.premises_id = p.id
+    INNER JOIN probation_delivery_units pdu ON p.probation_delivery_unit_id = pdu.id
+    WHERE (CAST(:probationRegionId AS UUID) IS NULL OR pdu.probation_region_id = :probationRegionId)
+      AND vb.start_date <= :endDate AND vb.end_date >= :startDate
+      AND vb.cancellation_date is NULL
+    ORDER BY vb.id     
+    """,
+    nativeQuery = true,
+  )
+  fun findAllVoidBedspaceByOverlappingDate(probationRegionId: UUID?, startDate: LocalDate, endDate: LocalDate): List<BedspaceOccupancyVoidBedspaceReportData>
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenACas3Premises.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/givens/GivenACas3Premises.kt
@@ -26,6 +26,19 @@ fun IntegrationTestBase.givenACas3Premises(
 )
 
 fun IntegrationTestBase.givenACas3Premises(
+  probationDeliveryUnit: ProbationDeliveryUnitEntity = probationDeliveryUnitFactory.produceAndPersist {
+    withProbationRegion(probationRegionEntityFactory.produceAndPersist())
+  },
+  status: Cas3PremisesStatus = randomOf(Cas3PremisesStatus.entries),
+  endDate: LocalDate? = null,
+) = givenACas3Premises(
+  name = randomStringMultiCaseWithNumbers(8),
+  probationDeliveryUnit = probationDeliveryUnit,
+  status = status,
+  endDate = endDate,
+)
+
+fun IntegrationTestBase.givenACas3Premises(
   name: String = randomStringMultiCaseWithNumbers(8),
   probationDeliveryUnit: ProbationDeliveryUnitEntity = probationDeliveryUnitFactory.produceAndPersist {
     withProbationRegion(probationRegionEntityFactory.produceAndPersist())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3VoidBedspaceJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3VoidBedspaceJobTest.kt
@@ -4,9 +4,7 @@ import com.ninjasquad.springmockk.SpykBean
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.Cas3VoidBedspaceMigrationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
@@ -21,9 +19,6 @@ class Cas3VoidBedspaceJobTest : MigrationJobTestBase() {
 
   @SpykBean
   private lateinit var cas3VoidBedspacesRepository: Cas3VoidBedspaceMigrationRepository
-
-  @Autowired
-  private lateinit var cas3BedspacesRepository: Cas3BedspacesRepository
 
   private fun createPremises(user: UserEntity): TemporaryAccommodationPremisesEntity {
     val probationDeliveryUnit = probationDeliveryUnitFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceOccupancyReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceOccupancyReportTest.kt
@@ -1,0 +1,1143 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ExcessiveColumns.Remove
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.io.readExcel
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenACas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.util.toShortBase58
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.CAS3_ASSESSOR
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class Cas3v2BedspaceOccupancyReportTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun beforeEach() {
+    mockFeatureFlagService.setFlag("cas3-reports-with-new-bedspace-model-tables-enabled", true)
+  }
+
+  @AfterEach
+  fun afterEach() {
+    mockFeatureFlagService.reset()
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK with correct body`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premisesOne, bedspaceOne) = setupPremisesWithABedspace(user)
+        bedspaceOne.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspaceOne)
+
+        val (_, bedspaceTwo) = setupPremisesWithABedspace(user)
+        bedspaceTwo.apply {
+          createdAt = OffsetDateTime.parse("2023-01-09T08:31:00+00:00")
+          endDate = LocalDate.parse("2023-03-27")
+        }
+        cas3BedspacesRepository.save(bedspaceTwo)
+
+        val (_, bedspaceThree) = setupPremisesWithABedspace(user)
+        bedspaceThree.apply { createdAt = OffsetDateTime.parse("2023-07-11T13:07:00+00:00") }
+        cas3BedspacesRepository.save(bedspaceThree)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premisesOne)
+          withBedspace(bedspaceOne)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+          withDepartureDate(LocalDate.parse("2023-04-17"))
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = premisesOne.probationDeliveryUnit.name,
+            localAuthority = premisesOne.localAuthorityArea?.name,
+            propertyRef = premisesOne.name,
+            addressLine1 = premisesOne.addressLine1,
+            town = premisesOne.town,
+            postCode = premisesOne.postcode,
+            bedspaceRef = bedspaceOne.reference,
+            bookedDaysActiveAndClosed = 0,
+            confirmedDays = 0,
+            provisionalDays = 17,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 0,
+            totalBookedDays = 0,
+            bedspaceStartDate = bedspaceOne.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspaceOne.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.0,
+            uniquePropertyRef = premisesOne.id.toShortBase58(),
+            uniqueBedspaceRef = bedspaceOne.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK with correct body with pdu and local authority`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-04-05"))
+          withDepartureDate(LocalDate.parse("2023-04-15"))
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 0,
+            confirmedDays = 0,
+            provisionalDays = 11,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 0,
+            totalBookedDays = 0,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.0,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly bookedDaysActiveAndClosed the total number of days for Bookings that are marked as arrived`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+          withDepartureDate(LocalDate.parse("2023-04-17"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 17,
+            confirmedDays = 0,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 0,
+            totalBookedDays = 17,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.5666666666666667,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly bookedDaysActiveAndClosed when there are multiple cancellations in the same period`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking1 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-02"))
+          withDepartureDate(LocalDate.parse("2023-05-25"))
+        }
+
+        val booking2 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(randomStringLowerCase(10))
+          withArrivalDate(LocalDate.parse("2023-02-18"))
+          withDepartureDate(LocalDate.parse("2023-05-11"))
+        }
+
+        val booking3 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(randomStringLowerCase(10))
+          withArrivalDate(LocalDate.parse("2023-02-15"))
+          withDepartureDate(LocalDate.parse("2023-05-08"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking1)
+          withArrivalDate(LocalDate.parse("2023-03-02"))
+          withExpectedDepartureDate(LocalDate.parse("2023-05-25"))
+        }
+
+        cas3CancellationEntityFactory.produceAndPersist {
+          withBooking(booking2)
+          withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3CancellationEntityFactory.produceAndPersist {
+          withBooking(booking3)
+          withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withWorkingDayCount(2)
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withWorkingDayCount(5)
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withWorkingDayCount(2)
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking2)
+          withWorkingDayCount(2)
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking3)
+          withWorkingDayCount(2)
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 30,
+            confirmedDays = 0,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 0,
+            totalBookedDays = 30,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 1.0,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly bookedDaysActiveAndClosed when there are multiple bookings in the same period`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        cas3VoidBedspaceEntityFactory.produceAndPersist {
+          withBedspace(bedspace)
+          withStartDate(LocalDate.parse("2023-04-28"))
+          withEndDate(LocalDate.parse("2023-05-04"))
+          withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
+        }
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking1 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+          withDepartureDate(LocalDate.parse("2023-04-05"))
+        }
+
+        val booking2 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(randomStringLowerCase(10))
+          withArrivalDate(LocalDate.parse("2023-04-07"))
+          withDepartureDate(LocalDate.parse("2023-04-14"))
+        }
+
+        val booking3 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(randomStringLowerCase(10))
+          withArrivalDate(LocalDate.parse("2023-04-08"))
+          withDepartureDate(LocalDate.parse("2023-04-22"))
+        }
+
+        cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(randomStringLowerCase(10))
+          withArrivalDate(LocalDate.parse("2023-04-24"))
+          withDepartureDate(LocalDate.parse("2023-05-20"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking1)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+          withExpectedDepartureDate(LocalDate.parse("2023-04-05"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withCreatedAt(OffsetDateTime.parse("2023-02-25T16:00:00+01:00"))
+          withWorkingDayCount(2)
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withCreatedAt(OffsetDateTime.parse("2023-02-12T17:00:00+01:00"))
+          withWorkingDayCount(5)
+        }
+
+        cas3CancellationEntityFactory.produceAndPersist {
+          withBooking(booking2)
+          withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking3)
+          withArrivalDate(LocalDate.parse("2023-04-08"))
+          withExpectedDepartureDate(LocalDate.parse("2023-04-22"))
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 20,
+            confirmedDays = 0,
+            provisionalDays = 7,
+            scheduledTurnaroundDays = 2,
+            effectiveTurnaroundDays = 2,
+            voidDays = 3,
+            totalBookedDays = 20,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.6666666666666666,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly bookedDaysActiveAndClosed when there are multiple booking arrivals in the same period`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2024-04-05"))
+          withDepartureDate(LocalDate.parse("2024-06-04"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withArrivalDate(LocalDate.parse("2024-04-05"))
+          withExpectedDepartureDate(LocalDate.parse("2024-06-28"))
+          withCreatedAt(OffsetDateTime.parse("2024-04-06T08:34:56.789Z"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withArrivalDate(LocalDate.parse("2024-04-07"))
+          withExpectedDepartureDate(LocalDate.parse("2024-06-30"))
+          withCreatedAt(OffsetDateTime.parse("2024-04-06T09:57:21.789Z"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withArrivalDate(LocalDate.parse("2024-04-06"))
+          withExpectedDepartureDate(LocalDate.parse("2024-06-27"))
+          withCreatedAt(OffsetDateTime.parse("2024-04-06T09:53:17.789Z"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking)
+          withCreatedAt(OffsetDateTime.parse("2024-03-28T17:00:00+01:00"))
+          withWorkingDayCount(7)
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 26,
+            confirmedDays = 0,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 0,
+            totalBookedDays = 26,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.8666666666666667,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2024-04-01&endDate=2024-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows confirmedDays with the total number of days for Bookings that are marked as confirmed but not arrived`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+          withDepartureDate(LocalDate.parse("2023-04-10"))
+        }
+
+        cas3v2ConfirmationEntityFactory.produceAndPersist {
+          withBooking(booking)
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 0,
+            confirmedDays = 10,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 0,
+            totalBookedDays = 0,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.0,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly scheduledTurnaroundDays the number of working days in the report period for the turnaround`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-04-07"))
+          withDepartureDate(LocalDate.parse("2023-04-21"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking)
+          withWorkingDayCount(5)
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 0,
+            confirmedDays = 0,
+            provisionalDays = 15,
+            scheduledTurnaroundDays = 5,
+            effectiveTurnaroundDays = 7,
+            voidDays = 0,
+            totalBookedDays = 0,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.0,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly effectiveTurnaroundDays the total number of days in the report period for the turnaround`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-25"))
+          withDepartureDate(LocalDate.parse("2023-04-17"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking)
+          withWorkingDayCount(5)
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 0,
+            confirmedDays = 0,
+            provisionalDays = 17,
+            scheduledTurnaroundDays = 5,
+            effectiveTurnaroundDays = 7,
+            voidDays = 0,
+            totalBookedDays = 0,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.0,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly scheduledTurnaroundDays and effectiveTurnaroundDays when there are multiple bookings`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking1 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2024-06-24"))
+          withDepartureDate(LocalDate.parse("2024-09-16"))
+        }
+
+        val booking2 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2024-03-21"))
+          withDepartureDate(LocalDate.parse("2024-06-13"))
+        }
+
+        val booking3 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2024-03-22"))
+          withDepartureDate(LocalDate.parse("2024-06-12"))
+        }
+
+        val booking4 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2024-03-15"))
+          withDepartureDate(LocalDate.parse("2024-06-07"))
+        }
+
+        val booking5 = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2024-03-12"))
+          withDepartureDate(LocalDate.parse("2024-06-04"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking3)
+          withArrivalDate(LocalDate.parse("2024-03-22"))
+          withExpectedDepartureDate(LocalDate.parse("2024-06-14"))
+          withCreatedAt(OffsetDateTime.parse("2024-03-25T09:23:17.789Z"))
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking1)
+          withArrivalDate(LocalDate.parse("2024-06-24"))
+          withExpectedDepartureDate(LocalDate.parse("2024-09-16"))
+          withCreatedAt(OffsetDateTime.parse("2024-06-28T08:31:17.789Z"))
+        }
+
+        cas3CancellationEntityFactory.produceAndPersist {
+          withBooking(booking4)
+          withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3CancellationEntityFactory.produceAndPersist {
+          withBooking(booking2)
+          withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3CancellationEntityFactory.produceAndPersist {
+          withBooking(booking5)
+          withYieldedReason { cancellationReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking5)
+          withWorkingDayCount(7)
+          withCreatedAt(OffsetDateTime.parse("2024-03-06T10:45:00+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking4)
+          withWorkingDayCount(7)
+          withCreatedAt(OffsetDateTime.parse("2024-03-13T09:34:00+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking2)
+          withWorkingDayCount(7)
+          withCreatedAt(OffsetDateTime.parse("2024-03-13T14:13:00+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking3)
+          withWorkingDayCount(7)
+          withCreatedAt(OffsetDateTime.parse("2024-03-13T16:43:00+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking3)
+          withWorkingDayCount(8)
+          withCreatedAt(OffsetDateTime.parse("2024-06-13T09:23:00+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking1)
+          withWorkingDayCount(7)
+          withCreatedAt(OffsetDateTime.parse("2024-06-17T13:55:00+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking3)
+          withWorkingDayCount(5)
+          withCreatedAt(OffsetDateTime.parse("2024-06-18T09:42:27+01:00"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking3)
+          withWorkingDayCount(3)
+          withCreatedAt(OffsetDateTime.parse("2024-06-18T09:42:37+01:00"))
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 19,
+            confirmedDays = 0,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 3,
+            effectiveTurnaroundDays = 5,
+            voidDays = 0,
+            totalBookedDays = 19,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.6333333333333333,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2024-06-01&endDate=2024-06-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly voidDays the total number of days in the month for voids`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        cas3VoidBedspaceEntityFactory.produceAndPersist {
+          withBedspace(bedspace)
+          withStartDate(LocalDate.parse("2023-03-28"))
+          withEndDate(LocalDate.parse("2023-04-04"))
+          withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
+        }
+
+        cas3VoidBedspaceEntityFactory.produceAndPersist {
+          withBedspace(bedspace)
+          withStartDate(LocalDate.parse("2023-04-25"))
+          withEndDate(LocalDate.parse("2023-05-03"))
+          withYieldedReason { cas3VoidBedspaceReasonEntityFactory.produceAndPersist() }
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 0,
+            confirmedDays = 0,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 0,
+            effectiveTurnaroundDays = 0,
+            voidDays = 10,
+            totalBookedDays = 0,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.0,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  @Test
+  fun `Get bedspace occupancy report returns OK and shows correctly totalBookedDays`() {
+    givenAUser(roles = listOf(CAS3_ASSESSOR)) { user, jwt ->
+      givenAnOffender { offenderDetails, inmateDetails ->
+        val (premises, bedspace) = setupPremisesWithABedspace(user)
+        bedspace.apply { createdAt = OffsetDateTime.parse("2023-02-16T14:03:00+00:00") }
+        cas3BedspacesRepository.save(bedspace)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withBedspace(bedspace)
+          withServiceName(ServiceName.temporaryAccommodation)
+          withCrn(offenderDetails.otherIds.crn)
+          withArrivalDate(LocalDate.parse("2023-03-28"))
+          withDepartureDate(LocalDate.parse("2023-04-04"))
+        }
+
+        cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking)
+          withWorkingDayCount(5)
+        }
+
+        cas3ArrivalEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withArrivalDate(LocalDate.parse("2023-03-28"))
+        }
+
+        cas3DepartureEntityFactory.produceAndPersist {
+          withBooking(booking)
+          withDateTime(OffsetDateTime.parse("2023-04-04T12:00:00.000Z"))
+          withReason(departureReasonEntityFactory.produceAndPersist())
+          withMoveOnCategory(moveOnCategoryEntityFactory.produceAndPersist())
+        }
+
+        val expectedReportRows = listOf(
+          BedspaceOccupancyReportRow(
+            probationRegion = user.probationRegion.name,
+            pdu = user.probationDeliveryUnit?.name,
+            localAuthority = premises.localAuthorityArea?.name,
+            propertyRef = premises.name,
+            addressLine1 = premises.addressLine1,
+            town = premises.town,
+            postCode = premises.postcode,
+            bedspaceRef = bedspace.reference,
+            bookedDaysActiveAndClosed = 4,
+            confirmedDays = 0,
+            provisionalDays = 0,
+            scheduledTurnaroundDays = 5,
+            effectiveTurnaroundDays = 7,
+            voidDays = 0,
+            totalBookedDays = 4,
+            bedspaceStartDate = bedspace.createdAt.toLocalDate(),
+            bedspaceEndDate = bedspace.endDate,
+            bedspaceOnlineDays = 30,
+            occupancyRate = 0.13333333333333333,
+            uniquePropertyRef = premises.id.toShortBase58(),
+            uniqueBedspaceRef = bedspace.id.toShortBase58(),
+          ),
+        )
+
+        val expectedDataFrame = expectedReportRows.toDataFrame()
+
+        webTestClient.get()
+          .uri("/cas3/reports/bedOccupancy?startDate=2023-04-01&endDate=2023-04-30&probationRegionId=${user.probationRegion.id}")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith {
+            val actual = DataFrame
+              .readExcel(it.responseBody!!.inputStream())
+              .convertTo<BedspaceOccupancyReportRow>(Remove)
+            assertThat(actual).isEqualTo(expectedDataFrame)
+          }
+      }
+    }
+  }
+
+  private fun setupPremisesWithABedspace(
+    user: UserEntity,
+    startDate: LocalDate = LocalDate.now().randomDateBefore(6),
+  ): Pair<Cas3PremisesEntity, Cas3BedspacesEntity> {
+    val premises = givenACas3Premises(
+      probationDeliveryUnit = user.probationDeliveryUnit!!,
+      status = Cas3PremisesStatus.online,
+    )
+    val bedspaceStartDate = startDate.minusDays(100)
+    val bedspace = cas3BedspaceEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withStartDate(bedspaceStartDate)
+      withCreatedDate(bedspaceStartDate)
+      withEndDate(null)
+    }
+    return premises to bedspace
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
@@ -1795,7 +1795,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class GetBedUsageReport {
+  inner class GetBedspaceUsageReport {
 
     @Test
     fun `Get bed usage report returns OK with correct body`() {
@@ -2702,8 +2702,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
 
           webTestClient.get()
             .uri("/cas3/reports/bookingGap?startDate=$reportStartDate&endDate=$reportEndDate&probationRegionId=${user.probationRegion.id}")
-            .header("Authorization", "Bearer $jwt")
-            .header("X-Service-Name", ServiceName.temporaryAccommodation.value)
+            .headers(buildTemporaryAccommodationHeaders(jwt))
             .exchange()
             .expectStatus()
             .isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/BedspaceOccupancyReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/BedspaceOccupancyReportGeneratorTest.kt
@@ -1,0 +1,1361 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.generator
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ArrivalEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3DepartureEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBedspaceReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2ConfirmationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator.BedspaceOccupancyReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.properties.BedspaceOccupancyReportProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.util.toShortBase58
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.util.convertToCas3BedspaceOccupancyBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.util.convertToCas3BedspaceOccupancyBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.util.convertToCas3BedspaceOccupancyBookingTurnaroundReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.util.convertToCas3BedspaceOccupancyVoidBedpaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.util.convertToCas3BedspaceOccupancyVoidBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+@SuppressWarnings("LargeClass")
+class BedspaceOccupancyReportGeneratorTest {
+  private val startDate = LocalDate.of(2023, 4, 1)
+  private val endDate = LocalDate.of(2023, 4, 30)
+  private val mockWorkingDayService = mockk<WorkingDayService>()
+
+  private val bedspaceOccupancyReportGenerator = BedspaceOccupancyReportGenerator(mockWorkingDayService)
+
+  @Test
+  fun `Results for bedspaces are returned in the report`() {
+    val cas3Premises = Cas3PremisesEntityFactory()
+      .withDefaults()
+      .produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(cas3Premises).produce()
+
+    val cas3VoidBedspaces =
+      Cas3VoidBedspaceEntityFactory().withBedspace(cas3Bedspace)
+        .withStartDate(LocalDate.parse("2023-04-05"))
+        .withEndDate(LocalDate.parse("2023-04-07"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val bedspaceOccupancyVoidBedspaceReportData = convertToCas3BedspaceOccupancyVoidBedpaceReportData(cas3VoidBedspaces)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(bedspaceOccupancyVoidBedspaceReportData),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::propertyRef]).isEqualTo(cas3Premises.name)
+    assertThat(result[0][BedspaceOccupancyReportRow::uniquePropertyRef]).isEqualTo(cas3Premises.id.toShortBase58())
+  }
+
+  @Test
+  fun `Results for bedspaces are returned in the report for 3 months`() {
+    val startDate = LocalDate.of(2023, 4, 1)
+    val endDate = LocalDate.of(2023, 7, 1)
+
+    val cas3Premises = Cas3PremisesEntityFactory()
+      .withDefaults()
+      .produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(cas3Premises).produce()
+
+    val temporaryAccommodationLostBed =
+      Cas3VoidBedspaceEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withStartDate(LocalDate.parse("2023-04-05"))
+        .withEndDate(LocalDate.parse("2023-04-07"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val bedspaceOccupancyReportGeneratorForThreeMonths = BedspaceOccupancyReportGenerator(mockWorkingDayService)
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val bedspaceOccupancyVoidBedspaceReportData = convertToCas3BedspaceOccupancyVoidBedpaceReportData(temporaryAccommodationLostBed)
+
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(bedspaceOccupancyVoidBedspaceReportData),
+    )
+
+    val result = bedspaceOccupancyReportGeneratorForThreeMonths.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::propertyRef]).isEqualTo(cas3Premises.name)
+    assertThat(result[0][BedspaceOccupancyReportRow::uniquePropertyRef]).isEqualTo(cas3Premises.id.toShortBase58())
+  }
+
+  @Test
+  fun `Results for bedspaces from the specified probation region are returned in the report`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val probationRegion2 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea2 = LocalAuthorityEntityFactory().produce()
+
+    val cas3PremisesInProbationRegion =
+      Cas3PremisesEntityFactory().withLocalAuthorityArea(localAuthorityArea1)
+        .withProbationDeliveryUnit(
+          ProbationDeliveryUnitEntityFactory().withProbationRegion(probationRegion1).produce(),
+        ).produce()
+
+    val cas3BedspaceInProbationRegion = Cas3BedspaceEntityFactory()
+      .withPremises(cas3PremisesInProbationRegion).produce()
+
+    val cas3VoidBedspaceInProbationArea =
+      Cas3VoidBedspaceEntityFactory()
+        .withBedspace(cas3BedspaceInProbationRegion)
+        .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val cas3PremisesOutsideProbationRegion =
+      Cas3PremisesEntityFactory().withLocalAuthorityArea(localAuthorityArea2)
+        .withProbationDeliveryUnit(
+          ProbationDeliveryUnitEntityFactory().withProbationRegion(probationRegion2).produce(),
+        ).produce()
+
+    val cas3BedspaceOutsideProbationRegion = Cas3BedspaceEntityFactory()
+      .withPremises(cas3PremisesOutsideProbationRegion).produce()
+
+    Cas3VoidBedspaceEntityFactory()
+      .withBedspace(cas3BedspaceOutsideProbationRegion)
+      .withStartDate(LocalDate.parse("2023-04-05"))
+      .withEndDate(LocalDate.parse("2023-04-07"))
+      .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+      .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3BedspaceInProbationRegion)
+    val bedspaceOccupancyVoidBedspaceReportData = convertToCas3BedspaceOccupancyVoidBedpaceReportData(cas3VoidBedspaceInProbationArea)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(bedspaceOccupancyVoidBedspaceReportData),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(probationRegion1.id, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::propertyRef]).isEqualTo(
+      cas3PremisesInProbationRegion.name,
+    )
+    assertThat(result[0][BedspaceOccupancyReportRow::uniquePropertyRef]).isEqualTo(
+      cas3PremisesInProbationRegion.id.toShortBase58(),
+    )
+  }
+
+  @Test
+  fun `Results for beds from all probation regions are returned in the report if no probation region ID is provided`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val probationRegion2 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea2 = LocalAuthorityEntityFactory().produce()
+
+    val cas3PremisesInProbationRegion =
+      Cas3PremisesEntityFactory()
+        .withLocalAuthorityArea(localAuthorityArea1)
+        .withProbationDeliveryUnit(
+          ProbationDeliveryUnitEntityFactory().withProbationRegion(probationRegion1).produce(),
+        ).produce()
+
+    val cas3BedspaceInProbationRegion = Cas3BedspaceEntityFactory()
+      .withPremises(cas3PremisesInProbationRegion).produce()
+
+    val cas3VoidBedspaceInProbationArea =
+      Cas3VoidBedspaceEntityFactory()
+        .withBedspace(cas3BedspaceInProbationRegion)
+        .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val cas3PremisesOutsideProbationRegion =
+      Cas3PremisesEntityFactory()
+        .withLocalAuthorityArea(localAuthorityArea2)
+        .withProbationDeliveryUnit(
+          ProbationDeliveryUnitEntityFactory().withProbationRegion(probationRegion2).produce(),
+        ).produce()
+
+    val cas3BedspaceOutsideProbationRegion =
+      Cas3BedspaceEntityFactory()
+        .withPremises(cas3PremisesOutsideProbationRegion)
+        .produce()
+
+    val cas3VoidBedspaceOutsideProbationArea =
+      Cas3VoidBedspaceEntityFactory()
+        .withBedspace(cas3BedspaceOutsideProbationRegion)
+        .withStartDate(LocalDate.parse("2023-04-05")).withEndDate(LocalDate.parse("2023-04-07"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val bedspaceOccupancyBedspaceInProbationRegionReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3BedspaceInProbationRegion)
+    val bedspaceOccupancyVoidBedspaceInProbationRegionReportData = convertToCas3BedspaceOccupancyVoidBedpaceReportData(cas3VoidBedspaceInProbationArea)
+    val bedspaceOccupancyInProbationRegionReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceInProbationRegionReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(bedspaceOccupancyVoidBedspaceInProbationRegionReportData),
+    )
+    val bedspaceOccupancyBedspaceOutsideProbationRegionReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3BedspaceOutsideProbationRegion)
+    val bedspaceOccupancyVoidBedspaceOutsideProbationRegionReportData = convertToCas3BedspaceOccupancyVoidBedpaceReportData(cas3VoidBedspaceOutsideProbationArea)
+    val bedspaceOccupancyOutsideProbationRegionReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceOutsideProbationRegionReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(bedspaceOccupancyVoidBedspaceOutsideProbationRegionReportData),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyInProbationRegionReportData, bedspaceOccupancyOutsideProbationRegionReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(2)
+    assertThat(result[0][BedspaceOccupancyReportRow::propertyRef]).isEqualTo(
+      cas3PremisesInProbationRegion.name,
+    )
+    assertThat(result[0][BedspaceOccupancyReportRow::uniquePropertyRef]).isEqualTo(
+      cas3PremisesInProbationRegion.id.toShortBase58(),
+    )
+    assertThat(result[1][BedspaceOccupancyReportRow::propertyRef]).isEqualTo(
+      cas3PremisesOutsideProbationRegion.name,
+    )
+    assertThat(result[1][BedspaceOccupancyReportRow::uniquePropertyRef]).isEqualTo(
+      cas3PremisesOutsideProbationRegion.id.toShortBase58(),
+    )
+  }
+
+  @Test
+  fun `bookedDaysActiveAndClosed shows the total number of days within the month for Bookings that are marked as arrived`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory().withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory().withProbationRegion(probationRegion1).produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    // An irrelevant Booking - does not have an Arrival set
+    Cas3BookingEntityFactory()
+      .withBedspace(cas3Bedspace).withPremises(premises)
+      .withArrivalDate(LocalDate.parse("2023-04-05"))
+      .withDepartureDate(LocalDate.parse("2023-04-10"))
+      .produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-03-28"))
+        .withDepartureDate(LocalDate.parse("2023-04-04"))
+        .produce().apply {
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).produce()
+        }
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-04-28"))
+        .withDepartureDate(LocalDate.parse("2023-05-04"))
+        .produce().apply {
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).produce()
+        }
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::bookedDaysActiveAndClosed]).isEqualTo(7)
+  }
+
+  @Test
+  fun `confirmedDays shows the total number of days within the month for Bookings that are marked as confirmed but not arrived`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    // An irrelevant Booking - does not have a Confirmation set
+    Cas3BookingEntityFactory()
+      .withBedspace(cas3Bedspace)
+      .withPremises(premises)
+      .withArrivalDate(LocalDate.parse("2023-04-05"))
+      .withDepartureDate(LocalDate.parse("2023-04-10"))
+      .produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory().withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-03-28"))
+        .withDepartureDate(LocalDate.parse("2023-04-04"))
+        .produce().apply {
+          confirmation = Cas3v2ConfirmationEntityFactory().withBooking(this).produce()
+        }
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-04-28"))
+        .withDepartureDate(LocalDate.parse("2023-05-04"))
+        .produce().apply {
+          confirmation = Cas3v2ConfirmationEntityFactory().withBooking(this).produce()
+        }
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::confirmedDays]).isEqualTo(7)
+  }
+
+  @Test
+  fun `scheduledTurnaroundDays shows the number of working days in the month for the turnaround`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-03-28"))
+        .withDepartureDate(LocalDate.parse("2023-04-04")).produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2023-04-10")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-05"),
+        LocalDate.parse("2023-04-10"),
+      )
+    } returns 5
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory().withBedspace(cas3Bedspace).withPremises(premises).withArrivalDate(LocalDate.parse("2023-04-25"))
+        .withDepartureDate(LocalDate.parse("2023-04-27")).produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2023-05-01")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-28"),
+        LocalDate.parse("2023-04-30"),
+      )
+    } returns 1
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingTurnaroundStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingTurnaroundReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val relevantBookingTurnaroundStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingTurnaroundReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(relevantBookingTurnaroundStraddlingStartOfMonthReportData, relevantBookingTurnaroundStraddlingEndOfMonthReportData),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::scheduledTurnaroundDays]).isEqualTo(6)
+  }
+
+  @Test
+  fun `effectiveTurnaroundDays shows the total number of days (regardless of whether working days) in the month for the turnaround`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-03-28"))
+        .withDepartureDate(LocalDate.parse("2023-04-04"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory()
+            .withBooking(this)
+            .withWorkingDayCount(5)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2023-04-10")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-05"),
+        LocalDate.parse("2023-04-10"),
+      )
+    } returns 4
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-04-25"))
+        .withDepartureDate(LocalDate.parse("2023-04-27"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory()
+            .withBooking(this)
+            .withWorkingDayCount(3)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2023-05-01")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-28"),
+        LocalDate.parse("2023-04-30"),
+      )
+    } returns 1
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingTurnaroundStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingTurnaroundReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val relevantBookingTurnaroundStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingTurnaroundReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(relevantBookingTurnaroundStraddlingStartOfMonthReportData, relevantBookingTurnaroundStraddlingEndOfMonthReportData),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::effectiveTurnaroundDays]).isEqualTo(9)
+  }
+
+  @Test
+  fun `voidDays shows the total number of days in the month for voids`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .produce()
+
+    val relevantVoidStraddlingStartOfMonth =
+      Cas3VoidBedspaceEntityFactory().withBedspace(cas3Bedspace)
+        .withStartDate(LocalDate.parse("2023-03-28"))
+        .withEndDate(LocalDate.parse("2023-04-04"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val relevantVoidStraddlingEndOfMonth =
+      Cas3VoidBedspaceEntityFactory().withBedspace(cas3Bedspace)
+        .withStartDate(LocalDate.parse("2023-04-25"))
+        .withEndDate(LocalDate.parse("2023-05-03"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantVoidStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyVoidBedspaceReportData(relevantVoidStraddlingStartOfMonth)
+    val relevantVoidStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyVoidBedspaceReportData(relevantVoidStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(relevantVoidStraddlingStartOfMonthReportData, relevantVoidStraddlingEndOfMonthReportData),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::voidDays]).isEqualTo(10)
+  }
+
+  @Test
+  fun `totalBookedDays shows the combined total days in the month of non-cancelled bookings, not non-cancelled voids or turnarounds - bedspaceOnlineDays, occupancyRate show correctly`() {
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withCreatedAt(OffsetDateTime.parse("2023-02-16T14:03:00+00:00"))
+      .produce()
+
+    val departureReason = DepartureReasonEntityFactory().produce()
+    val moveOnCategory = MoveOnCategoryEntityFactory().produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory().withBedspace(cas3Bedspace).withPremises(premises).withArrivalDate(LocalDate.parse("2023-03-28"))
+        .withDepartureDate(LocalDate.parse("2023-04-04")).produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(5).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2023-03-28")).produce()
+          departures += Cas3DepartureEntityFactory().withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2023-04-04T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2023-04-09")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-05"),
+        LocalDate.parse("2023-04-09"),
+      )
+    } returns 4
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2023-04-25"))
+        .withDepartureDate(LocalDate.parse("2023-04-27"))
+        .produce()
+        .apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory()
+            .withBooking(this)
+            .withWorkingDayCount(4)
+            .produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2023-04-25")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2023-04-27T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory).produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2023-05-01")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2023-04-28"),
+        LocalDate.parse("2023-04-30"),
+      )
+    } returns 1
+
+    val relevantVoidStraddlingStartOfMonth =
+      Cas3VoidBedspaceEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withStartDate(LocalDate.parse("2023-03-28"))
+        .withEndDate(LocalDate.parse("2023-04-04"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val relevantVoidStraddlingEndOfMonth =
+      Cas3VoidBedspaceEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withStartDate(LocalDate.parse("2023-04-25"))
+        .withEndDate(LocalDate.parse("2023-05-03"))
+        .withYieldedReason { Cas3VoidBedspaceReasonEntityFactory().produce() }
+        .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val relevantVoidStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyVoidBedspaceReportData(relevantVoidStraddlingStartOfMonth)
+    val relevantVoidStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyVoidBedspaceReportData(relevantVoidStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(relevantVoidStraddlingStartOfMonthReportData, relevantVoidStraddlingEndOfMonthReportData),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    // The following should be counted for a total of 7 booked days:
+    // 4 days for relevantBookingStraddlingStartOfMonth
+    // 3 days for relevantBookingStraddlingEndOfMonth
+    //
+    // These should not be counted:
+    // 5 days for turnaround of relevantBookingStraddlingStartOfMonth
+    // 3 days for turnaround of relevantBookingStraddlingEndOfMonth
+    // 4 days for relevantVoidStraddlingStartOfMonth
+    // 6 days for relevantVoidStraddlingEndOfMonth
+    assertThat(result[0][BedspaceOccupancyReportRow::totalBookedDays]).isEqualTo(7)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceOnlineDays]).isEqualTo(30)
+    assertThat(result[0][BedspaceOccupancyReportRow::occupancyRate]).isEqualTo(7.toDouble() / 30)
+  }
+
+  @Test
+  fun `bedspaceStartDate show bedspace created date`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      )
+      .produce()
+
+    val bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withCreatedAt(OffsetDateTime.parse("2024-01-16T14:03:00+00:00"))
+      .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(bedspace)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceStartDate]).isEqualTo(LocalDate.parse("2024-01-16"))
+  }
+
+  @Test
+  fun `bedspaceEndDate show bedspace end date when it is not null`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withCreatedAt(OffsetDateTime.parse("2024-02-16T14:03:00+00:00"))
+      .withEndDate(LocalDate.parse("2024-05-12"))
+      .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceEndDate]).isEqualTo(LocalDate.parse("2024-05-12"))
+  }
+
+  @Test
+  fun `bedspaceEndDate show nothing when bedspace end date is null`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withEndDate(null)
+      .withCreatedAt(OffsetDateTime.parse("2024-02-16T14:03:00+00:00"))
+      .produce()
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceEndDate]).isNull()
+  }
+
+  @Test
+  fun `bedspaceOnlineDays shows number of days between bedspaceStartDate and report end date when bedspaceStartDate is later than report start date and bedspaceEndDate is null`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withEndDate(null)
+      .withCreatedAt(OffsetDateTime.parse("2024-02-05T14:03:00+00:00"))
+      .produce()
+
+    val departureReason = DepartureReasonEntityFactory().produce()
+    val moveOnCategory = MoveOnCategoryEntityFactory().produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-07"))
+        .withDepartureDate(LocalDate.parse("2024-02-12"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-07")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-12T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-14")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-13"),
+        LocalDate.parse("2024-02-14"),
+      )
+    } returns 2
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-16"))
+        .withDepartureDate(LocalDate.parse("2024-02-22"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-16")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-22T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-27")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-23"),
+        LocalDate.parse("2024-02-27"),
+      )
+    } returns 3
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::totalBookedDays]).isEqualTo(13)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceStartDate]).isEqualTo(LocalDate.parse("2024-02-05"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceEndDate]).isNull()
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceOnlineDays]).isEqualTo(25)
+    assertThat(result[0][BedspaceOccupancyReportRow::occupancyRate]).isEqualTo(13.toDouble() / 25)
+  }
+
+  @Test
+  fun `bedspaceOnlineDays shows number of days between bedspaceStartDate and bedspaceEndDate when bedspace dates are in report dates range`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withCreatedAt(OffsetDateTime.parse("2024-02-05T14:03:00+00:00"))
+      .withEndDate(LocalDate.parse("2024-02-27"))
+      .produce()
+
+    val departureReason = DepartureReasonEntityFactory().produce()
+    val moveOnCategory = MoveOnCategoryEntityFactory().produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory().withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-07"))
+        .withDepartureDate(LocalDate.parse("2024-02-12"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory()
+            .withBooking(this)
+            .withWorkingDayCount(2)
+            .produce()
+          arrivals += Cas3ArrivalEntityFactory()
+            .withBooking(this)
+            .withArrivalDate(LocalDate.parse("2024-02-07"))
+            .produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-12T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-14")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-13"),
+        LocalDate.parse("2024-02-14"),
+      )
+    } returns 2
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-16"))
+        .withDepartureDate(LocalDate.parse("2024-02-22"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-16")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-22T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-27")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-23"),
+        LocalDate.parse("2024-02-27"),
+      )
+    } returns 3
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData = convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::totalBookedDays]).isEqualTo(13)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceStartDate]).isEqualTo(LocalDate.parse("2024-02-05"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceEndDate]).isEqualTo(LocalDate.parse("2024-02-27"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceOnlineDays]).isEqualTo(23)
+    assertThat(result[0][BedspaceOccupancyReportRow::occupancyRate]).isEqualTo(13.toDouble() / 23)
+  }
+
+  @Test
+  fun `bedspaceOnlineDays shows number of days between report start date and bedspaceEndtDate when bedspace star and end dates are earlier than report start and end dates`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withCreatedAt(OffsetDateTime.parse("2024-01-17T14:03:00+00:00"))
+      .withEndDate(LocalDate.parse("2024-02-25"))
+      .produce()
+    val departureReason = DepartureReasonEntityFactory().produce()
+    val moveOnCategory = MoveOnCategoryEntityFactory().produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-02"))
+        .withDepartureDate(LocalDate.parse("2024-02-07"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-02")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-07T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-09")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-08"),
+        LocalDate.parse("2024-02-09"),
+      )
+    } returns 2
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-10"))
+        .withDepartureDate(LocalDate.parse("2024-02-15"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-10")).produce()
+          departures += Cas3DepartureEntityFactory().withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-15T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-20")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-16"),
+        LocalDate.parse("2024-02-20"),
+      )
+    } returns 3
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::totalBookedDays]).isEqualTo(12)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceStartDate]).isEqualTo(LocalDate.parse("2024-01-17"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceEndDate]).isEqualTo(LocalDate.parse("2024-02-25"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceOnlineDays]).isEqualTo(25)
+    assertThat(result[0][BedspaceOccupancyReportRow::occupancyRate]).isEqualTo(12.toDouble() / 25)
+  }
+
+  @Test
+  fun `bedspaceOnlineDays shows number of days between report start and end date when bedspace start and end dates are out of the report dates range`() {
+    val startDate = LocalDate.of(2024, 2, 1)
+    val endDate = LocalDate.of(2024, 2, 29)
+    val apArea = ApAreaEntityFactory().produce()
+
+    val probationRegion1 = ProbationRegionEntityFactory().withApArea(apArea).produce()
+
+    val localAuthorityArea1 = LocalAuthorityEntityFactory().produce()
+
+    val premises = Cas3PremisesEntityFactory()
+      .withLocalAuthorityArea(localAuthorityArea1)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(probationRegion1)
+          .produce(),
+      ).produce()
+
+    val cas3Bedspace = Cas3BedspaceEntityFactory()
+      .withPremises(premises)
+      .withCreatedAt(OffsetDateTime.parse("2024-01-17T14:03:00+00:00"))
+      .withEndDate(LocalDate.parse("2024-03-15"))
+      .produce()
+
+    val departureReason = DepartureReasonEntityFactory().produce()
+    val moveOnCategory = MoveOnCategoryEntityFactory().produce()
+
+    val relevantBookingStraddlingStartOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-02"))
+        .withDepartureDate(LocalDate.parse("2024-02-07"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(2).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-02")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-07T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingStartOfMonth.departureDate,
+        relevantBookingStraddlingStartOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-09")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-08"),
+        LocalDate.parse("2024-02-09"),
+      )
+    } returns 2
+
+    val relevantBookingStraddlingEndOfMonth =
+      Cas3BookingEntityFactory()
+        .withBedspace(cas3Bedspace)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.parse("2024-02-10"))
+        .withDepartureDate(LocalDate.parse("2024-02-15"))
+        .produce().apply {
+          turnarounds += Cas3v2TurnaroundEntityFactory().withBooking(this).withWorkingDayCount(3).produce()
+          arrivals += Cas3ArrivalEntityFactory().withBooking(this).withArrivalDate(LocalDate.parse("2024-02-10")).produce()
+          departures += Cas3DepartureEntityFactory()
+            .withBooking(this)
+            .withDateTime(OffsetDateTime.parse("2024-02-15T12:00:00.000Z"))
+            .withReason(departureReason)
+            .withMoveOnCategory(moveOnCategory)
+            .produce()
+        }
+
+    every {
+      mockWorkingDayService.addWorkingDays(
+        relevantBookingStraddlingEndOfMonth.departureDate,
+        relevantBookingStraddlingEndOfMonth.turnaround!!.workingDayCount,
+      )
+    } returns LocalDate.parse("2024-02-20")
+
+    every {
+      mockWorkingDayService.getWorkingDaysCount(
+        LocalDate.parse("2024-02-16"),
+        LocalDate.parse("2024-02-20"),
+      )
+    } returns 3
+
+    val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)
+    val relevantBookingStraddlingStartOfMonthReportData =
+      convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingStartOfMonth)
+    val relevantBookingStraddlingEndOfMonthReportData =
+      convertToCas3BedspaceOccupancyBookingReportData(relevantBookingStraddlingEndOfMonth)
+    val bedspaceOccupancyReportData = BedspaceOccupancyReportData(
+      bedspaceOccupancyBedspaceReportData,
+      listOf(relevantBookingStraddlingStartOfMonthReportData, relevantBookingStraddlingEndOfMonthReportData),
+      listOf(),
+      listOf(),
+      listOf(),
+    )
+
+    val result = bedspaceOccupancyReportGenerator.createReport(
+      listOf(bedspaceOccupancyReportData),
+      BedspaceOccupancyReportProperties(null, startDate, endDate),
+    )
+
+    assertThat(result.count()).isEqualTo(1)
+    assertThat(result[0][BedspaceOccupancyReportRow::totalBookedDays]).isEqualTo(12)
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceStartDate]).isEqualTo(LocalDate.parse("2024-01-17"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceEndDate]).isEqualTo(LocalDate.parse("2024-03-15"))
+    assertThat(result[0][BedspaceOccupancyReportRow::bedspaceOnlineDays]).isEqualTo(29)
+    assertThat(result[0][BedspaceOccupancyReportRow::occupancyRate]).isEqualTo(12.toDouble() / 29)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/Cas3BedspaceUsageReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/Cas3BedspaceUsageReportGeneratorTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Void
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3CostCentre
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator.Cas3BedspaceUsageReportGenerator
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator.BedspaceUsageReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedUsageReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.Cas3BedUsageReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.Cas3BedUsageType
@@ -38,7 +38,7 @@ class Cas3BedspaceUsageReportGeneratorTest {
   private val mockLostBedsRepository = mockk<Cas3VoidBedspacesRepository>()
   private val mockWorkingDayService = mockk<WorkingDayService>()
 
-  private val bedUsageReportGenerator = Cas3BedspaceUsageReportGenerator(
+  private val bedUsageReportGenerator = BedspaceUsageReportGenerator(
     mockBookingTransformer,
     mockBookingRepository,
     mockLostBedsRepository,
@@ -117,7 +117,7 @@ class Cas3BedspaceUsageReportGeneratorTest {
       )
     } returns listOf(voidBedspace)
 
-    val bedUsageReportGeneratorWithThreeMonth = Cas3BedspaceUsageReportGenerator(
+    val bedUsageReportGeneratorWithThreeMonth = BedspaceUsageReportGenerator(
       mockBookingTransformer,
       mockBookingRepository,
       mockLostBedsRepository,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/util/Cas3ReportsTestHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/util/Cas3ReportsTestHelper.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.reporting.util
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBedspaceReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBookingReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyBookingTurnaroundReportData
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyVoidBedspaceReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedUtilisationBedspaceReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedUtilisationBookingCancellationReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedUtilisationBookingReportData
@@ -38,6 +44,35 @@ fun convertToCas3BedUtilisationBedspaceReportData(bed: BedEntity): Cas3BedUtilis
   )
 }
 
+fun convertToCas3BedspaceOccupancyBedspaceReportData(bedspace: Cas3BedspacesEntity): BedspaceOccupancyBedspaceReportData {
+  val probationDeliveryUnitName = bedspace.premises.probationDeliveryUnit.name
+  val premises = bedspace.premises
+  return Cas3BedspaceOccupancyReportData(
+    bedspaceId = bedspace.id.toString(),
+    probationRegionName = premises.probationDeliveryUnit.probationRegion.name,
+    probationDeliveryUnitName = probationDeliveryUnitName,
+    localAuthorityName = premises.localAuthorityArea?.name,
+    premisesName = premises.name,
+    addressLine1 = premises.addressLine1,
+    town = premises.town,
+    postCode = premises.postcode,
+    roomName = bedspace.reference,
+    bedspaceStartDate = bedspace.createdAt?.toInstant(),
+    bedspaceEndDate = bedspace.endDate,
+    premisesId = premises.id.toString(),
+  )
+}
+
+fun convertToCas3BedspaceOccupancyBookingReportData(booking: Cas3BookingEntity) = Cas3BedspaceOccupancyBookingReportData(
+  bookingId = booking.id.toString(),
+  arrivalDate = booking.arrivalDate,
+  departureDate = booking.departureDate,
+  bedspaceId = booking.bedspace?.id.toString(),
+  arrivalId = booking.arrival?.id?.toString(),
+  arrivalCreatedAt = booking.arrival?.createdAt?.toInstant(),
+  confirmationId = booking.confirmation?.id?.toString(),
+)
+
 fun convertToCas3BedUtilisationBookingReportData(booking: BookingEntity): Cas3BedUtilisationBookingReportData = Cas3BedUtilisationBookingReportData(
   bookingId = booking.id.toString(),
   arrivalDate = booking.arrivalDate,
@@ -63,11 +98,33 @@ fun convertToCas3BedUtilisationBookingTurnaroundReportData(booking: BookingEntit
   createdAt = booking.turnaround?.createdAt?.toInstant()!!,
 )
 
+fun convertToCas3BedspaceOccupancyBookingTurnaroundReportData(booking: Cas3BookingEntity) = Cas3BedspaceOccupancyBookingTurnaroundReportData(
+  turnaroundId = booking.turnaround?.id.toString(),
+  bedspaceId = booking.bedspace?.id.toString(),
+  bookingId = booking.id.toString(),
+  workingDayCount = booking.turnaround?.workingDayCount!!,
+  createdAt = booking.turnaround?.createdAt?.toInstant()!!,
+)
+
 fun convertToCas3BedUtilisationLostBedReportData(voidBedspace: Cas3VoidBedspaceEntity): Cas3BedUtilisationVoidBedspaceUtilisationVoidBedspaceReportData = Cas3BedUtilisationVoidBedspaceUtilisationVoidBedspaceReportData(
   bedId = voidBedspace.bed!!.id.toString(),
   startDate = voidBedspace.startDate,
   endDate = voidBedspace.endDate,
   cancellationId = voidBedspace.cancellation?.id?.toString(),
+)
+
+fun convertToCas3BedspaceOccupancyVoidBedspaceReportData(voidBedspace: Cas3VoidBedspaceEntity) = Cas3BedspaceOccupancyVoidBedspaceReportData(
+  bedspaceId = voidBedspace.bedspace!!.id.toString(),
+  startDate = voidBedspace.startDate,
+  endDate = voidBedspace.endDate,
+  cancellationId = voidBedspace.cancellation?.id?.toString(),
+)
+
+fun convertToCas3BedspaceOccupancyVoidBedpaceReportData(voidBedspace: Cas3VoidBedspaceEntity) = Cas3BedspaceOccupancyVoidBedspaceReportData(
+  bedspaceId = voidBedspace.bedspace!!.id.toString(),
+  startDate = voidBedspace.startDate,
+  endDate = voidBedspace.endDate,
+  cancellationId = null,
 )
 
 @Suppress("LongParameterList")
@@ -119,3 +176,45 @@ class Cas3BedUtilisationVoidBedspaceUtilisationVoidBedspaceReportData(
   override val endDate: LocalDate,
   override val cancellationId: String?,
 ) : BedUtilisationVoidBedspaceReportData
+
+@Suppress("LongParameterList")
+class Cas3BedspaceOccupancyReportData(
+  override val bedspaceId: String,
+  override val probationRegionName: String?,
+  override val probationDeliveryUnitName: String?,
+  override val localAuthorityName: String?,
+  override val premisesName: String,
+  override val addressLine1: String,
+  override val town: String?,
+  override val postCode: String,
+  override val roomName: String,
+  override val bedspaceStartDate: Instant?,
+  override val bedspaceEndDate: LocalDate?,
+  override val premisesId: String,
+) : BedspaceOccupancyBedspaceReportData
+
+@Suppress("LongParameterList")
+class Cas3BedspaceOccupancyBookingReportData(
+  override val bookingId: String,
+  override val arrivalDate: LocalDate,
+  override val departureDate: LocalDate,
+  override val bedspaceId: String,
+  override val arrivalId: String?,
+  override val arrivalCreatedAt: Instant?,
+  override val confirmationId: String?,
+) : BedspaceOccupancyBookingReportData
+
+class Cas3BedspaceOccupancyVoidBedspaceReportData(
+  override val bedspaceId: String,
+  override val startDate: LocalDate,
+  override val endDate: LocalDate,
+  override val cancellationId: String?,
+) : BedspaceOccupancyVoidBedspaceReportData
+
+class Cas3BedspaceOccupancyBookingTurnaroundReportData(
+  override val turnaroundId: String,
+  override val bedspaceId: String,
+  override val bookingId: String,
+  override val createdAt: Instant,
+  override val workingDayCount: Int,
+) : BedspaceOccupancyBookingTurnaroundReportData

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ReportServiceTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.propertie
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.properties.TransitionalAccommodationReferralReportProperties
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedUsageRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedUtilisationReportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BedspaceOccupancyReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BookingsReportData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.BookingsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.TransitionalAccommodationReferralReportData
@@ -52,6 +53,7 @@ class Cas3ReportServiceTest {
   private val mockCas3v2BookingRepository = mockk<Cas3v2BookingRepository>()
   private val mockBedUsageRepository = mockk<BedUsageRepository>()
   private val mockBedUtilisationReportRepository = mockk<BedUtilisationReportRepository>()
+  private val mockBedspaceOccupancyReportRepository = mockk<BedspaceOccupancyReportRepository>()
   private val mockCas3BookingGapReportRepository = mockk<Cas3BookingGapReportRepository>()
   private val mockCas3FutureBookingsReportRepository = mockk<Cas3FutureBookingsReportRepository>()
 
@@ -69,6 +71,7 @@ class Cas3ReportServiceTest {
     mockCas3v2BookingRepository,
     mockBedUsageRepository,
     mockBedUtilisationReportRepository,
+    mockBedspaceOccupancyReportRepository,
     mockCas3FutureBookingsReportRepository,
     mockCas3BookingGapReportRepository,
     2,
@@ -177,6 +180,7 @@ class Cas3ReportServiceTest {
       mockCas3v2BookingRepository,
       mockBedUsageRepository,
       mockBedUtilisationReportRepository,
+      mockBedspaceOccupancyReportRepository,
       mockCas3FutureBookingsReportRepository,
       mockCas3BookingGapReportRepository,
       3,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -80,6 +80,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Arri
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3CancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ConfirmationEntity
@@ -614,6 +615,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var placementApplicationPlaceholderRepository: PlacementApplicationPlaceholderRepository
+
+  @Autowired
+  lateinit var cas3BedspacesRepository: Cas3BedspacesRepository
 
   lateinit var offenderManagementUnitEntityFactory: PersistedFactory<OffenderManagementUnitEntity, UUID, OffenderManagementUnitEntityFactory>
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>


### PR DESCRIPTION
**PR includes:**
* Refactor the `GET /cas3/reports/{reportName}` endpoint for the `bedOccupancy` report type
* uses the `cas3-reports-with-new-bedspace-model-tables-enabled` feature-flag to determine whether to execute a query against the new `Bedspace model refactor` tables (or to execute against the tables currently queried in production when feature-flag off)
* executes the old or new query accordingly
* test coverage for the report against the new tables
