### PR TITLE
CAS3 V2 Bedspace Search API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BedspaceSearchController.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller
+
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BedspaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BedspaceSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3v2BedspaceSearchResultsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@RestController
+@Cas3Controller
+@RequestMapping("/cas3/v2", headers = ["X-Service-Name=temporary-accommodation"])
+class Cas3v2BedspaceSearchController(
+  private val userService: UserService,
+  private val cas3v2BedspaceSearchService: Cas3v2BedspaceSearchService,
+  private val cas3v2BedspaceSearchResultsTransformer: Cas3v2BedspaceSearchResultsTransformer,
+) {
+
+  @PostMapping(
+    "/bedspaces/search",
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  fun postBedspaceSearch(@RequestBody cas3BedspaceSearchParameters: Cas3BedspaceSearchParameters): ResponseEntity<Cas3v2BedspaceSearchResults> {
+    val user = userService.getUserForRequest()
+
+    val searchResult = cas3v2BedspaceSearchService.searchBedspaces(
+      user = user,
+      cas3BedspaceSearchParameters,
+    )
+
+    return ResponseEntity.ok(cas3v2BedspaceSearchResultsTransformer.transformDomainToApi(extractEntityFromCasResult(searchResult)))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspaceCharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BedspaceCharacteristicEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
@@ -9,15 +10,20 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface Cas3BedspaceCharacteristicRepository : JpaRepository<Cas3BedspaceCharacteristicEntity, UUID>
+interface Cas3BedspaceCharacteristicRepository : JpaRepository<Cas3BedspaceCharacteristicEntity, UUID> {
+  fun findByActive(active: Boolean): List<Cas3BedspaceCharacteristicEntity>
+
+  fun findByName(name: String): Cas3BedspaceCharacteristicEntity?
+}
 
 @Entity
 @Table(name = "cas3_bedspace_characteristics")
 @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class Cas3BedspaceCharacteristicEntity(
   @Id
-  var id: UUID,
-  var name: String?,
-  var description: String,
-  var isActive: Boolean,
+  val id: UUID,
+  val name: String?,
+  val description: String,
+  @Column(name = "is_active")
+  val active: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesCharacteristicEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3PremisesCharacteristicEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
@@ -13,8 +14,22 @@ import java.util.UUID
 
 @Repository
 interface Cas3PremisesCharacteristicRepository : JpaRepository<Cas3PremisesCharacteristicEntity, UUID> {
-  @Query("select c from Cas3PremisesCharacteristicEntity c where c.id in (:ids) and c.isActive = true")
+
+  companion object Constants {
+    const val CAS3_PROPERTY_NAME_SINGLE_OCCUPANCY = "isSingleOccupancy"
+    const val CAS3_PROPERTY_NAME_SHARED_PROPERTY = "isSharedProperty"
+    const val CAS3_PROPERTY_NAME_WHEELCHAIR_ACCESSIBLE = "isWheelchairAccessible"
+    const val CAS3_PROPERTY_NAME_MEN_ONLY = "isMenOnly"
+    const val CAS3_PROPERTY_NAME_WOMEN_ONLY = "isWomenOnly"
+    const val CAS3_PROPERTY_NAME_PUB_NEAR_BY = "isPubNearBy"
+  }
+
+  fun findByActive(active: Boolean): List<Cas3PremisesCharacteristicEntity>
+
+  @Query("select c from Cas3PremisesCharacteristicEntity c where c.id in (:ids) and c.active = true")
   fun findActiveCharacteristicsByIdIn(ids: List<UUID>): List<Cas3PremisesCharacteristicEntity>
+
+  fun findByName(name: String): Cas3PremisesCharacteristicEntity?
 }
 
 @Entity
@@ -22,10 +37,11 @@ interface Cas3PremisesCharacteristicRepository : JpaRepository<Cas3PremisesChara
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 data class Cas3PremisesCharacteristicEntity(
   @Id
-  var id: UUID,
-  var name: String,
-  var description: String,
-  var isActive: Boolean,
+  val id: UUID,
+  val name: String,
+  val description: String,
+  @Column(name = "is_active")
+  val active: Boolean,
 ) {
   fun toCas3PremisesCharacteristic() = Cas3PremisesCharacteristic(
     id = this.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3MigrateNewBedspaceModelDataJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3MigrateNewBedspaceModelDataJob.kt
@@ -127,7 +127,7 @@ class Cas3MigrateNewBedspaceModelDataJob(
       id = it.id,
       name = it.propertyName,
       description = it.name,
-      isActive = it.isActive,
+      active = it.isActive,
     )
   }
 
@@ -139,7 +139,7 @@ class Cas3MigrateNewBedspaceModelDataJob(
       id = it.id,
       name = it.propertyName!!,
       description = it.name,
-      isActive = it.isActive,
+      active = it.isActive,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BedspaceSearchResultBedspaceSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BedspaceSearchResultBedspaceSummary.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import java.util.UUID
+
+data class Cas3BedspaceSearchResultBedspaceSummary(
+  val id: UUID,
+  val reference: String,
+  val characteristics: List<Cas3CharacteristicPair>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BedspaceSearchResultPremisesSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3BedspaceSearchResultPremisesSummary.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import java.util.UUID
+
+data class Cas3BedspaceSearchResultPremisesSummary(
+  val id: UUID,
+  val name: String,
+  val addressLine1: String,
+  val postcode: String,
+  val characteristics: List<Cas3CharacteristicPair>,
+  val bedspaceCount: Int,
+  val addressLine2: String? = null,
+  val town: String? = null,
+  val probationDeliveryUnitName: String? = null,
+  val notes: String? = null,
+  val bookedBedspaceCount: Int? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3CharacteristicPair.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3CharacteristicPair.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
 
-import java.util.UUID
-
-data class Cas3PremisesCharacteristic(
-  val id: UUID,
+data class Cas3CharacteristicPair(
   val name: String,
   val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3v2BedspaceSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3v2BedspaceSearchResult.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+data class Cas3v2BedspaceSearchResult(
+  val premises: Cas3BedspaceSearchResultPremisesSummary,
+  val bedspace: Cas3BedspaceSearchResultBedspaceSummary,
+  val overlaps: List<Cas3v2BedspaceSearchResultOverlap>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3v2BedspaceSearchResultOverlap.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3v2BedspaceSearchResultOverlap.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import java.util.UUID
+
+data class Cas3v2BedspaceSearchResultOverlap(
+  val name: String,
+  val crn: String,
+  val personType: PersonType,
+  val days: Int,
+  val bookingId: UUID,
+  val bedspaceId: UUID,
+  val isSexualRisk: Boolean,
+  val sex: String? = null,
+  val assessmentId: UUID? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3v2BedspaceSearchResults.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3v2BedspaceSearchResults.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+data class Cas3v2BedspaceSearchResults(
+  val resultsBedspaceCount: Int,
+  val resultsPremisesCount: Int,
+  val results: List<Cas3v2BedspaceSearchResult>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/Cas3BedspaceSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/Cas3BedspaceSearchRepository.kt
@@ -1,0 +1,204 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository
+
+import org.springframework.jdbc.core.ResultSetExtractor
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import java.sql.ResultSet
+import java.time.LocalDate
+import java.util.UUID
+
+@Repository
+class Cas3BedspaceSearchRepository(private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate) {
+
+  private val temporaryAccommodationSearchQuery =
+    """
+    WITH BookedBedspaces AS
+        (SELECT distinct b.bed_id as bedspace_id, b.premises_id 
+             FROM bookings b
+             INNER JOIN cas3_premises p ON b.premises_id = p.id
+             INNER JOIN probation_delivery_units pdu on pdu.id = p.probation_delivery_unit_id
+             LEFT JOIN cancellations bc ON bc.booking_id = b.id
+         WHERE pdu.probation_region_id = :probation_region_id
+             AND (b.arrival_date, b.departure_date) OVERLAPS (:start_date, :end_date)
+             AND bc.id IS NULL)
+                             
+    SELECT p.id as premises_id,
+           p.name as premises_name,
+           p.address_line1 as premises_address_line1,
+           p.address_line2 as premises_address_line2,
+           p.town as premises_town,
+           p.postcode as premises_postcode,
+           p.notes as premises_notes,
+           pc.name as premises_characteristic_name,
+           pc.description as premises_characteristic_description,
+           bc.name as bedspace_characteristic_name,
+           bc.description as bedspace_characteristic_description,
+           (
+            SELECT count(1)
+            FROM cas3_bedspaces b2
+            WHERE b2.premises_id = p.id
+            AND ( b2.end_date IS NULL OR b2.end_date > :end_date)
+           ) as premises_bedspace_count,
+           (SELECT count(bedspace_id) FROM BookedBedspaces bb WHERE bb.premises_id = p.id) as booked_bedspace_count,
+           b.id as bedspace_id,
+           b.reference as bedspace_reference,
+           pdu.name as probation_delivery_unit_name
+    FROM cas3_premises p  
+    LEFT JOIN cas3_premises_characteristic_assignments pca ON p.id = pca.premises_id
+    LEFT JOIN cas3_premises_characteristics pc ON pca.premises_characteristics_id = pc.id
+    LEFT JOIN cas3_bedspaces b ON b.premises_id = p.id
+    LEFT JOIN cas3_bedspace_characteristic_assignments bca on bca.bedspace_id = b.id
+    LEFT JOIN cas3_bedspace_characteristics bc ON bca.bedspace_characteristics_id = bc.id
+    LEFT JOIN probation_delivery_units pdu on pdu.id = p.probation_delivery_unit_id
+    WHERE
+        NOT EXISTS (SELECT bb.bedspace_id FROM BookedBedspaces bb
+         WHERE bb.bedspace_id = b.id
+        ) AND
+        NOT EXISTS (
+         SELECT void_bedspace.bedspace_id FROM cas3_void_bedspaces void_bedspace
+         WHERE
+             void_bedspace.bed_id = b.id AND
+             (void_bedspace.start_date, void_bedspace.end_date) OVERLAPS (:start_date, :end_date) AND
+             void_bedspace.cancellation_date IS NULL
+        ) AND 
+        pdu.id IN (:probation_delivery_unit_ids) AND
+        pdu.probation_region_id = :probation_region_id AND 
+        (p.end_date IS NULL OR p.end_date > :start_date) AND 
+        (b.start_date <= :start_date AND (b.end_date IS NULL OR b.end_date > :end_date))
+        ORDER BY pdu.name, p.name, b.reference;
+"""
+
+  fun searchBedspaces(
+    probationDeliveryUnits: List<UUID>,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    probationRegionId: UUID,
+  ): List<Cas3v2CandidateBedspace> {
+    val params = MapSqlParameterSource().apply {
+      addValue("probation_region_id", probationRegionId)
+      addValue("probation_delivery_unit_ids", probationDeliveryUnits)
+      addValue("start_date", startDate)
+      addValue("end_date", endDate)
+    }
+
+    val result = namedParameterJdbcTemplate.query(
+      temporaryAccommodationSearchQuery,
+      params,
+      ResultSetExtractor { resultSet ->
+        val bedspaces = mutableMapOf<UUID, Cas3v2CandidateBedspace>()
+
+        while (resultSet.next()) {
+          val premisesId = UUID.fromString(resultSet.getString("premises_id"))
+          val premisesName = resultSet.getString("premises_name")
+          val premisesAddressLine1 = resultSet.getString("premises_address_line1")
+          val premisesAddressLine2 = resultSet.getString("premises_address_line2")
+          val premisesTown = resultSet.getString("premises_town")
+          val premisesPostcode = resultSet.getString("premises_postcode")
+          val premisesNotes = resultSet.getString("premises_notes")
+
+          val premisesCharacteristicName = resultSet.getString("premises_characteristic_name")
+          val premisesCharacteristicDescription = resultSet.getString("premises_characteristic_description")
+          val bedspaceCharacteristicName = resultSet.getString("bedspace_characteristic_name")
+          val bedspaceCharacteristicDescription = resultSet.getString("bedspace_characteristic_description")
+
+          val premisesBedspaceCount = resultSet.getInt("premises_bedspace_count")
+          val bookedBedspaceCount = resultSet.getInt("booked_bedspace_count")
+          val bedspaceId = resultSet.getNullableUUID("bedspace_id")
+          val bedspaceReference = resultSet.getString("bedspace_reference")
+          val probationDeliveryUnitName = resultSet.getString("probation_delivery_unit_name")
+
+          if (bedspaceId == null) continue
+
+          if (!bedspaces.containsKey(bedspaceId)) {
+            bedspaces[bedspaceId] = Cas3v2CandidateBedspace(
+              premisesId = premisesId,
+              premisesName = premisesName,
+              premisesAddressLine1 = premisesAddressLine1,
+              premisesAddressLine2 = premisesAddressLine2,
+              premisesTown = premisesTown,
+              premisesPostcode = premisesPostcode,
+              premisesNotes = premisesNotes,
+              probationDeliveryUnitName = probationDeliveryUnitName,
+              premisesCharacteristics = mutableListOf(),
+              premisesBedspaceCount = premisesBedspaceCount,
+              bookedBedspaceCount = bookedBedspaceCount,
+              bedspaceId = bedspaceId,
+              bedspaceReference = bedspaceReference,
+              bedspaceCharacteristics = mutableListOf(),
+              overlaps = mutableListOf(),
+            )
+          }
+
+          bedspaces[bedspaceId]!!.apply {
+            if (premisesCharacteristicDescription != null) {
+              premisesCharacteristics.addIfNoneMatch(Cas3CharacteristicNames(premisesCharacteristicName, premisesCharacteristicDescription)) {
+                it.description == premisesCharacteristicDescription
+              }
+            }
+
+            if (bedspaceCharacteristicName != null) {
+              bedspaceCharacteristics.addIfNoneMatch(Cas3CharacteristicNames(bedspaceCharacteristicName, bedspaceCharacteristicDescription)) {
+                it.description == bedspaceCharacteristicDescription
+              }
+            }
+          }
+        }
+
+        bedspaces.values.toList()
+      },
+    )
+
+    return result ?: emptyList()
+  }
+}
+
+private fun ResultSet.getNullableUUID(columnName: String): UUID? {
+  val stringValue = this.getString(columnName) ?: return null
+
+  return UUID.fromString(stringValue)
+}
+
+private inline fun <reified T> MutableList<T>.addIfNoneMatch(entry: T, matcher: (T) -> Boolean) {
+  if (this.any { matcher(it) }) return
+
+  this.add(entry)
+}
+
+@SuppressWarnings("LongParameterList")
+class Cas3v2CandidateBedspace(
+  val premisesId: UUID,
+  val premisesName: String,
+  val premisesAddressLine1: String,
+  val premisesAddressLine2: String?,
+  val premisesTown: String?,
+  val premisesPostcode: String,
+  val premisesCharacteristics: MutableList<Cas3CharacteristicNames>,
+  val premisesBedspaceCount: Int,
+  val bedspaceId: UUID,
+  val bedspaceReference: String,
+  val bedspaceCharacteristics: MutableList<Cas3CharacteristicNames>,
+  val probationDeliveryUnitName: String,
+  val premisesNotes: String?,
+  val bookedBedspaceCount: Int,
+  val overlaps: MutableList<Cas3v2CandidateBedspaceOverlap>,
+)
+
+data class Cas3CharacteristicNames(
+  val name: String,
+  val description: String,
+)
+
+data class Cas3v2CandidateBedspaceOverlap(
+  val name: String,
+  val crn: String,
+  val personType: PersonType,
+  val sex: String?,
+  val days: Int,
+  val premisesId: UUID,
+  val bedspaceId: UUID,
+  val bookingId: UUID,
+  val assessmentId: UUID?,
+  val isSexualRisk: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BedspaceSearchService.kt
@@ -1,0 +1,222 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2OverlapBookingsSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BedspaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3BedspaceSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3v2CandidateBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3v2CandidateBedspaceOverlap
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS3_PROPERTY_NAME_MEN_ONLY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS3_PROPERTY_NAME_WOMEN_ONLY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.forCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.containsNone
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.countOverlappingDays
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromPersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.tryGetDetails
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class Cas3v2BedspaceSearchService(
+  private val cas3BedspaceSearchRepository: Cas3BedspaceSearchRepository,
+  private val cas3v2BookingRepository: Cas3v2BookingRepository,
+  private val probationDeliveryUnitRepository: ProbationDeliveryUnitRepository,
+  private val characteristicService: CharacteristicService,
+  private val workingDayService: WorkingDayService,
+  private val offenderService: OffenderService,
+) {
+  companion object {
+    const val MAX_NUMBER_PDUS = 5
+  }
+
+  @Suppress("detekt:CyclomaticComplexMethod")
+  fun searchBedspaces(
+    user: UserEntity,
+    searchParams: Cas3BedspaceSearchParameters,
+  ): CasResult<List<Cas3v2CandidateBedspace>> = validatedCasResult {
+    val probationDeliveryUnitIds = mutableListOf<UUID>()
+
+    if (searchParams.durationDays < 1) {
+      "$.durationDays" hasValidationError "mustBeAtLeast1"
+    }
+
+    if (searchParams.probationDeliveryUnits.isEmpty()) {
+      "$.probationDeliveryUnits" hasValidationError "empty"
+    } else if (searchParams.probationDeliveryUnits.size > MAX_NUMBER_PDUS) {
+      "$.probationDeliveryUnits" hasValidationError "maxNumberProbationDeliveryUnits"
+    } else {
+      searchParams.probationDeliveryUnits.mapIndexed { index, id ->
+        val probationDeliveryUnitEntityExist = probationDeliveryUnitRepository.existsById(id)
+        if (!probationDeliveryUnitEntityExist) {
+          "$.probationDeliveryUnits[$index]" hasValidationError "doesNotExist"
+        } else {
+          probationDeliveryUnitIds.add(id)
+        }
+      }
+    }
+
+    if (validationErrors.any()) {
+      return fieldValidationError
+    }
+
+    val endDate = searchParams.calculateEndDate()
+
+    val candidateResults =
+      cas3BedspaceSearchRepository.searchBedspaces(
+        probationDeliveryUnits = probationDeliveryUnitIds,
+        startDate = searchParams.startDate,
+        endDate = endDate,
+        probationRegionId = user.probationRegion.id,
+      )
+
+    val bedspaceIds = candidateResults.map { it.bedspaceId }
+    val bedspacesWithABookingInTurnaround = cas3v2BookingRepository.findClosestBookingBeforeDateForBedspaces(searchParams.startDate, bedspaceIds)
+      .filter { workingDayService.addWorkingDays(it.departureDate, it.turnaround?.workingDayCount ?: 0) >= searchParams.startDate }
+      .map { it.bedspace.id }
+
+    val results = candidateResults.filter { !bedspacesWithABookingInTurnaround.contains(it.bedspaceId) }
+
+    val distinctIds = results.map { it.premisesId }.distinct()
+    val overlappedBookings = cas3v2BookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(distinctIds, searchParams.startDate, endDate)
+    val crns = overlappedBookings.map { it.crn }.distinct().toSet()
+    val offenderSummaries = offenderService.getPersonSummaryInfoResults(
+      crns = crns.toSet(),
+      laoStrategy = user.cas3LaoStrategy(),
+    )
+
+    val groupedOverlappedBookings = overlappedBookings
+      .map { transformBookingToOverlap(it, searchParams.startDate, endDate, offenderSummaries.forCrn(it.crn)) }
+      .groupBy { it.premisesId }
+
+    results.forEach {
+      val overlappingBookings = groupedOverlappedBookings[it.premisesId]?.toList() ?: listOf()
+      it.overlaps.addAll(overlappingBookings)
+    }
+
+    return success(applySearchFilters(searchParams, results))
+  }
+
+  /*
+  This temporally adds new filter functionality to the search results and to unblock the UI whilst we await confirmation from the central team on how
+  bed search should work. This will be removed and be added to the query added earlier in the search process to improve performance.
+   */
+  private fun applySearchFilters(
+    searchParams: Cas3BedspaceSearchParameters,
+    results: List<Cas3v2CandidateBedspace>,
+  ): List<Cas3v2CandidateBedspace> {
+    if (searchParams.bedspaceFilters == null && searchParams.premisesFilters == null) {
+      return results
+    }
+
+    val bedspaceCharacteristicNames =
+      characteristicService.getCas3BedspaceCharacteristics().associateBy({ it.id }, { it.name })
+
+    // we will use IDs in the query in future refactoring, but for now it only returns names, so map IDs to characteristic propertyNames.
+    val bedspaceCharacteristicsToInclude =
+      searchParams.bedspaceFilters?.includedCharacteristicIds?.map { bedspaceCharacteristicNames[it]!! } ?: emptyList()
+    val bedspaceCharacteristicsToExclude =
+      searchParams.bedspaceFilters?.excludedCharacteristicIds?.map { bedspaceCharacteristicNames[it]!! } ?: emptyList()
+
+    val premisesCharacteristicNames =
+      characteristicService.getCas3PremisesCharacteristics().associateBy({ it.id }, { it.name })
+
+    var premisesCharacteristicsToInclude =
+      searchParams.premisesFilters?.includedCharacteristicIds?.map { premisesCharacteristicNames[it]!! } ?: emptyList()
+    val premisesCharacteristicsToExclude =
+      searchParams.premisesFilters?.excludedCharacteristicIds?.map { premisesCharacteristicNames[it]!! } ?: emptyList()
+
+    val excludePremisesIds = when {
+      premisesCharacteristicsToInclude.contains(CAS3_PROPERTY_NAME_MEN_ONLY) -> {
+        // remove isMenOnly characteristic to ensure it is not filtered by later
+        premisesCharacteristicsToInclude = premisesCharacteristicsToInclude.filter { it != CAS3_PROPERTY_NAME_MEN_ONLY }
+
+        // filter properties that have women only characteristic or have female occupants to exclude them
+        premisesIdsNotSuitableForGender(results, CAS3_PROPERTY_NAME_WOMEN_ONLY, "female")
+      }
+
+      premisesCharacteristicsToInclude.contains(CAS3_PROPERTY_NAME_WOMEN_ONLY) -> {
+        // remove isWomenOnly characteristic to ensure it is not filtered by later
+        premisesCharacteristicsToInclude = premisesCharacteristicsToInclude.filter { it != CAS3_PROPERTY_NAME_WOMEN_ONLY }
+
+        // filter properties that have men only characteristic or have man occupants to exclude them
+        premisesIdsNotSuitableForGender(results, CAS3_PROPERTY_NAME_MEN_ONLY, "male")
+      }
+
+      else -> emptyList()
+    }
+
+    return results
+      .filter { result ->
+        val premisesCharacteristics = result.premisesCharacteristics.map { it.name }
+        premisesCharacteristics.containsAll(premisesCharacteristicsToInclude) &&
+          premisesCharacteristics.containsNone(premisesCharacteristicsToExclude)
+      }.filter { result ->
+        val bedspaceCharacteristics = result.bedspaceCharacteristics.map { it.name }
+        bedspaceCharacteristics.containsAll(bedspaceCharacteristicsToInclude) &&
+          bedspaceCharacteristics.containsNone(bedspaceCharacteristicsToExclude)
+      }.filter { result ->
+        !excludePremisesIds.contains(result.premisesId)
+      }
+  }
+
+  fun transformBookingToOverlap(
+    overlappedBooking: Cas3v2OverlapBookingsSearchResult,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    personSummaryInfo: PersonSummaryInfoResult,
+  ): Cas3v2CandidateBedspaceOverlap {
+    val queryDuration = startDate..endDate
+    val bookingDuration = overlappedBooking.arrivalDate..overlappedBooking.departureDate
+
+    return Cas3v2CandidateBedspaceOverlap(
+      name = getNameFromPersonSummaryInfoResult(personSummaryInfo),
+      crn = overlappedBooking.crn,
+      personType = getPersonType(personSummaryInfo),
+      sex = personSummaryInfo.tryGetDetails { it.gender },
+      days = bookingDuration countOverlappingDays queryDuration,
+      premisesId = overlappedBooking.premisesId,
+      bedspaceId = overlappedBooking.bedspaceId,
+      bookingId = overlappedBooking.bookingId,
+      assessmentId = overlappedBooking.assessmentId,
+      isSexualRisk = overlappedBooking.sexualRisk,
+    )
+  }
+
+  private fun getPersonType(
+    personSummaryInfo: PersonSummaryInfoResult,
+  ): PersonType = when (personSummaryInfo) {
+    is PersonSummaryInfoResult.Success.Full -> PersonType.fullPerson
+    is PersonSummaryInfoResult.Success.Restricted -> PersonType.restrictedPerson
+    is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> PersonType.unknownPerson
+  }
+
+  private fun Cas3BedspaceSearchParameters.calculateEndDate(): LocalDate {
+    // Adjust to include the start date in the duration, e.g. 1st January for 1 day should end on the 1st January
+    val adjustedDuration = durationDays - 1
+    return startDate.plusDays(adjustedDuration)
+  }
+
+  private fun premisesIdsNotSuitableForGender(
+    bedspaces: List<Cas3v2CandidateBedspace>,
+    excludeCharacteristic: String,
+    excludeOverlapsGender: String,
+  ) = bedspaces
+    .asSequence()
+    .filter { bedspace ->
+      bedspace.premisesCharacteristics.any { it.name == excludeCharacteristic } ||
+        bedspace.overlaps.any { it.sex?.lowercase() == excludeOverlapsGender.lowercase() }
+    }
+    .map { it.premisesId }
+    .toSet()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
@@ -120,7 +120,7 @@ class Cas3v2BookingService(
     val bedspace = cas3BedspaceRepository.findByIdOrNull(bedspaceId)
     if (bedspace == null) {
       "$.bedspaceId" hasValidationError "doesNotExist"
-    } else if (bedspace.startDate != null && bedspace.startDate!!.isAfter(arrivalDate)) {
+    } else if (bedspace.startDate.isAfter(arrivalDate)) {
       "$.arrivalDate" hasValidationError "bookingArrivalDateBeforeBedspaceStartDate"
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3v2BedspaceSearchResultsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3v2BedspaceSearchResultsTransformer.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceSearchResultBedspaceSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceSearchResultPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3CharacteristicPair
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResultOverlap
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3v2CandidateBedspace
+
+@Component
+class Cas3v2BedspaceSearchResultsTransformer {
+  fun transformDomainToApi(results: List<Cas3v2CandidateBedspace>) = Cas3v2BedspaceSearchResults(
+    resultsBedspaceCount = results.distinctBy { it.bedspaceId }.size,
+    resultsPremisesCount = results.distinctBy { it.premisesId }.size,
+    results = results.map(::transformResult),
+  )
+
+  private fun transformResult(result: Cas3v2CandidateBedspace) = Cas3v2BedspaceSearchResult(
+    premises = Cas3BedspaceSearchResultPremisesSummary(
+      id = result.premisesId,
+      name = result.premisesName,
+      addressLine1 = result.premisesAddressLine1,
+      postcode = result.premisesPostcode,
+      characteristics = result.premisesCharacteristics.map {
+        Cas3CharacteristicPair(
+          name = it.name,
+          description = it.description,
+        )
+      },
+      addressLine2 = result.premisesAddressLine2,
+      town = result.premisesTown,
+      probationDeliveryUnitName = result.probationDeliveryUnitName,
+      notes = result.premisesNotes,
+      bedspaceCount = result.premisesBedspaceCount,
+      bookedBedspaceCount = result.bookedBedspaceCount,
+    ),
+    bedspace = Cas3BedspaceSearchResultBedspaceSummary(
+      id = result.bedspaceId,
+      reference = result.bedspaceReference,
+      characteristics = result.bedspaceCharacteristics.map {
+        Cas3CharacteristicPair(
+          name = it.name,
+          description = it.description,
+        )
+      },
+    ),
+    overlaps = result.overlaps.map {
+      Cas3v2BedspaceSearchResultOverlap(
+        name = it.name,
+        crn = it.crn,
+        personType = it.personType,
+        days = it.days,
+        bookingId = it.bookingId,
+        bedspaceId = it.bedspaceId,
+        sex = it.sex,
+        assessmentId = it.assessmentId,
+        isSexualRisk = it.isSexualRisk,
+      )
+    },
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/CharacteristicService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
@@ -18,6 +19,7 @@ import java.util.UUID
 class CharacteristicService(
   val characteristicRepository: CharacteristicRepository,
   val bedspaceCharacteristicRepository: Cas3BedspaceCharacteristicRepository,
+  val premisesCharacteristicRepository: Cas3PremisesCharacteristicRepository,
 ) {
   fun getCharacteristic(characteristicId: UUID): CharacteristicEntity? = characteristicRepository.findByIdOrNull(characteristicId)
 
@@ -36,6 +38,10 @@ class CharacteristicService(
   }
 
   fun getCas3BedspaceCharacteristic(characteristicId: UUID): Cas3BedspaceCharacteristicEntity? = bedspaceCharacteristicRepository.findByIdOrNull(characteristicId)
+
+  fun getCas3BedspaceCharacteristics() = bedspaceCharacteristicRepository.findByActive(active = true)
+
+  fun getCas3PremisesCharacteristics() = premisesCharacteristicRepository.findByActive(active = true)
 
   fun getCas3Characteristics(): List<CharacteristicEntity> = characteristicRepository.findActiveByServiceScopeAndModelScope(
     ServiceName.temporaryAccommodation.value,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceCharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceCharacteristicEntityFactory.kt
@@ -33,6 +33,6 @@ class Cas3BedspaceCharacteristicEntityFactory : Factory<Cas3BedspaceCharacterist
     id = this.id(),
     description = this.description(),
     name = this.name(),
-    isActive = this.isActive(),
+    active = this.isActive(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BedspaceEntityFactory.kt
@@ -5,9 +5,6 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -19,10 +16,10 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
   private var characteristics: Yielded<MutableList<Cas3BedspaceCharacteristicEntity>> = { mutableListOf() }
   private var reference: Yielded<String> = { randomStringUpperCase(6) }
   private var notes: Yielded<String?> = { null }
-  private var startDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
-  private var endDate: Yielded<LocalDate?> = { LocalDate.now().randomDateAfter(6) }
-  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(30) }
-  private var createdDate: Yielded<LocalDate> = { LocalDate.now().randomDateBefore(6) }
+  private var startDate: Yielded<LocalDate> = { LocalDate.now().minusDays(90) }
+  private var endDate: Yielded<LocalDate?>? = null
+  private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
+  private var createdDate: Yielded<LocalDate> = { LocalDate.now().minusDays(90) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -68,7 +65,7 @@ class Cas3BedspaceEntityFactory : Factory<Cas3BedspacesEntity> {
     reference = this.reference(),
     notes = this.notes(),
     startDate = this.startDate(),
-    endDate = this.endDate(),
+    endDate = this.endDate?.invoke(),
     createdAt = this.createdAt(),
     createdDate = this.createdDate(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3PremisesCharacteristicEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3PremisesCharacteristicEntityFactory.kt
@@ -32,6 +32,6 @@ class Cas3PremisesCharacteristicEntityFactory : Factory<Cas3PremisesCharacterist
     id = this.id,
     name = this.name,
     description = this.description,
-    isActive = this.isActive,
+    active = this.isActive,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3MigrateNewBedspaceModelDataJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3MigrateNewBedspaceModelDataJobTest.kt
@@ -146,7 +146,7 @@ class Cas3MigrateNewBedspaceModelDataJobTest : Cas3IntegrationTestBase() {
       val sourcePremisesCharacteristic = temporaryAccommodationPremisesEntity.characteristics.first { it.id == migratedCharacteristic.id }
       assertThat(migratedCharacteristic.description).isEqualTo(sourcePremisesCharacteristic.name)
       assertThat(migratedCharacteristic.name).isEqualTo(sourcePremisesCharacteristic.propertyName)
-      assertThat(migratedCharacteristic.isActive).isEqualTo(sourcePremisesCharacteristic.isActive)
+      assertThat(migratedCharacteristic.active).isEqualTo(sourcePremisesCharacteristic.isActive)
     }
   }
 
@@ -156,7 +156,7 @@ class Cas3MigrateNewBedspaceModelDataJobTest : Cas3IntegrationTestBase() {
       val sourcePremisesCharacterists = expectedRoomToMatch.characteristics.first { it.id == migratedCharacteristic.id }
       assertThat(migratedCharacteristic.description).isEqualTo(sourcePremisesCharacterists.name)
       assertThat(migratedCharacteristic.name).isEqualTo(sourcePremisesCharacterists.propertyName)
-      assertThat(migratedCharacteristic.isActive).isEqualTo(sourcePremisesCharacterists.isActive)
+      assertThat(migratedCharacteristic.active).isEqualTo(sourcePremisesCharacterists.isActive)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceSearchTest.kt
@@ -1,0 +1,2507 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository.Constants.CAS3_PROPERTY_NAME_MEN_ONLY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository.Constants.CAS3_PROPERTY_NAME_PUB_NEAR_BY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository.Constants.CAS3_PROPERTY_NAME_SINGLE_OCCUPANCY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository.Constants.CAS3_PROPERTY_NAME_WHEELCHAIR_ACCESSIBLE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository.Constants.CAS3_PROPERTY_NAME_WOMEN_ONLY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceSearchResultBedspaceSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceSearchResultPremisesSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3CharacteristicPair
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResultOverlap
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3v2BedspaceSearchResults
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.BedspaceFilters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BedspaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.PremisesFilters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenCas3PremisesAndBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenSomeOffenders
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS3_PROPERTY_NAME_SHARED_PROPERTY
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJobService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+@SuppressWarnings("LargeClass")
+class Cas3v2BedspaceSearchTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var migrationJobService: MigrationJobService
+
+  lateinit var probationRegion: ProbationRegionEntity
+
+  companion object Constants {
+    const val PREMISES_SINGLE_OCCUPANCY_ID = "007c8237-b4f4-4ee0-a9e6-62dc0d1c6a2c"
+    const val PREMISES_SHARED_PROPERTY_ID = "e7e492d7-7853-48a8-9a98-23f68af92a85"
+    const val PREMISES_MEN_ONLY_ID = "f21a3f74-0538-4541-8b29-3cbdcd240ae4"
+    const val PREMISES_WOMEN_ONLY_ID = "25ff5695-eab1-46ad-9f3f-639edb180672"
+    const val PREMISES_PUB_NEARBY_ID = "6a952536-d88c-4e14-be24-d80eb754d12b"
+    const val PREMISES_SINGLE_OCCUPANCY_MEN_ONLY_ID = "f2a0b5d1-3c4e-4b8c-8f6d-7a9e0b1f2c3d"
+    const val PREMISES_SINGLE_OCCUPANCY_WOMEN_ONLY_ID = "1735874f-ab84-479c-b007-dd49d54ab339"
+    const val PREMISES_SINGLE_OCCUPANCY_WHEELCHAIR_ACCESSIBILITY_ID = "df702555-6e5e-4e28-8b83-c7bdd8a8db1a"
+    const val PREMISES_SHARED_PROPERTY_MEN_ONLY_ID = "a7540305-dd6e-41f3-8647-c45e7cfe7e0c"
+    const val PREMISES_SHARED_PROPERTY_WOMEN_ONLY_ID = "b2a7306c-7049-41b0-b0d9-fd23bd0f7d42"
+  }
+
+  @BeforeEach
+  fun before() {
+    probationRegion = givenAProbationRegion()
+  }
+
+  @Nested
+  inner class BedspaceSearchForPremises {
+    @Test
+    fun `Searching for a bedspace without JWT returns 401`() {
+      webTestClient.post()
+        .uri("/cas3/v2/bedspaces/search")
+        .bodyValue(
+          Cas3BedspaceSearchParameters(
+            startDate = LocalDate.now().plusDays(7),
+            durationDays = 7,
+            probationDeliveryUnits = listOf(UUID.randomUUID()),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Searching for a bedspace returns 200 with correct body`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val (premises, bedspace) = givenCas3PremisesAndBedspace(user, startDate = LocalDate.now().minusDays(30), endDate = null)
+        val searchPdu = premises.probationDeliveryUnit
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().minusDays(10),
+              durationDays = 7,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 1,
+                resultsBedspaceCount = 1,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premises,
+                    bedspace,
+                    pduName = searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace returns an upcoming bedspace in the schedule to unarchive premises when the bedspace is online within the search range`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = cas3PremisesEntityFactory
+          .produceAndPersist {
+            withStatus(Cas3PremisesStatus.online)
+            withStartDate(LocalDate.now().minusDays(90))
+            withEndDate(null)
+            withProbationDeliveryUnit(
+              probationDeliveryUnitFactory.produceAndPersist {
+                withProbationRegion(user.probationRegion)
+              },
+            )
+            withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+          }
+        val bedspace = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withStartDate(LocalDate.now().plusDays(3))
+          withEndDate(null)
+        }
+        val searchPdu = premises.probationDeliveryUnit
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(7),
+              durationDays = 7,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 1,
+                resultsBedspaceCount = 1,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premises,
+                    bedspace,
+                    pduName = searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace will not return an upcoming bedspace with a start date after the search range start date`() {
+      givenAUser(roles = listOf(UserRole.CAS3_ASSESSOR)) { user, jwt ->
+        val premises = cas3PremisesEntityFactory
+          .produceAndPersist {
+            withStatus(Cas3PremisesStatus.online)
+            withStartDate(LocalDate.now().minusDays(90))
+            withEndDate(null)
+            withProbationDeliveryUnit(
+              probationDeliveryUnitFactory.produceAndPersist {
+                withProbationRegion(user.probationRegion)
+              },
+            )
+            withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+          }
+        cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withStartDate(LocalDate.now().plusDays(3))
+          withEndDate(null)
+        }
+        val searchPdu = premises.probationDeliveryUnit!!
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(1),
+              durationDays = 7,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsBedspaceCount = 0,
+                resultsPremisesCount = 0,
+                results = listOf(),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace returns results that do not include bedspaces with current turnarounds`() {
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+        }
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premises = cas3PremisesEntityFactory.produceAndPersist {
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(searchPdu)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        val bedspace = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("Matching Bed")
+        }
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withServiceName(ServiceName.temporaryAccommodation)
+          withPremises(premises)
+          withBedspace(bedspace)
+          withArrivalDate(LocalDate.parse("2022-12-21"))
+          withDepartureDate(LocalDate.parse("2023-03-21"))
+        }
+        val turnaround = cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking)
+          withWorkingDayCount(2)
+        }
+        booking.turnarounds = mutableListOf(turnaround)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        searchCas3BedspaceAndAssertNoAvailability(
+          jwt,
+          searchStartDate = LocalDate.parse("2023-03-23"),
+          durationDays = 7,
+          pduId = searchPdu.id,
+        )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace returns results when existing booking departure date is same as search start date`() {
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+          withProbationRegion(probationRegion)
+        }
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premises = cas3PremisesEntityFactory.produceAndPersist {
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(searchPdu)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        val bedspace = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("Matching Bedspace")
+        }
+        val booking = cas3BookingEntityFactory.produceAndPersist {
+          withServiceName(ServiceName.temporaryAccommodation)
+          withPremises(premises)
+          withBedspace(bedspace)
+          withArrivalDate(LocalDate.parse("2022-12-21"))
+          withDepartureDate(LocalDate.parse("2023-03-21"))
+        }
+        val turnaround = cas3v2TurnaroundFactory.produceAndPersist {
+          withBooking(booking)
+          withWorkingDayCount(2)
+        }
+        booking.turnarounds = mutableListOf(turnaround)
+
+        govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
+
+        searchCas3BedspaceAndAssertNoAvailability(
+          jwt,
+          searchStartDate = LocalDate.parse("2023-03-21"),
+          durationDays = 7,
+          pduId = searchPdu.id,
+        )
+      }
+    }
+
+    @ParameterizedTest
+    @CsvSource("true,cas3/v2/bedspaces/search", "false,cas3/v2/bedspaces/search")
+    fun `Searching for a bedspace returns results which include overlapping bookings for bedspaces in the same premises`(sexualRisk: Boolean, baseUrl: String) {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { user, jwt ->
+        givenSomeOffenders { offenderSequence ->
+
+          val offenders = offenderSequence.take(4).toList()
+          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+          val applications = mutableListOf<TemporaryAccommodationApplicationEntity>()
+          val assessments = mutableListOf<AssessmentEntity>()
+          offenders.mapIndexed { _, (offenderDetails, _) ->
+            val (application, assessment) = createAssessment(user, offenderDetails.otherIds.crn, sexualRisk = sexualRisk)
+            applications += application
+            assessments += assessment
+          }
+          val premises = cas3PremisesEntityFactory.produceAndPersist {
+            withLocalAuthorityArea(localAuthorityArea)
+            withProbationDeliveryUnit(searchPdu)
+            withStatus(Cas3PremisesStatus.online)
+          }
+          val bedspaceOne = cas3BedspaceEntityFactory.produceAndPersist {
+            withReference("matching bedspace")
+            withPremises(premises)
+          }
+          val bedspaceTwo = cas3BedspaceEntityFactory.produceAndPersist {
+            withReference("matching bedspace, but with an overlapping booking")
+            withPremises(premises)
+          }
+          val bedspaceThree = cas3BedspaceEntityFactory.produceAndPersist {
+            withReference("another bedspace with an overlapping booking")
+            withPremises(premises)
+          }
+          val bedspaceFour = cas3BedspaceEntityFactory.produceAndPersist {
+            withReference("yet another bedspace with an overlapping booking")
+            withPremises(premises)
+          }
+
+          val fullPersonOffenderDetails = offenders.first().first
+          val fullPersonApplication = applications.first()
+          val fullPersonAssessment = assessments.first()
+          val fullPersonCaseSummary = CaseSummaryFactory()
+            .fromOffenderDetails(fullPersonOffenderDetails)
+            .withPnc(fullPersonOffenderDetails.otherIds.pncNumber)
+            .produce()
+
+          val overlappingBookingSameBedspaces = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(fullPersonApplication)
+            withPremises(premises)
+            withBedspace(bedspaceTwo)
+            withArrivalDate(LocalDate.now().minusDays(17))
+            withDepartureDate(LocalDate.now().plusDays(14))
+            withCrn(fullPersonCaseSummary.crn)
+            withId(UUID.randomUUID())
+          }
+
+          val currentRestrictionOffenderDetails = offenders.drop(1).first().first
+          val currentRestrictionApplication = applications.drop(1).first()
+          val currentRestrictionAssessment = assessments.drop(1).first()
+          val currentRestrictionCaseSummary = CaseSummaryFactory()
+            .fromOffenderDetails(currentRestrictionOffenderDetails)
+            .withPnc(currentRestrictionOffenderDetails.otherIds.pncNumber)
+            .withCurrentRestriction(true)
+            .produce()
+
+          val currentRestrictionOverlappingBooking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(currentRestrictionApplication)
+            withPremises(premises)
+            withBedspace(bedspaceThree)
+            withArrivalDate(LocalDate.now().plusDays(26))
+            withDepartureDate(LocalDate.now().plusDays(43))
+            withCrn(currentRestrictionCaseSummary.crn)
+            withId(UUID.randomUUID())
+          }
+
+          val userExcludedOffenderDetails = offenders.drop(2).first().first
+          val userExcludedApplication = applications.drop(2).first()
+          val userExcludedAssessment = assessments.drop(2).first()
+          val userExcludedCaseSummary = CaseSummaryFactory()
+            .fromOffenderDetails(userExcludedOffenderDetails)
+            .withPnc(userExcludedOffenderDetails.otherIds.pncNumber)
+            .withCurrentExclusion(true)
+            .produce()
+
+          val userExcludedOverlappingBooking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(userExcludedApplication)
+            withPremises(premises)
+            withBedspace(bedspaceFour)
+            withArrivalDate(LocalDate.now().plusDays(24))
+            withDepartureDate(LocalDate.now().plusDays(55))
+            withCrn(userExcludedCaseSummary.crn)
+            withId(UUID.randomUUID())
+          }
+
+          apDeliusContextAddListCaseSummaryToBulkResponse(listOf(fullPersonCaseSummary, userExcludedCaseSummary, currentRestrictionCaseSummary))
+
+          apDeliusContextAddResponseToUserAccessCall(
+            listOf(
+              CaseAccessFactory()
+                .withCrn(userExcludedCaseSummary.crn)
+                .withUserExcluded(true)
+                .produce(),
+              CaseAccessFactory()
+                .withCrn(currentRestrictionCaseSummary.crn)
+                .withUserRestricted(true)
+                .produce(),
+            ),
+            user.deliusUsername,
+          )
+
+          webTestClient.post()
+            .uri(baseUrl)
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              Cas3BedspaceSearchParameters(
+                startDate = LocalDate.now(),
+                durationDays = 31,
+                probationDeliveryUnits = listOf(searchPdu.id),
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                Cas3v2BedspaceSearchResults(
+                  resultsPremisesCount = 1,
+                  resultsBedspaceCount = 1,
+                  results = listOf(
+                    createBedspaceSearchResult(
+                      premises,
+                      bedspaceOne,
+                      pduName = searchPdu.name,
+                      numberOfBedspaces = 4,
+                      numberOfBookedBeds = 3,
+                      premisesCharacteristics = listOf(),
+                      bedspaceCharacteristics = listOf(),
+                      listOf(
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "${fullPersonCaseSummary.name.forename} ${fullPersonCaseSummary.name.surname}",
+                          crn = fullPersonCaseSummary.crn,
+                          personType = PersonType.fullPerson,
+                          sex = fullPersonCaseSummary.gender!!,
+                          days = 15,
+                          bookingId = overlappingBookingSameBedspaces.id,
+                          bedspaceId = bedspaceTwo.id,
+                          assessmentId = fullPersonAssessment.id,
+                          isSexualRisk = sexualRisk,
+                        ),
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "Limited Access Offender",
+                          crn = currentRestrictionCaseSummary.crn,
+                          personType = PersonType.restrictedPerson,
+                          days = 5,
+                          bookingId = currentRestrictionOverlappingBooking.id,
+                          bedspaceId = bedspaceThree.id,
+                          assessmentId = currentRestrictionAssessment.id,
+                          isSexualRisk = sexualRisk,
+                        ),
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "Limited Access Offender",
+                          crn = userExcludedCaseSummary.crn,
+                          personType = PersonType.restrictedPerson,
+                          days = 7,
+                          bookingId = userExcludedOverlappingBooking.id,
+                          bedspaceId = bedspaceFour.id,
+                          assessmentId = userExcludedAssessment.id,
+                          isSexualRisk = sexualRisk,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            )
+        }
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace returns results which include overlapping bookings across multiple premises`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { user, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+          val (application, assessment) = createAssessment(user, offenderDetails.otherIds.crn)
+          val caseSummary = CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetails)
+            .withPnc(offenderDetails.otherIds.pncNumber)
+            .produce()
+          val premisesOne = cas3PremisesEntityFactory.produceAndPersist {
+            withName("Premises One")
+            withLocalAuthorityArea(localAuthorityArea)
+            withProbationDeliveryUnit(searchPdu)
+            withStatus(Cas3PremisesStatus.online)
+          }
+          val premisesTwo = cas3PremisesEntityFactory.produceAndPersist {
+            withName("Premises Two")
+            withLocalAuthorityArea(localAuthorityArea)
+            withProbationDeliveryUnit(searchPdu)
+            withStatus(Cas3PremisesStatus.online)
+          }
+          val matchingBedInPremisesOne = cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(premisesOne)
+            withReference("matching bed in premises one")
+          }
+          val overlappingBedInPremisesOne = cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(premisesOne)
+            withReference("overlapping bed in premises one")
+          }
+          val matchingBedInPremisesTwo = cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(premisesTwo)
+            withReference("matching bed in premises two")
+          }
+          val overlappingBedInPremisesTwo = cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(premisesTwo)
+            withReference("overlapping bed in premises two")
+          }
+          val overlappingBookingForBedInPremisesOne = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(application)
+            withPremises(premisesOne)
+            withBedspace(overlappingBedInPremisesOne)
+            withArrivalDate(LocalDate.now().minusDays(19))
+            withDepartureDate(LocalDate.now().plusDays(16))
+            withCrn(offenderDetails.otherIds.crn)
+            withId(UUID.randomUUID())
+          }
+          val overlappingBookingForBedInPremisesTwo = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(application)
+            withPremises(premisesTwo)
+            withBedspace(overlappingBedInPremisesTwo)
+            withArrivalDate(LocalDate.now().plusDays(26))
+            withDepartureDate(LocalDate.now().plusDays(57))
+            withCrn(offenderDetails.otherIds.crn)
+            withId(UUID.randomUUID())
+          }
+
+          val cancelledOverlappingBookingForBedInPremisesTwo = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(application)
+            withPremises(premisesTwo)
+            withBedspace(overlappingBedInPremisesTwo)
+            withArrivalDate(LocalDate.now().minusDays(9))
+            withDepartureDate(LocalDate.now().plusDays(7))
+            withCrn(offenderDetails.otherIds.crn)
+            withId(UUID.randomUUID())
+          }
+
+          cas3CancellationEntityFactory.produceAndPersist {
+            withBooking(cancelledOverlappingBookingForBedInPremisesTwo)
+            withReason(cancellationReasonEntityFactory.produceAndPersist())
+          }
+
+          apDeliusContextAddResponseToUserAccessCall(
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
+            user.deliusUsername,
+          )
+
+          webTestClient.post()
+            .uri("cas3/v2/bedspaces/search")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              Cas3BedspaceSearchParameters(
+                startDate = LocalDate.now().plusDays(2),
+                durationDays = 31,
+                probationDeliveryUnits = listOf(searchPdu.id),
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                Cas3v2BedspaceSearchResults(
+                  resultsPremisesCount = 2,
+                  resultsBedspaceCount = 2,
+                  results = listOf(
+                    createBedspaceSearchResult(
+                      premisesOne,
+                      bedspace = matchingBedInPremisesOne,
+                      pduName = searchPdu.name,
+                      numberOfBedspaces = 2,
+                      numberOfBookedBeds = 1,
+                      premisesCharacteristics = listOf(),
+                      bedspaceCharacteristics = listOf(),
+                      listOf(
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "${caseSummary.name.forename} ${caseSummary.name.surname}",
+                          crn = overlappingBookingForBedInPremisesOne.crn,
+                          personType = PersonType.fullPerson,
+                          sex = caseSummary.gender!!,
+                          days = 15,
+                          bookingId = overlappingBookingForBedInPremisesOne.id,
+                          bedspaceId = overlappingBedInPremisesOne.id,
+                          assessmentId = assessment.id,
+                          isSexualRisk = false,
+                        ),
+                      ),
+                    ),
+                    createBedspaceSearchResult(
+                      premisesTwo,
+                      bedspace = matchingBedInPremisesTwo,
+                      pduName = searchPdu.name,
+                      numberOfBedspaces = 2,
+                      numberOfBookedBeds = 1,
+                      premisesCharacteristics = listOf(),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "${caseSummary.name.forename} ${caseSummary.name.surname}",
+                          crn = overlappingBookingForBedInPremisesTwo.crn,
+                          personType = PersonType.fullPerson,
+                          sex = caseSummary.gender!!,
+                          days = 7,
+                          bookingId = overlappingBookingForBedInPremisesTwo.id,
+                          bedspaceId = overlappingBedInPremisesTwo.id,
+                          assessmentId = assessment.id,
+                          isSexualRisk = false,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              true,
+            )
+        }
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace returns results which do not include non-overlapping bookings`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premises = cas3PremisesEntityFactory.produceAndPersist {
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(searchPdu)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        val bedOne = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("1 - matching bed with no bookings")
+        }
+        val bedTwo = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("2 - matching bed with non-overlapping booking")
+        }
+        val nonOverlappingBooking = cas3BookingEntityFactory.produceAndPersist {
+          withServiceName(ServiceName.temporaryAccommodation)
+          withPremises(premises)
+          withBedspace(bedTwo)
+          withArrivalDate(LocalDate.now().plusDays(60))
+          withDepartureDate(LocalDate.now().plusDays(90))
+          withCrn(randomStringMultiCaseWithNumbers(16))
+        }
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(7),
+              durationDays = 31,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 1,
+                resultsBedspaceCount = 2,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premises,
+                    bedOne,
+                    pduName = searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    premises,
+                    bedTwo,
+                    pduName = searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+            true,
+          )
+          .jsonPath("$.results[*].overlaps[*].bookingId").value(Matchers.not(nonOverlappingBooking.id))
+          .jsonPath("$.results[*].overlaps[*].bedspaceId").value(Matchers.not(nonOverlappingBooking.bedspace.id))
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace returns results which do not consider cancelled bookings as overlapping`() {
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { user, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+          val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(probationRegion)
+          }
+          val (application, _) = createAssessment(user, offenderDetails.otherIds.crn)
+          val premises = cas3PremisesEntityFactory.produceAndPersist {
+            withLocalAuthorityArea(localAuthorityArea)
+            withProbationDeliveryUnit(searchPdu)
+            withStatus(Cas3PremisesStatus.online)
+          }
+          val bedOne = cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(premises)
+            withReference("1 - matching bed with no bookings")
+          }
+          val bedTwo = cas3BedspaceEntityFactory.produceAndPersist {
+            withPremises(premises)
+            withReference("2 - matching bed with a cancelled booking")
+          }
+          val nonOverlappingBooking = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withApplication(application)
+            withPremises(premises)
+            withBedspace(bedTwo)
+            withArrivalDate(LocalDate.now().minusDays(48))
+            withDepartureDate(LocalDate.now().minusDays(18))
+            withCrn(offenderDetails.otherIds.crn)
+          }
+
+          nonOverlappingBooking.cancellations += cas3CancellationEntityFactory.produceAndPersist {
+            withBooking(nonOverlappingBooking)
+            withYieldedReason {
+              cancellationReasonEntityFactory.produceAndPersist()
+            }
+          }
+
+          apDeliusContextAddResponseToUserAccessCall(
+            listOf(
+              CaseAccessFactory()
+                .withCrn(offenderDetails.otherIds.crn)
+                .produce(),
+            ),
+            user.deliusUsername,
+          )
+
+          webTestClient.post()
+            .uri("cas3/v2/bedspaces/search")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              Cas3BedspaceSearchParameters(
+                startDate = LocalDate.now(),
+                durationDays = 31,
+                probationDeliveryUnits = listOf(searchPdu.id),
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                Cas3v2BedspaceSearchResults(
+                  resultsPremisesCount = 1,
+                  resultsBedspaceCount = 2,
+                  results = listOf(
+                    createBedspaceSearchResult(
+                      premises,
+                      bedOne,
+                      pduName = searchPdu.name,
+                      numberOfBedspaces = 2,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      premises,
+                      bedTwo,
+                      pduName = searchPdu.name,
+                      numberOfBedspaces = 2,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                  ),
+                ),
+              ),
+              true,
+            )
+            .jsonPath("$.results[*].overlaps[*].bookingId").value(Matchers.not(nonOverlappingBooking.id))
+            .jsonPath("$.results[*].overlaps[*].bedspaceId").value(Matchers.not(nonOverlappingBooking.bedspace.id))
+        }
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace in a Shared Property returns only bedspaces in shared properties`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premises = createPremisesAndBedspacesWithCharacteristics(
+          localAuthorityArea,
+          searchPdu,
+        )
+
+        val expextedPremisesOne = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_ID) }
+        val expextedPremisesOneRoomOne = expextedPremisesOne.bedspaces.first()
+        val expextedPremisesOneRoomTwo = expextedPremisesOne.bedspaces.drop(1).first()
+        val expextedPremisesTwo = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_MEN_ONLY_ID) }
+        val expextedPremisesTwoRoomOne = expextedPremisesTwo.bedspaces.first()
+        val expextedPremisesThree = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_WOMEN_ONLY_ID) }
+        val expextedPremisesThreeRoomOne = expextedPremisesThree.bedspaces.first()
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(10),
+              durationDays = 84,
+              probationDeliveryUnits = listOf(searchPdu.id),
+              premisesFilters = PremisesFilters(
+                includedCharacteristicIds = listOf(getPremisesSharedPropertyCharacteristic()?.id!!),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 3,
+                resultsBedspaceCount = 4,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    expextedPremisesOne,
+                    expextedPremisesOneRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(getSharedPropertyCharacteristicPair()),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesOne,
+                    expextedPremisesOneRoomTwo,
+                    searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(getSharedPropertyCharacteristicPair()),
+                    bedspaceCharacteristics = listOf(getWheelchairAccessibleCharacteristicPair()),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesTwo,
+                    expextedPremisesTwoRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(
+                      getSharedPropertyCharacteristicPair(),
+                      getMenOnlyCharacteristicPair(),
+                    ),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesThree,
+                    expextedPremisesThreeRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(
+                      getSharedPropertyCharacteristicPair(),
+                      getWomenOnlyCharacteristicPair(),
+                    ),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+            true,
+          )
+      }
+    }
+
+    @Test
+    fun `Bedspace search filter only returns included premises filters`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val characteristicOne = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicOne")
+        }
+        val characteristicTwo = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicTwo")
+        }
+        val premisesOne = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises One",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(characteristicOne),
+        )
+        val premisesTwo = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises Two",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(characteristicTwo),
+        )
+        createBedspace(premisesOne, "Bedspace One", listOf())
+        createBedspace(premisesTwo, "Bedspace Two", listOf())
+
+        val result = getResponseForRequest(
+          jwt,
+          Cas3BedspaceSearchParameters(
+            startDate = LocalDate.now().plusDays(21),
+            durationDays = 84,
+            probationDeliveryUnits = listOf(searchPdu.id),
+            premisesFilters = PremisesFilters(
+              includedCharacteristicIds = listOf(characteristicOne.id),
+            ),
+          ),
+        )
+
+        val returnedPremisesIds = result.results.map { it.premises.id }
+
+        assertThat(returnedPremisesIds).containsExactly(premisesOne.id)
+        assertThat(returnedPremisesIds).doesNotContain(premisesTwo.id)
+      }
+    }
+
+    @Test
+    fun `Bedspace search filter does not return excluded premises filters`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val characteristicOne = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicOne")
+        }
+        val characteristicTwo = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicTwo")
+        }
+        val premisesOne = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises One",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(characteristicOne),
+        )
+
+        val premisesTwo = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises Two",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(characteristicTwo),
+        )
+
+        createBedspace(premisesOne, "Bedspace One", listOf())
+        createBedspace(premisesTwo, "Bedspace Two", listOf())
+
+        val result = getResponseForRequest(
+          jwt,
+          Cas3BedspaceSearchParameters(
+            startDate = LocalDate.now().plusDays(17),
+            durationDays = 84,
+            probationDeliveryUnits = listOf(searchPdu.id),
+            premisesFilters = PremisesFilters(
+              excludedCharacteristicIds = listOf(characteristicOne.id),
+            ),
+          ),
+        )
+
+        val returnedPremisesIds = result.results.map { it.premises.id }
+
+        assertThat(returnedPremisesIds).containsExactly(premisesTwo.id)
+        assertThat(returnedPremisesIds).doesNotContain(premisesOne.id)
+      }
+    }
+
+    @Test
+    fun `Bedspace search filter only returns included bedspace filters`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val characteristicOne = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicOne")
+        }
+        val characteristicTwo = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicTwo")
+        }
+        val premisesOne = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises One",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(),
+        )
+        val premisesOneBedOne = createBedspace(premisesOne, "Bedspace One", listOf(characteristicOne))
+        val premisesOneBedTwo = createBedspace(premisesOne, "Bedspace Two", listOf(characteristicTwo))
+
+        val result = getResponseForRequest(
+          jwt,
+          Cas3BedspaceSearchParameters(
+            startDate = LocalDate.now(),
+            durationDays = 84,
+            probationDeliveryUnits = listOf(searchPdu.id),
+            bedspaceFilters = BedspaceFilters(
+              includedCharacteristicIds = listOf(characteristicOne.id),
+            ),
+          ),
+        )
+
+        val returnedBedIds = result.results.map { it.bedspace.id }
+        assertThat(returnedBedIds).containsExactly(premisesOneBedOne.id)
+        assertThat(returnedBedIds).doesNotContain(premisesOneBedTwo.id)
+      }
+    }
+
+    @Test
+    fun `Bedspace search filter does not return excluded bedspace filters`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val characteristicOne = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicOne")
+        }
+        val characteristicTwo = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicTwo")
+        }
+        val premisesOne = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises One",
+          localAuthorityArea,
+          searchPdu,
+          characteristics = mutableListOf(
+            cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+              name("CharacteristicOne")
+            },
+          ),
+        )
+
+        val premisesOneBedOne = createBedspace(premisesOne, "Bedspace One", listOf(characteristicOne))
+        val premisesOneBedTwo = createBedspace(premisesOne, "Bedspace Two", listOf(characteristicTwo))
+        val premisesOneBedThree = createBedspace(premisesOne, "Bedspace Three", listOf(characteristicOne, characteristicTwo))
+
+        val result = getResponseForRequest(
+          jwt,
+          Cas3BedspaceSearchParameters(
+            startDate = LocalDate.now().minusDays(3),
+            durationDays = 84,
+            probationDeliveryUnits = listOf(searchPdu.id),
+            bedspaceFilters = BedspaceFilters(
+              excludedCharacteristicIds = listOf(characteristicOne.id),
+            ),
+          ),
+        )
+
+        val returnedBedIds = result.results.map { it.bedspace.id }
+        assertThat(returnedBedIds).containsExactly(premisesOneBedTwo.id)
+        assertThat(returnedBedIds).doesNotContain(premisesOneBedOne.id, premisesOneBedThree.id)
+      }
+    }
+
+    @Test
+    fun `Bedspace search filter returns correct results with multiple bedspace filters`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premisesCharacteristicOne = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicOne")
+        }
+        val premisesCharacteristicTwo = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicTwo")
+        }
+        val premisesCharacteristicThree = cas3PremisesCharacteristicEntityFactory.produceAndPersist {
+          name("CharacteristicThree")
+        }
+        val premisesOne = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises One",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(premisesCharacteristicOne),
+        )
+
+        val premisesTwo = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises Two",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(premisesCharacteristicOne, premisesCharacteristicTwo),
+        )
+
+        val premisesThree = createPremisesWithCharacteristics(
+          UUID.randomUUID(),
+          "Premises Three",
+          localAuthorityArea,
+          searchPdu,
+          mutableListOf(premisesCharacteristicOne, premisesCharacteristicTwo, premisesCharacteristicThree),
+        )
+        val roomCharacteristicOne = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicOne")
+        }
+        val roomCharacteristicTwo = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicTwo")
+        }
+        val roomCharacteristicThree = cas3BedspaceCharacteristicEntityFactory.produceAndPersist {
+          withName("CharacteristicThree")
+        }
+
+        // premises one beds
+        val premisesOneBedOne = createBedspace(premisesOne, "11", listOf(roomCharacteristicOne))
+        val premisesOneBedTwo = createBedspace(premisesOne, "12", listOf(roomCharacteristicOne, roomCharacteristicTwo))
+        createBedspace(premisesOne, "13", listOf(roomCharacteristicOne, roomCharacteristicTwo, roomCharacteristicThree))
+
+        // premises two beds
+        val premisesTwoBedOne = createBedspace(premisesTwo, "21", listOf(roomCharacteristicOne))
+        val premisesTwoBedTwo = createBedspace(premisesTwo, "22", listOf(roomCharacteristicOne, roomCharacteristicTwo))
+        createBedspace(premisesTwo, "23", listOf(roomCharacteristicOne, roomCharacteristicTwo, roomCharacteristicThree))
+
+        // premises three beds
+        createBedspace(premisesThree, "31", listOf(roomCharacteristicOne))
+        createBedspace(premisesThree, "32", listOf(roomCharacteristicOne, roomCharacteristicTwo))
+        createBedspace(premisesThree, "33", listOf(roomCharacteristicOne, roomCharacteristicTwo, roomCharacteristicThree))
+
+        val result = getResponseForRequest(
+          jwt,
+          Cas3BedspaceSearchParameters(
+            startDate = LocalDate.now().plusDays(10),
+            durationDays = 84,
+            probationDeliveryUnits = listOf(searchPdu.id),
+            bedspaceFilters = BedspaceFilters(
+              includedCharacteristicIds = listOf(roomCharacteristicOne.id),
+              excludedCharacteristicIds = listOf(roomCharacteristicThree.id),
+            ),
+            premisesFilters = PremisesFilters(
+              includedCharacteristicIds = listOf(premisesCharacteristicOne.id),
+              excludedCharacteristicIds = listOf(premisesCharacteristicThree.id),
+            ),
+          ),
+        )
+
+        // only premises one and two are returned, as both have PremisesCharacteristicOne and neither have PremisesCharacteristicThree
+        val returnedPremisesIds = result.results.map { it.premises.id }
+        assertThat(returnedPremisesIds).containsOnly(premisesOne.id, premisesTwo.id)
+        assertThat(returnedPremisesIds).doesNotContain(premisesThree.id)
+
+        // only rooms 1 and 2 should be returned, as both have RoomCharacteristicOne and neither have RoomCharacteristicThree
+        val returnedBedIds = result.results.map { it.bedspace.id }
+        assertThat(returnedBedIds).hasSize(4)
+          .containsExactlyInAnyOrder(
+            premisesOneBedOne.id,
+            premisesOneBedTwo.id,
+            premisesTwoBedOne.id,
+            premisesTwoBedTwo.id,
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace in a Single Occupancy Property returns only bedspaces in properties with single occupancy`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premises = createPremisesAndBedspacesWithCharacteristics(
+          localAuthorityArea,
+          searchPdu,
+        )
+
+        val expextedPremisesOne = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_ID) }
+        val expextedPremisesOneRoomOne = expextedPremisesOne.bedspaces.first()
+        val expextedPremisesTwo = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_MEN_ONLY_ID) }
+        val expextedPremisesTwoRoomOne = expextedPremisesTwo.bedspaces.first()
+        val expextedPremisesThree = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WHEELCHAIR_ACCESSIBILITY_ID) }
+        val expextedPremisesThreeRoomOne = expextedPremisesThree.bedspaces.first()
+        val expextedPremisesFour = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WOMEN_ONLY_ID) }
+        val expextedPremisesFourRoomOne = expextedPremisesFour.bedspaces.first()
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(2),
+              durationDays = 84,
+              probationDeliveryUnits = listOf(searchPdu.id),
+              premisesFilters = PremisesFilters(
+                includedCharacteristicIds = listOf(getPremisesSingleOccupancyCharacteristic()?.id!!),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 4,
+                resultsBedspaceCount = 4,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    expextedPremisesOne,
+                    expextedPremisesOneRoomOne,
+                    pduName = searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(getSingleOccupancyCharacteristicPair()),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesTwo,
+                    expextedPremisesTwoRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(
+                      getSingleOccupancyCharacteristicPair(),
+                      getMenOnlyCharacteristicPair(),
+                    ),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesThree,
+                    expextedPremisesThreeRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(getSingleOccupancyCharacteristicPair()),
+                    bedspaceCharacteristics = listOf(getWheelchairAccessibleCharacteristicPair()),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesFour,
+                    expextedPremisesFourRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    listOf(
+                      getWomenOnlyCharacteristicPair(),
+                      getSingleOccupancyCharacteristicPair(),
+                    ),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+            true,
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace with wheelchair accessible returns only bedspaces with wheelchair accessible`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premises = createPremisesAndBedspacesWithCharacteristics(
+          localAuthorityArea,
+          searchPdu,
+        )
+
+        val expextedPremisesOne = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_ID) }
+        val expextedPremisesOneRoomOne = expextedPremisesOne.bedspaces.drop(1).first()
+        val expextedPremisesTwo = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WHEELCHAIR_ACCESSIBILITY_ID) }
+        val expextedPremisesTwoRoomOne = expextedPremisesTwo.bedspaces.first()
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(14),
+              durationDays = 84,
+              probationDeliveryUnits = listOf(searchPdu.id),
+              bedspaceFilters = BedspaceFilters(
+                includedCharacteristicIds = listOf(getWheelchairAccessibleCharacteristic()?.id!!),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 2,
+                resultsBedspaceCount = 2,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    expextedPremisesOne,
+                    expextedPremisesOneRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(getSharedPropertyCharacteristicPair()),
+                    bedspaceCharacteristics = listOf(getWheelchairAccessibleCharacteristicPair()),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    expextedPremisesTwo,
+                    expextedPremisesTwoRoomOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(getSingleOccupancyCharacteristicPair()),
+                    bedspaceCharacteristics = listOf(getWheelchairAccessibleCharacteristicPair()),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+            true,
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for men only bedspaces returns bedspaces suitable for men`() {
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        givenSomeOffenders { offenderSequence ->
+          val offenders = offenderSequence.take(3).toList()
+
+          val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(probationRegion)
+          }
+
+          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+          val premises = createPremisesAndBedspacesWithCharacteristics(
+            localAuthorityArea,
+            searchPdu,
+          )
+
+          val expextedPremisesOne = premises.first { p -> p.id == UUID.fromString(PREMISES_MEN_ONLY_ID) }
+          val expextedPremisesOneRoomOne = expextedPremisesOne.bedspaces.first()
+          val expextedPremisesTwo = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_ID) }
+          val expextedPremisesTwoRoomOne = expextedPremisesTwo.bedspaces.first()
+          val expextedPremisesThree = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_MEN_ONLY_ID) }
+          val expextedPremisesThreeRoomOne = expextedPremisesThree.bedspaces.first()
+          val expextedPremisesFour = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_ID) }
+          val expextedPremisesFourRoomOne = expextedPremisesFour.bedspaces.first()
+          val expextedPremisesFive = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_MEN_ONLY_ID) }
+          val expextedPremisesFiveRoomOne = expextedPremisesFive.bedspaces.first()
+
+          val offenderDetailsOne = offenders.first().first
+          CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetailsOne)
+            .withGender("Male")
+            .produce()
+
+          val premisesPubNearBy = premises.first { p -> p.id == UUID.fromString(PREMISES_PUB_NEARBY_ID) }
+          val premisesPubNearByBedspaceOne = premisesPubNearBy.bedspaces.first()
+          cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withPremises(premisesPubNearBy)
+            withBedspace(premisesPubNearByBedspaceOne)
+            withArrivalDate(LocalDate.now().minusDays(20))
+            withDepartureDate(LocalDate.now().plusDays(71))
+            withCrn(offenderDetailsOne.otherIds.crn)
+          }
+
+          val offenderDetailsTwo = offenders.drop(1).first().first
+          val caseSummaryTwo = CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetailsTwo)
+            .withGender("Male")
+            .produce()
+
+          val premisesSharedProperty = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_ID) }
+          val premisesSharedPropertyRoomTwo = premisesSharedProperty.bedspaces.drop(1).first()
+          val bookingOffenderTwo = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withPremises(premisesSharedPropertyRoomTwo.premises)
+            withBedspace(premisesSharedPropertyRoomTwo)
+            withArrivalDate(LocalDate.now().minusDays(6))
+            withDepartureDate(LocalDate.now().plusDays(23))
+            withCrn(offenderDetailsTwo.otherIds.crn)
+          }
+
+          val offenderDetailsThree = offenders.drop(2).first().first
+          CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetailsThree)
+            .withGender("Female")
+            .produce()
+
+          val premisesSingleOccupancyWheelchairAccessible = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WHEELCHAIR_ACCESSIBILITY_ID) }
+          val premisesSingleOccupancyWheelchairAccessibleRoomOne = premisesSingleOccupancyWheelchairAccessible.bedspaces.first()
+          cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withPremises(premisesSingleOccupancyWheelchairAccessible)
+            withBedspace(premisesSingleOccupancyWheelchairAccessibleRoomOne)
+            withArrivalDate(LocalDate.now().minusDays(28))
+            withDepartureDate(LocalDate.now().plusDays(34))
+            withCrn(offenderDetailsThree.otherIds.crn)
+          }
+
+          apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseSummaryTwo))
+
+          webTestClient.post()
+            .uri("cas3/v2/bedspaces/search")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              Cas3BedspaceSearchParameters(
+                startDate = LocalDate.now().plusDays(4),
+                durationDays = 84,
+                probationDeliveryUnits = listOf(searchPdu.id),
+                premisesFilters = PremisesFilters(
+                  includedCharacteristicIds = listOf(getPremisesMenOnlyCharacteristic()?.id!!),
+                ),
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                Cas3v2BedspaceSearchResults(
+                  resultsPremisesCount = 5,
+                  resultsBedspaceCount = 5,
+                  results = listOf(
+                    createBedspaceSearchResult(
+                      expextedPremisesOne,
+                      expextedPremisesOneRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(getMenOnlyCharacteristicPair()),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesTwo,
+                      expextedPremisesTwoRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 2,
+                      numberOfBookedBeds = 1,
+                      premisesCharacteristics = listOf(getSharedPropertyCharacteristicPair()),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "${offenderDetailsTwo.firstName} ${offenderDetailsTwo.surname}",
+                          crn = offenderDetailsTwo.otherIds.crn,
+                          personType = PersonType.fullPerson,
+                          days = 20,
+                          bookingId = bookingOffenderTwo.id,
+                          bedspaceId = premisesSharedPropertyRoomTwo.id,
+                          isSexualRisk = false,
+                          sex = "Male",
+                          assessmentId = null,
+                        ),
+                      ),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesThree,
+                      expextedPremisesThreeRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(
+                        getMenOnlyCharacteristicPair(),
+                        getSharedPropertyCharacteristicPair(),
+                      ),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesFour,
+                      expextedPremisesFourRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(getSingleOccupancyCharacteristicPair()),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesFive,
+                      expextedPremisesFiveRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(
+                        getSingleOccupancyCharacteristicPair(),
+                        getMenOnlyCharacteristicPair(),
+                      ),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                  ),
+                ),
+              ),
+              true,
+            )
+        }
+      }
+    }
+
+    @Test
+    fun `Searching for women only bedspaces returns bedspaces suitable for women`() {
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        givenSomeOffenders { offenderSequence ->
+          val offenders = offenderSequence.take(3).toList()
+
+          val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+            withProbationRegion(probationRegion)
+          }
+
+          val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+          val premises = createPremisesAndBedspacesWithCharacteristics(
+            localAuthorityArea,
+            searchPdu,
+          )
+
+          val expextedPremisesOne = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_ID) }
+          val expextedPremisesOneRoomOne = expextedPremisesOne.bedspaces.first()
+          val expextedPremisesTwo = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_WOMEN_ONLY_ID) }
+          val expextedPremisesTwoRoomOne = expextedPremisesTwo.bedspaces.first()
+          val expextedPremisesThree = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WHEELCHAIR_ACCESSIBILITY_ID) }
+          val expextedPremisesThreeRoomOne = expextedPremisesThree.bedspaces.first()
+          val expextedPremisesFour = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WOMEN_ONLY_ID) }
+          val expextedPremisesFourRoomOne = expextedPremisesFour.bedspaces.first()
+          val expextedPremisesFive = premises.first { p -> p.id == UUID.fromString(PREMISES_WOMEN_ONLY_ID) }
+          val expextedPremisesFiveRoomOne = expextedPremisesFive.bedspaces.first()
+
+          val offenderDetailsOne = offenders.first().first
+          CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetailsOne)
+            .withGender("Male")
+            .produce()
+
+          val premisesSingleOccupancy = premises.first { p -> p.id == UUID.fromString(PREMISES_SINGLE_OCCUPANCY_ID) }
+          val premisesSingleOccupancyRoomOne = premisesSingleOccupancy.bedspaces.first()
+          cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withPremises(premisesSingleOccupancy)
+            withBedspace(premisesSingleOccupancyRoomOne)
+            withArrivalDate(LocalDate.now().minusDays(10))
+            withDepartureDate(LocalDate.now().plusDays(33))
+            withCrn(offenderDetailsOne.otherIds.crn)
+          }
+
+          val offenderDetailsTwo = offenders.drop(1).first().first
+          val caseSummaryTwo = CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetailsTwo)
+            .withGender("Female")
+            .produce()
+
+          val premisesSharedProperty = premises.first { p -> p.id == UUID.fromString(PREMISES_SHARED_PROPERTY_ID) }
+          val premisesSharedPropertyRoomTwo = premisesSharedProperty.bedspaces.drop(1).first()
+          val bookingOffenderTwo = cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withPremises(premisesSharedProperty)
+            withBedspace(premisesSharedPropertyRoomTwo)
+            withArrivalDate(LocalDate.now().minusDays(2))
+            withDepartureDate(LocalDate.now().plusDays(65))
+            withCrn(offenderDetailsTwo.otherIds.crn)
+          }
+
+          val offenderDetailsThree = offenders.drop(2).first().first
+          CaseSummaryFactory()
+            .fromOffenderDetails(offenderDetailsThree)
+            .withGender("Female")
+            .produce()
+
+          val premisesPubNearby = premises.first { p -> p.id == UUID.fromString(PREMISES_PUB_NEARBY_ID) }
+          val premisesPubNearbyRoomOne = premisesPubNearby.bedspaces.first()
+          cas3BookingEntityFactory.produceAndPersist {
+            withServiceName(ServiceName.temporaryAccommodation)
+            withPremises(premisesPubNearby)
+            withBedspace(premisesPubNearbyRoomOne)
+            withArrivalDate(LocalDate.now().minusDays(3))
+            withDepartureDate(LocalDate.now().plusDays(102))
+            withCrn(offenderDetailsThree.otherIds.crn)
+          }
+
+          apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseSummaryTwo))
+
+          webTestClient.post()
+            .uri("cas3/v2/bedspaces/search")
+            .headers(buildTemporaryAccommodationHeaders(jwt))
+            .bodyValue(
+              Cas3BedspaceSearchParameters(
+                startDate = LocalDate.now(),
+                durationDays = 84,
+                probationDeliveryUnits = listOf(searchPdu.id),
+                premisesFilters = PremisesFilters(
+                  includedCharacteristicIds = listOf(getPremisesWomenOnlyCharacteristic()?.id!!),
+                ),
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(
+              objectMapper.writeValueAsString(
+                Cas3v2BedspaceSearchResults(
+                  resultsPremisesCount = 5,
+                  resultsBedspaceCount = 5,
+                  results = listOf(
+                    createBedspaceSearchResult(
+                      expextedPremisesOne,
+                      expextedPremisesOneRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 2,
+                      numberOfBookedBeds = 1,
+                      premisesCharacteristics = listOf(getSharedPropertyCharacteristicPair()),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(
+                        Cas3v2BedspaceSearchResultOverlap(
+                          name = "${offenderDetailsTwo.firstName} ${offenderDetailsTwo.surname}",
+                          crn = offenderDetailsTwo.otherIds.crn,
+                          personType = PersonType.fullPerson,
+                          days = 66,
+                          bookingId = bookingOffenderTwo.id,
+                          bedspaceId = premisesSharedPropertyRoomTwo.id,
+                          isSexualRisk = false,
+                          sex = "Female",
+                          assessmentId = null,
+                        ),
+                      ),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesTwo,
+                      expextedPremisesTwoRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(
+                        getWomenOnlyCharacteristicPair(),
+                        getSharedPropertyCharacteristicPair(),
+                      ),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesThree,
+                      expextedPremisesThreeRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(getSingleOccupancyCharacteristicPair()),
+                      bedspaceCharacteristics = listOf(getWheelchairAccessibleCharacteristicPair()),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesFour,
+                      expextedPremisesFourRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(
+                        getSingleOccupancyCharacteristicPair(),
+                        getWomenOnlyCharacteristicPair(),
+                      ),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                    createBedspaceSearchResult(
+                      expextedPremisesFive,
+                      expextedPremisesFiveRoomOne,
+                      searchPdu.name,
+                      numberOfBedspaces = 1,
+                      numberOfBookedBeds = 0,
+                      premisesCharacteristics = listOf(getWomenOnlyCharacteristicPair()),
+                      bedspaceCharacteristics = listOf(),
+                      overlaps = listOf(),
+                    ),
+                  ),
+                ),
+              ),
+              true,
+            )
+        }
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should not return bedspace when given premises bedspace endDate is same as search start date`() {
+      givenAUser { _, jwt ->
+        val durationDays = 7L
+        val searchStartDate = LocalDate.parse("2023-03-23")
+        val searchPdu = createPremisesWithBedspaceEndDate(searchStartDate, searchStartDate)
+
+        searchCas3BedspaceAndAssertNoAvailability(jwt, searchStartDate, durationDays, searchPdu.id)
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should not return bedspace when given premises bedspace endDate is between search start date and end date`() {
+      givenAUser { _, jwt ->
+        val durationDays = 7L
+        val searchStartDate = LocalDate.parse("2023-03-23")
+        val bedEndDate = searchStartDate.plusDays(2)
+        val searchPdu = createPremisesWithBedspaceEndDate(searchStartDate, bedEndDate)
+
+        searchCas3BedspaceAndAssertNoAvailability(jwt, searchStartDate, durationDays, searchPdu.id)
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should not return bed when given premises bedspace endDate is same as search end date`() {
+      givenAUser { _, jwt ->
+        val durationDays = 7L
+        val searchStartDate = LocalDate.parse("2023-03-23")
+        val bedEndDate = searchStartDate.plusDays(durationDays.toLong() - 1)
+        val searchPdu = createPremisesWithBedspaceEndDate(searchStartDate, bedEndDate)
+
+        searchCas3BedspaceAndAssertNoAvailability(jwt, searchStartDate, durationDays, searchPdu.id)
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should not return bed when given premises bedspace endDate less than than search start date`() {
+      givenAUser { _, jwt ->
+        val durationDays = 7L
+        val searchStartDate = LocalDate.parse("2023-03-23")
+        val bedEndDate = searchStartDate.minusDays(1)
+        val searchPdu = createPremisesWithBedspaceEndDate(searchStartDate, bedEndDate)
+
+        searchCas3BedspaceAndAssertNoAvailability(jwt, searchStartDate, durationDays, searchPdu.id)
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should return single bed when given premises has got 2 rooms where one with endDate and another bedspace without end date`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val searchStartDate = LocalDate.now().plusDays(3)
+        val durationDays = 7L
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+        val premises = cas3PremisesEntityFactory.produceAndPersist {
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(searchPdu)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("not Matching Bed")
+          withEndDate(searchStartDate.plusDays(2))
+        }
+
+        val bedWithoutEndDate = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("Matching Bed")
+        }
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = searchStartDate,
+              durationDays = durationDays,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 1,
+                resultsBedspaceCount = 1,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premises,
+                    bedWithoutEndDate,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should return bed when given premises bedspace endDate after search end date`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val durationDays = 7L
+        val searchStartDate = LocalDate.now().plusDays(3)
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+        val premises = cas3PremisesEntityFactory.produceAndPersist {
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(searchPdu)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        val bed = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premises)
+          withReference("Matching Bed")
+          withEndDate(searchStartDate.plusDays(durationDays.toLong() + 2))
+        }
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = searchStartDate,
+              durationDays = durationDays,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 1,
+                resultsBedspaceCount = 1,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premises,
+                    bed,
+                    searchPdu.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should return no bed when given premises has got 2 rooms where one with endDate in the passed and another bedspace with matching end date`() {
+      givenAUser { _, jwt ->
+        val durationDays = 7L
+        val searchStartDate = LocalDate.parse("2023-03-23")
+        val bedEndDate = searchStartDate.plusDays(1)
+        val searchPdu = createPremisesWithBedspaceEndDate(searchStartDate, bedEndDate)
+
+        searchCas3BedspaceAndAssertNoAvailability(jwt, searchStartDate, durationDays, searchPdu.id)
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace should return bed matches searching pdu`() {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withName(randomStringLowerCase(8))
+        withProbationRegion(probationRegion)
+      }
+
+      val pduTwo = probationDeliveryUnitFactory.produceAndPersist {
+        withName(randomStringLowerCase(8))
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val searchStartDate = LocalDate.now().plusDays(3)
+        val durationDays = 7L
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+        val premisesOne = cas3PremisesEntityFactory.produceAndPersist {
+          withName("Premises One")
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(searchPdu)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        val bedOne = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premisesOne)
+          withReference("Bed One")
+          withEndDate(searchStartDate.plusDays(20))
+        }
+        val bedTwo = cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premisesOne)
+          withReference("Bed Two")
+        }
+        val premisesTwo = cas3PremisesEntityFactory.produceAndPersist {
+          withName("Premises Two")
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduTwo)
+          withStatus(Cas3PremisesStatus.online)
+        }
+        cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premisesTwo)
+          withReference("Bed Three")
+          withEndDate(searchStartDate.plusDays(40))
+        }
+        cas3BedspaceEntityFactory.produceAndPersist {
+          withPremises(premisesTwo)
+          withReference("Bed Four")
+        }
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = searchStartDate,
+              durationDays = durationDays,
+              probationDeliveryUnits = listOf(searchPdu.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 1,
+                resultsBedspaceCount = 2,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premisesOne,
+                    bedOne,
+                    searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    premisesOne,
+                    bedTwo,
+                    searchPdu.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+            true,
+          )
+      }
+    }
+
+    @Test
+    fun `Searching for a bedspace in multiple pdus should return bedspace matches searching pdus`() {
+      val pduOne = probationDeliveryUnitFactory.produceAndPersist {
+        withName("Probation Delivery Unit One")
+        withProbationRegion(probationRegion)
+      }
+
+      val pduTwo = probationDeliveryUnitFactory.produceAndPersist {
+        withName("Probation Delivery Unit Two")
+        withProbationRegion(probationRegion)
+      }
+
+      val pduThree = probationDeliveryUnitFactory.produceAndPersist {
+        withName("Probation Delivery Unit Three")
+        withProbationRegion(probationRegion)
+      }
+
+      givenAUser(
+        probationRegion = probationRegion,
+      ) { _, jwt ->
+        val durationDays = 7L
+        val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+
+        val premisesOne = cas3PremisesEntityFactory.produceAndPersist {
+          withName("Premises One")
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduOne)
+          withStatus(Cas3PremisesStatus.online)
+        }
+
+        val bedOnePremisesOne = createBedspace(premisesOne, "Bedspace One", listOf())
+        val bedTwoPremisesOne = createBedspace(premisesOne, "Bedspace Two", listOf())
+
+        val premisesTwo = cas3PremisesEntityFactory.produceAndPersist {
+          withName("Premises Two")
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduTwo)
+          withStatus(Cas3PremisesStatus.online)
+        }
+
+        createBedspace(premisesTwo, "Bedspace Three", listOf())
+
+        val premisesThree = cas3PremisesEntityFactory.produceAndPersist {
+          withName("Premises Three")
+          withLocalAuthorityArea(localAuthorityArea)
+          withProbationDeliveryUnit(pduThree)
+          withStatus(Cas3PremisesStatus.online)
+        }
+
+        val bedOnePremisesThree = createBedspace(premisesThree, "Bedspace Four", listOf())
+
+        webTestClient.post()
+          .uri("cas3/v2/bedspaces/search")
+          .headers(buildTemporaryAccommodationHeaders(jwt))
+          .bodyValue(
+            Cas3BedspaceSearchParameters(
+              startDate = LocalDate.now().plusDays(5),
+              durationDays = durationDays,
+              probationDeliveryUnits = listOf(pduOne.id, pduThree.id),
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            objectMapper.writeValueAsString(
+              Cas3v2BedspaceSearchResults(
+                resultsPremisesCount = 2,
+                resultsBedspaceCount = 3,
+                results = listOf(
+                  createBedspaceSearchResult(
+                    premisesOne,
+                    bedOnePremisesOne,
+                    pduOne.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    premisesOne,
+                    bedTwoPremisesOne,
+                    pduOne.name,
+                    numberOfBedspaces = 2,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                  createBedspaceSearchResult(
+                    premisesThree,
+                    bedOnePremisesThree,
+                    pduThree.name,
+                    numberOfBedspaces = 1,
+                    numberOfBookedBeds = 0,
+                    premisesCharacteristics = listOf(),
+                    bedspaceCharacteristics = listOf(),
+                    overlaps = listOf(),
+                  ),
+                ),
+              ),
+            ),
+            true,
+          )
+      }
+    }
+
+    private fun searchCas3BedspaceAndAssertNoAvailability(
+      jwt: String,
+      searchStartDate: LocalDate,
+      durationDays: Long,
+      pduId: UUID,
+    ) {
+      webTestClient.post()
+        .uri("cas3/v2/bedspaces/search")
+        .headers(buildTemporaryAccommodationHeaders(jwt))
+        .bodyValue(
+          Cas3BedspaceSearchParameters(
+            startDate = searchStartDate,
+            durationDays = durationDays,
+            probationDeliveryUnits = listOf(pduId),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          objectMapper.writeValueAsString(
+            Cas3v2BedspaceSearchResults(
+              resultsPremisesCount = 0,
+              resultsBedspaceCount = 0,
+              results = listOf(),
+            ),
+          ),
+        )
+    }
+
+    @SuppressWarnings("LongParameterList")
+    private fun createPremisesWithCharacteristics(
+      premisesId: UUID,
+      premisesName: String,
+      localAuthorityArea: LocalAuthorityAreaEntity,
+      probationDeliveryUnit: ProbationDeliveryUnitEntity,
+      characteristics: MutableList<Cas3PremisesCharacteristicEntity>,
+    ) = cas3PremisesEntityFactory.produceAndPersist {
+      withId(premisesId)
+      withName(premisesName)
+      withLocalAuthorityArea(localAuthorityArea)
+      withProbationDeliveryUnit(probationDeliveryUnit)
+      withStatus(Cas3PremisesStatus.online)
+      withCharacteristics(characteristics)
+    }
+
+    private fun createBedspace(premises: Cas3PremisesEntity, bedspaceReference: String, bedspaceCharacteristics: List<Cas3BedspaceCharacteristicEntity>): Cas3BedspacesEntity {
+      val bedspace = when {
+        bedspaceCharacteristics.isEmpty() -> {
+          cas3BedspaceEntityFactory.produceAndPersist {
+            withReference(bedspaceReference)
+            withPremises(premises)
+          }
+        }
+
+        else -> {
+          cas3BedspaceEntityFactory.produceAndPersist {
+            withReference(bedspaceReference)
+            withPremises(premises)
+            withCharacteristics(bedspaceCharacteristics.toMutableList())
+          }
+        }
+      }
+      premises.bedspaces.add(bedspace)
+      return bedspace
+    }
+
+    private fun createPremisesWithBedspaceEndDate(
+      searchStartDate: LocalDate,
+      bedEndDate: LocalDate,
+    ): ProbationDeliveryUnitEntity {
+      val searchPdu = probationDeliveryUnitFactory.produceAndPersist {
+        withProbationRegion(probationRegion)
+      }
+      val localAuthorityArea = localAuthorityEntityFactory.produceAndPersist()
+      val premises = cas3PremisesEntityFactory.produceAndPersist {
+        withLocalAuthorityArea(localAuthorityArea)
+        withProbationDeliveryUnit(searchPdu)
+        withStatus(Cas3PremisesStatus.online)
+      }
+      cas3BedspaceEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withReference("not Matching Bed")
+        withEndDate(bedEndDate)
+      }
+      cas3BedspaceEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withReference("Not Matching Bed")
+        withEndDate(searchStartDate.minusDays(5))
+      }
+      return searchPdu
+    }
+
+    @SuppressWarnings("LongParameterList")
+    private fun createBedspaceSearchResult(
+      premises: Cas3PremisesEntity,
+      bedspace: Cas3BedspacesEntity,
+      pduName: String,
+      numberOfBedspaces: Int,
+      numberOfBookedBeds: Int,
+      premisesCharacteristics: List<Cas3CharacteristicPair>,
+      bedspaceCharacteristics: List<Cas3CharacteristicPair>,
+      overlaps: List<Cas3v2BedspaceSearchResultOverlap>,
+    ) = Cas3v2BedspaceSearchResult(
+      premises = Cas3BedspaceSearchResultPremisesSummary(
+        id = premises.id,
+        name = premises.name,
+        addressLine1 = premises.addressLine1,
+        postcode = premises.postcode,
+        probationDeliveryUnitName = pduName,
+        characteristics = premisesCharacteristics,
+        addressLine2 = premises.addressLine2,
+        town = premises.town,
+        notes = premises.notes,
+        bedspaceCount = numberOfBedspaces,
+        bookedBedspaceCount = numberOfBookedBeds,
+      ),
+      bedspace = Cas3BedspaceSearchResultBedspaceSummary(
+        id = bedspace.id,
+        reference = bedspace.reference,
+        characteristics = bedspaceCharacteristics,
+      ),
+      overlaps = overlaps,
+    )
+
+    private fun createPremisesAndBedspacesWithCharacteristics(
+      localAuthorityArea: LocalAuthorityAreaEntity,
+      pdu: ProbationDeliveryUnitEntity,
+    ): List<Cas3PremisesEntity> {
+      // migrates characteristics
+      migrationJobService.runMigrationJob(MigrationJobType.updateCas3BedspaceModelData)
+
+      val premisesSingleOccupancyCharacteristic = getPremisesSingleOccupancyCharacteristic()
+      val premisesSharedPropertyCharacteristic = getPremisesSharedPropertyCharacteristic()
+      val premisesMenOnlyCharacteristic = getPremisesMenOnlyCharacteristic()
+      val premisesWomenOnlyCharacteristic = getPremisesWomenOnlyCharacteristic()
+      val premisesPubNearbyCharacteristic = getPremisesPubNearByCharacteristic()
+      val wheelchairAccessibleCharacteristic = getWheelchairAccessibleCharacteristic()
+
+      val premisesSingleOccupancy = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SINGLE_OCCUPANCY_ID),
+        "Premises Single Occupancy",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesSingleOccupancyCharacteristic!!),
+      )
+      createBedspace(premisesSingleOccupancy, "Premises Single Occupancy Bedspace", listOf())
+
+      val premisesSingleOccupancyWithWheelchairAccessible = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WHEELCHAIR_ACCESSIBILITY_ID),
+        "Premises Single Occupancy with Wheelchair Accessible",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesSingleOccupancyCharacteristic),
+      )
+      createBedspace(
+        premisesSingleOccupancyWithWheelchairAccessible,
+        "Premises Single Occupancy with Wheelchair Accessible Bedspace",
+        listOf(wheelchairAccessibleCharacteristic!!),
+      )
+
+      val premisesSharedProperty = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SHARED_PROPERTY_ID),
+        "Premises Shared Property",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesSharedPropertyCharacteristic!!),
+      )
+
+      createBedspace(premisesSharedProperty, "Premises Shared Property Bedspace", listOf())
+      createBedspace(
+        premisesSharedProperty,
+        "Premises Shared Property with Wheelchair Accessible Bedspace",
+        listOf(wheelchairAccessibleCharacteristic),
+      )
+
+      val premisesMenOnly = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_MEN_ONLY_ID),
+        "Premises Men Only",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesMenOnlyCharacteristic!!),
+      )
+      createBedspace(premisesMenOnly, "Premises Men Only Bedspace", listOf())
+
+      val premisesWomenOnly = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_WOMEN_ONLY_ID),
+        "Premises Women Only",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesWomenOnlyCharacteristic!!),
+      )
+      createBedspace(premisesWomenOnly, "Premises Women Only Bedspace", listOf())
+
+      val premisesPubNearby = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_PUB_NEARBY_ID),
+        "Premises Pub Nearby",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesPubNearbyCharacteristic!!),
+      )
+      createBedspace(premisesPubNearby, "Premises Pub Nearby Bedspace", listOf())
+
+      val premisesSingleOccupancyMenOnly = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SINGLE_OCCUPANCY_MEN_ONLY_ID),
+        "Premises Single Occupancy - Men Only",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesMenOnlyCharacteristic, premisesSingleOccupancyCharacteristic),
+      )
+      createBedspace(
+        premisesSingleOccupancyMenOnly,
+        "Premises Single Occupancy Men Only Bedspace",
+        listOf(),
+      )
+
+      val premisesSingleOccupancyWomenOnly = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SINGLE_OCCUPANCY_WOMEN_ONLY_ID),
+        "Premises Single Occupancy - Women Only",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesWomenOnlyCharacteristic, premisesSingleOccupancyCharacteristic),
+      )
+      createBedspace(
+        premisesSingleOccupancyWomenOnly,
+        "Premises Single Occupancy Women Only Bedspace",
+        listOf(),
+      )
+
+      val premisesSharedPropertyMenOnly = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SHARED_PROPERTY_MEN_ONLY_ID),
+        "Premises Shared Property - Men Only",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesMenOnlyCharacteristic, premisesSharedPropertyCharacteristic),
+      )
+      createBedspace(
+        premisesSharedPropertyMenOnly,
+        "Premises Shared Property Men Only Bedspace",
+        listOf(),
+      )
+
+      val premisesSharedPropertyWomenOnly = createPremisesWithCharacteristics(
+        UUID.fromString(PREMISES_SHARED_PROPERTY_WOMEN_ONLY_ID),
+        "Premises Shared Property - Women Only",
+        localAuthorityArea,
+        pdu,
+        mutableListOf(premisesWomenOnlyCharacteristic, premisesSharedPropertyCharacteristic),
+      )
+      createBedspace(
+        premisesSharedPropertyWomenOnly,
+        "Premises Shared Property Women Only Bedspace",
+        listOf(),
+      )
+
+      return listOf(
+        premisesSingleOccupancy,
+        premisesSingleOccupancyMenOnly,
+        premisesSingleOccupancyWomenOnly,
+        premisesSingleOccupancyWithWheelchairAccessible,
+        premisesSharedProperty,
+        premisesSharedPropertyMenOnly,
+        premisesSharedPropertyWomenOnly,
+        premisesMenOnly,
+        premisesWomenOnly,
+        premisesPubNearby,
+      )
+    }
+
+    private fun getResponseForRequest(jwt: String, searchParameters: Cas3BedspaceSearchParameters) = webTestClient.post()
+      .uri("cas3/v2/bedspaces/search")
+      .headers(buildTemporaryAccommodationHeaders(jwt))
+      .bodyValue(searchParameters)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody(Cas3v2BedspaceSearchResults::class.java)
+      .returnResult()
+      .responseBody!!
+
+    private fun createAssessment(user: UserEntity, crn: String, sexualRisk: Boolean? = null): Pair<TemporaryAccommodationApplicationEntity, AssessmentEntity> {
+      val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+        withCrn(crn)
+        withCreatedByUser(user)
+        withProbationRegion(user.probationRegion)
+        if (sexualRisk != null) {
+          withHasHistoryOfSexualOffence(sexualRisk)
+          withIsConcerningSexualBehaviour(sexualRisk)
+          withHasRegisteredSexOffender(sexualRisk)
+        }
+      }
+
+      val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
+        withApplication(application)
+      }
+
+      return Pair(application, assessment)
+    }
+
+    private fun getPremisesSingleOccupancyCharacteristic(): Cas3PremisesCharacteristicEntity? = cas3PremisesCharacteristicRepository.findByName(CAS3_PROPERTY_NAME_SINGLE_OCCUPANCY)
+    private fun getPremisesSharedPropertyCharacteristic(): Cas3PremisesCharacteristicEntity? = cas3PremisesCharacteristicRepository.findByName(CAS3_PROPERTY_NAME_SHARED_PROPERTY)
+    private fun getPremisesMenOnlyCharacteristic(): Cas3PremisesCharacteristicEntity? = cas3PremisesCharacteristicRepository.findByName(CAS3_PROPERTY_NAME_MEN_ONLY)
+    private fun getPremisesWomenOnlyCharacteristic(): Cas3PremisesCharacteristicEntity? = cas3PremisesCharacteristicRepository.findByName(CAS3_PROPERTY_NAME_WOMEN_ONLY)
+    private fun getWheelchairAccessibleCharacteristic(): Cas3BedspaceCharacteristicEntity? = cas3BedspaceCharacteristicRepository.findByName(CAS3_PROPERTY_NAME_WHEELCHAIR_ACCESSIBLE)
+    private fun getPremisesPubNearByCharacteristic(): Cas3PremisesCharacteristicEntity? = cas3PremisesCharacteristicRepository.findByName(CAS3_PROPERTY_NAME_PUB_NEAR_BY)
+
+    private fun getSharedPropertyCharacteristicPair() = Cas3CharacteristicPair(name = CAS3_PROPERTY_NAME_SHARED_PROPERTY, description = "Shared property")
+    private fun getSingleOccupancyCharacteristicPair() = Cas3CharacteristicPair(name = CAS3_PROPERTY_NAME_SINGLE_OCCUPANCY, description = "Single occupancy")
+    private fun getMenOnlyCharacteristicPair() = Cas3CharacteristicPair(name = CAS3_PROPERTY_NAME_MEN_ONLY, description = "Men only")
+    private fun getWomenOnlyCharacteristicPair() = Cas3CharacteristicPair(name = CAS3_PROPERTY_NAME_WOMEN_ONLY, description = "Women only")
+    private fun getWheelchairAccessibleCharacteristicPair() = Cas3CharacteristicPair(name = CAS3_PROPERTY_NAME_WHEELCHAIR_ACCESSIBLE, description = "Wheelchair accessible")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2VoidBedspaceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2VoidBedspaceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.go
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withConflictMessage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withNotFoundMessage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -717,6 +718,7 @@ class Cas3v2VoidBedspaceTest : Cas3IntegrationTestBase() {
     val bedspaces = cas3BedspaceEntityFactory.produceAndPersistMultiple(2) {
       withPremises(premises)
       withStartDate(LocalDate.now().minusDays(10))
+      withEndDate(LocalDate.now().randomDateAfter(6))
     }
 
     val reason = cas3VoidBedspaceReasonEntityFactory.produceAndPersist()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BedspaceSearchServiceTest.kt
@@ -1,0 +1,432 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.service.v2
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2TurnaroundEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2BookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2OverlapBookingsSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BedspaceSearchParameters
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3BedspaceSearchRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3CharacteristicNames
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3v2CandidateBedspace
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3v2CandidateBedspaceOverlap
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BedspaceSearchService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.WorkingDayService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
+import java.time.LocalDate
+import java.util.UUID
+
+class Cas3v2BedspaceSearchServiceTest {
+  private val mockCas3BedspaceSearchRepository = mockk<Cas3BedspaceSearchRepository>()
+  private val mockCharacteristicService = mockk<CharacteristicService>()
+  private val mockCas3v2BookingRepository = mockk<Cas3v2BookingRepository>()
+  private val mockWorkingDayService = mockk<WorkingDayService>()
+  private val mockProbationDeliveryUnitRepository = mockk<ProbationDeliveryUnitRepository>()
+  private val mockOffenderService = mockk<OffenderService>()
+
+  private val cas3v2BedspaceSearchService = Cas3v2BedspaceSearchService(
+    mockCas3BedspaceSearchRepository,
+    mockCas3v2BookingRepository,
+    mockProbationDeliveryUnitRepository,
+    mockCharacteristicService,
+    mockWorkingDayService,
+    mockOffenderService,
+  )
+
+  @Test
+  fun `searchBedspaces returns FieldValidationError when duration in days is less than 1`() {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val probationDeliveryUnit = ProbationDeliveryUnitEntityFactory()
+      .withName(randomStringMultiCaseWithNumbers(10))
+      .withProbationRegion(user.probationRegion)
+      .produce()
+
+    every {
+      mockProbationDeliveryUnitRepository.existsById(probationDeliveryUnit.id)
+    } returns true
+
+    val result = cas3v2BedspaceSearchService.searchBedspaces(
+      user = user,
+      Cas3BedspaceSearchParameters(
+        startDate = LocalDate.parse("2023-03-22"),
+        durationDays = 0,
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+      ),
+    )
+
+    assertThatCasResult(result).isFieldValidationError("$.durationDays", "mustBeAtLeast1")
+  }
+
+  @Test
+  fun `searchBedspaces returns FieldValidationError when number of pdus is greater than pdus limit`() {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val probationDeliveryUnitIds = ProbationDeliveryUnitEntityFactory()
+      .withName(randomStringMultiCaseWithNumbers(10))
+      .withProbationRegion(user.probationRegion)
+      .produceMany()
+      .take(7)
+      .map { it.id }
+      .toList()
+
+    val result = cas3v2BedspaceSearchService.searchBedspaces(
+      user = user,
+      Cas3BedspaceSearchParameters(
+        startDate = LocalDate.parse("2024-08-22"),
+        durationDays = 30,
+        probationDeliveryUnits = probationDeliveryUnitIds,
+      ),
+    )
+    assertThatCasResult(result).isFieldValidationError("$.probationDeliveryUnits", "maxNumberProbationDeliveryUnits")
+  }
+
+  @Test
+  fun `searchBedspaces returns FieldValidationError when a pdu does not exist`() {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val probationDeliveryUnitIds = ProbationDeliveryUnitEntityFactory()
+      .withName(randomStringMultiCaseWithNumbers(10))
+      .withProbationRegion(user.probationRegion)
+      .produceMany()
+      .take(3)
+      .map { it.id }
+      .toMutableList()
+
+    val notExistPduId = UUID.randomUUID()
+    probationDeliveryUnitIds.add(notExistPduId)
+
+    every {
+      mockProbationDeliveryUnitRepository.existsById(match { probationDeliveryUnitIds.contains(it) })
+    } returns true
+
+    every {
+      mockProbationDeliveryUnitRepository.existsById(notExistPduId)
+    } returns false
+
+    val result = cas3v2BedspaceSearchService.searchBedspaces(
+      user = user,
+      Cas3BedspaceSearchParameters(
+        startDate = LocalDate.parse("2024-08-28"),
+        durationDays = 84,
+        probationDeliveryUnits = probationDeliveryUnitIds,
+      ),
+    )
+    assertThatCasResult(result).isFieldValidationError("$.probationDeliveryUnits[3]", "doesNotExist")
+  }
+
+  @Test
+  fun `searchBedspaces returns results from repository`() {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val probationDeliveryUnit = ProbationDeliveryUnitEntityFactory()
+      .withName(randomStringMultiCaseWithNumbers(10))
+      .withProbationRegion(user.probationRegion)
+      .produce()
+
+    val caseSummary = CaseSummaryFactory()
+      .produce()
+
+    val overlapBookingsSearchResult = TestOverlapBookingsSearchResult(
+      bookingId = UUID.randomUUID(),
+      crn = caseSummary.crn,
+      arrivalDate = LocalDate.parse("2023-02-15"),
+      departureDate = LocalDate.parse("2023-03-10"),
+      premisesId = UUID.randomUUID(),
+      bedspaceId = UUID.randomUUID(),
+      assessmentId = UUID.randomUUID(),
+      sexualRisk = false,
+    )
+
+    val candidateBedspaces = listOf(
+      Cas3v2CandidateBedspace(
+        premisesId = overlapBookingsSearchResult.premisesId,
+        premisesName = "Premises Name",
+        premisesAddressLine1 = "1 Someplace",
+        premisesAddressLine2 = null,
+        premisesTown = null,
+        premisesPostcode = "LA1111A",
+        probationDeliveryUnitName = probationDeliveryUnit.name,
+        premisesCharacteristics = mutableListOf(
+          Cas3CharacteristicNames(
+            name = "bedCharacteristicPropertyName",
+            description = "Bed Characteristic Name",
+          ),
+        ),
+        premisesNotes = "Premises notes",
+        premisesBedspaceCount = 3,
+        bookedBedspaceCount = 0,
+        bedspaceId = overlapBookingsSearchResult.bedspaceId,
+        bedspaceReference = "Bedspace Ref",
+        bedspaceCharacteristics = mutableListOf(
+          Cas3CharacteristicNames(
+            name = "roomCharacteristicPropertyName",
+            description = "Bedspace Characteristic Name",
+          ),
+        ),
+        overlaps = mutableListOf(
+          Cas3v2CandidateBedspaceOverlap(
+            name = caseSummary.name.forename,
+            sex = caseSummary.gender,
+            personType = PersonType.fullPerson,
+            crn = overlapBookingsSearchResult.crn,
+            days = 7,
+            premisesId = overlapBookingsSearchResult.premisesId,
+            bedspaceId = overlapBookingsSearchResult.bedspaceId,
+            bookingId = overlapBookingsSearchResult.bookingId,
+            assessmentId = overlapBookingsSearchResult.assessmentId,
+            isSexualRisk = false,
+          ),
+        ),
+      ),
+    )
+
+    every {
+      mockCas3BedspaceSearchRepository.searchBedspaces(
+        startDate = LocalDate.parse("2023-03-22"),
+        endDate = LocalDate.parse("2023-03-28"),
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+        probationRegionId = user.probationRegion.id,
+      )
+    } returns candidateBedspaces
+
+    every { mockCas3v2BookingRepository.findClosestBookingBeforeDateForBedspaces(any(), any()) } returns listOf()
+    every { mockWorkingDayService.addWorkingDays(any(), any()) } answers { it.invocation.args[0] as LocalDate }
+    every { mockCas3v2BookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(any(), any(), any()) } returns
+      listOf(overlapBookingsSearchResult)
+    every {
+      mockProbationDeliveryUnitRepository.existsById(probationDeliveryUnit.id)
+    } returns true
+    every { mockOffenderService.getPersonSummaryInfoResults(setOf(caseSummary.crn), any()) } returns
+      listOf(PersonSummaryInfoResult.Success.Full(caseSummary.crn, caseSummary))
+
+    val result = cas3v2BedspaceSearchService.searchBedspaces(
+      user = user,
+      Cas3BedspaceSearchParameters(
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+        startDate = LocalDate.parse("2023-03-22"),
+        durationDays = 7,
+      ),
+    )
+
+    assertThatCasResult(result).isSuccess().hasValueEqualTo(candidateBedspaces)
+  }
+
+  @Test
+  fun `searchBedspaces does not return results for beds that currently have turnarounds`() {
+    val user = UserEntityFactory()
+      .withUnitTestControlProbationRegion()
+      .produce()
+
+    val probationDeliveryUnit = ProbationDeliveryUnitEntityFactory()
+      .withName(randomStringMultiCaseWithNumbers(10))
+      .withProbationRegion(user.probationRegion)
+      .produce()
+
+    val expectedResults = listOf(
+      Cas3v2CandidateBedspace(
+        premisesId = UUID.randomUUID(),
+        premisesName = "Premises Name",
+        premisesAddressLine1 = "1 Someplace",
+        premisesAddressLine2 = null,
+        premisesTown = null,
+        premisesPostcode = "LA1111A",
+        probationDeliveryUnitName = probationDeliveryUnit.name,
+        premisesCharacteristics = mutableListOf(
+          Cas3CharacteristicNames(
+            name = "bedCharacteristicPropertyName",
+            description = "Bed Characteristic Name",
+          ),
+        ),
+        premisesNotes = "Premises notes",
+        premisesBedspaceCount = 3,
+        bookedBedspaceCount = 0,
+        bedspaceId = UUID.randomUUID(),
+        bedspaceReference = "Bedspace Ref",
+        bedspaceCharacteristics = mutableListOf(
+          Cas3CharacteristicNames(
+            name = "roomCharacteristicPropertyName",
+            description = "Bedspace Characteristic Name",
+          ),
+        ),
+        overlaps = mutableListOf(),
+      ),
+    )
+
+    // This bed is in a turnaround
+    val unexpectedResults = listOf(
+      Cas3v2CandidateBedspace(
+        premisesId = UUID.randomUUID(),
+        premisesName = "Another Premises Name",
+        premisesAddressLine1 = "2 Someplace",
+        premisesAddressLine2 = null,
+        premisesTown = null,
+        premisesPostcode = "LA1111A",
+        premisesCharacteristics = mutableListOf(
+          Cas3CharacteristicNames(
+            name = "bedCharacteristicPropertyName",
+            description = "Bed Characteristic Name",
+          ),
+        ),
+        premisesNotes = "Premises notes",
+        premisesBedspaceCount = 3,
+        bookedBedspaceCount = 0,
+        bedspaceId = UUID.randomUUID(),
+        bedspaceReference = "Another Bedspace Name",
+        probationDeliveryUnitName = probationDeliveryUnit.name,
+        bedspaceCharacteristics = mutableListOf(
+          Cas3CharacteristicNames(
+            name = "roomCharacteristicPropertyName",
+            description = "Bedspace Characteristic Name",
+          ),
+        ),
+        overlaps = mutableListOf(),
+      ),
+    )
+
+    val repositorySearchResults = expectedResults + unexpectedResults
+
+    every {
+      mockProbationDeliveryUnitRepository.findByName(probationDeliveryUnit.name)
+    } returns probationDeliveryUnit
+
+    every {
+      mockCas3BedspaceSearchRepository.searchBedspaces(
+        startDate = LocalDate.parse("2023-03-22"),
+        endDate = LocalDate.parse("2023-03-28"),
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+        probationRegionId = user.probationRegion.id,
+      )
+    } returns repositorySearchResults
+
+    val expectedResultPremises = Cas3PremisesEntityFactory()
+      .withId(expectedResults[0].premisesId)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(user.probationRegion)
+          .produce(),
+      )
+      .withLocalAuthorityArea(
+        LocalAuthorityEntityFactory()
+          .produce(),
+      )
+      .produce()
+
+    val expectedResultBed = Cas3BedspaceEntityFactory()
+      .withPremises(expectedResultPremises)
+      .withId(expectedResults[0].bedspaceId)
+      .produce()
+
+    val expectedResultBooking = Cas3BookingEntityFactory()
+      .withArrivalDate(LocalDate.parse("2022-12-19"))
+      .withDepartureDate(LocalDate.parse("2023-03-19"))
+      .withPremises(expectedResultPremises)
+      .withBedspace(expectedResultBed)
+      .produce()
+
+    val expectedTurnaround = Cas3v2TurnaroundEntityFactory()
+      .withBooking(expectedResultBooking)
+      .withWorkingDayCount(2)
+      .produce()
+
+    expectedResultBooking.turnarounds = mutableListOf(expectedTurnaround)
+
+    val unexpectedResultPremises = Cas3PremisesEntityFactory()
+      .withId(unexpectedResults[0].premisesId)
+      .withProbationDeliveryUnit(
+        ProbationDeliveryUnitEntityFactory()
+          .withProbationRegion(user.probationRegion)
+          .produce(),
+      )
+      .withLocalAuthorityArea(
+        LocalAuthorityEntityFactory()
+          .produce(),
+      )
+      .produce()
+
+    val unexpectedResultBed = Cas3BedspaceEntityFactory()
+      .withPremises(unexpectedResultPremises)
+      .withId(unexpectedResults[0].bedspaceId)
+      .produce()
+
+    val unexpectedResultBooking = Cas3BookingEntityFactory()
+      .withArrivalDate(LocalDate.parse("2022-12-20"))
+      .withDepartureDate(LocalDate.parse("2023-03-20"))
+      .withPremises(unexpectedResultPremises)
+      .withBedspace(unexpectedResultBed)
+      .produce()
+
+    val unexpectedTurnaround = Cas3v2TurnaroundEntityFactory()
+      .withBooking(unexpectedResultBooking)
+      .withWorkingDayCount(2)
+      .produce()
+
+    unexpectedResultBooking.turnarounds = mutableListOf(unexpectedTurnaround)
+
+    every {
+      mockCas3v2BookingRepository.findClosestBookingBeforeDateForBedspaces(
+        date = any(),
+        bedIds = any(),
+      )
+    } returns listOf(
+      expectedResultBooking,
+      unexpectedResultBooking,
+    )
+
+    every { mockWorkingDayService.addWorkingDays(any(), any()) } answers {
+      (it.invocation.args[0] as LocalDate).plusDays((it.invocation.args[1] as Int).toLong())
+    }
+
+    every { mockCas3v2BookingRepository.findAllNotCancelledByPremisesIdsAndOverlappingDate(any(), any(), any()) } returns listOf()
+
+    every { mockOffenderService.getPersonSummaryInfoResults(any(), any()) } returns listOf()
+
+    every {
+      mockProbationDeliveryUnitRepository.existsById(probationDeliveryUnit.id)
+    } returns true
+
+    val result = cas3v2BedspaceSearchService.searchBedspaces(
+      user = user,
+      Cas3BedspaceSearchParameters(
+        startDate = LocalDate.parse("2023-03-22"),
+        durationDays = 7,
+        probationDeliveryUnits = listOf(probationDeliveryUnit.id),
+      ),
+    )
+    assertThatCasResult(result).isSuccess().hasValueEqualTo(expectedResults)
+  }
+
+  @Suppress("LongParameterList")
+  class TestOverlapBookingsSearchResult(
+    override val bookingId: UUID,
+    override val crn: String,
+    override val arrivalDate: LocalDate,
+    override val departureDate: LocalDate,
+    override val premisesId: UUID,
+    override val bedspaceId: UUID,
+    override val assessmentId: UUID,
+    override val sexualRisk: Boolean,
+  ) : Cas3v2OverlapBookingsSearchResult
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -305,7 +305,7 @@ import java.util.UUID
 @Tag("integration")
 abstract class IntegrationTestBase {
   @Autowired
-  private lateinit var cas3BedspaceCharacteristicRepository: Cas3BedspaceCharacteristicRepository
+  lateinit var cas3BedspaceCharacteristicRepository: Cas3BedspaceCharacteristicRepository
 
   @Autowired
   private lateinit var cas3PemisesCharacteristicRepository: Cas3PremisesCharacteristicRepository
@@ -501,6 +501,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var characteristicRepository: CharacteristicRepository
+
+  @Autowired
+  lateinit var cas3PremisesCharacteristicRepository: Cas3PremisesCharacteristicRepository
 
   @Autowired
   lateinit var roomRepository: RoomRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CharacteristicServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/CharacteristicServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesCharacteristicRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
@@ -19,7 +20,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.CharacteristicSe
 class CharacteristicServiceTest {
   private val characteristicRepository = mockk<CharacteristicRepository>()
   private val bedspaceCharacteristicRepository = mockk<Cas3BedspaceCharacteristicRepository>()
-  private val characteristicService = CharacteristicService(characteristicRepository, bedspaceCharacteristicRepository)
+  private val premisesCharacteristicRepository = mockk<Cas3PremisesCharacteristicRepository>()
+  private val characteristicService = CharacteristicService(characteristicRepository, bedspaceCharacteristicRepository, premisesCharacteristicRepository)
 
   @Test
   fun `serviceScopeMatches returns false if the characteristic has the wrong service scope`() {


### PR DESCRIPTION
**New endpoint delivered**

<img width="2048" height="1152" alt="Screenshot 2025-10-07 at 17 09 56 (2)" src="https://github.com/user-attachments/assets/9f0275de-201a-40bf-8a8f-ba93d8047ee4" />

**Background**

Latest PR in a larger piece of work delivering new `CAS3` versions of pre-existing endpoints in the API. The reasons we are doing this are:
1. To deliver endpoint separation for all `CAS3` endpoints (in the `Bedspace model refactor` area)
2. To deliver service separation for all `CAS3` services (in the `Bedspace model refactor` area)
3. To deliver data model separation so we end yup with distinct `CAS3` tables (in the`Bedspace model refactor` area)

Here is the new data model:

![new premises tables with cas3 void bedspace](https://github.com/user-attachments/assets/518b4962-5394-4bd3-936f-08ce2a49280a)

**PR includes**
1. Delivery of the new `POST /cas3/v2/bedspaces/search`
2. This endpoint was modelled on the `POST /cas3/bedspaces/search` and so all functionality / integration tests and unit tests have been ported over and refactored to use the new data models
