### PR TITLE
chore/Enable ossIndex analyzer for dependencyCheck.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,7 +219,6 @@ detekt {
 
 dependencyCheck {
   suppressionFile = ".dependencycheckignore.xml"
-  analyzers.ossIndex.enabled = false
 }
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {


### PR DESCRIPTION
We are now using a username and password for the OWASP OSS Index checks so we can re-enable this database.

See: https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/9.x.md#add-ability-to-configure-oss-index-analyzer-via-project-properties

