### PR TITLE
FM-270 update premises email address seed job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SeedFileType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SeedFileType.kt
@@ -35,6 +35,7 @@ enum class SeedFileType(@get:JsonValue val value: String) {
   approvedPremisesUpdateApplicationContactDetails("approved_premises_update_application_contact_details"),
   approvedPremisesUpdatePremisesStatus("approved_premises_update_premises_status"),
   approvedPremisesRemovePlacementNonArrivalData("approved_premises_remove_placement_non_arrival_data"),
+  approvedPremisesUpdatePremisesEmail("approved_premises_update_premises_email"),
   temporaryAccommodationReferralRejection("temporary_accommodation_referral_rejection"),
   approvedPremisesRemapBedCodes("approved_premises_remap_bed_codes"),
   shortTermAccommodationCreateOmus("short_term_accommodation_create_omus"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1UpdatePremisesEmailSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1UpdatePremisesEmailSeedJob.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedColumns
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedException
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import java.util.UUID
+
+@Component
+class Cas1UpdatePremisesEmailSeedJob(
+  private val approvedPremisesRepository: ApprovedPremisesRepository,
+) : SeedJob<PremisesEmailSeedRow>(
+  requiredHeaders = setOf(
+    "premises_id",
+    "email_address",
+  ),
+) {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>): PremisesEmailSeedRow {
+    val seedColumns = SeedColumns(columns)
+    return PremisesEmailSeedRow(
+      premisesId = seedColumns.getUuidOrNull("premises_id")!!,
+      emailAddress = seedColumns.getStringOrNull("email_address")!!,
+    )
+  }
+
+  override fun processRow(row: PremisesEmailSeedRow) {
+    val premisesId = row.premisesId
+    val emailAddress = row.emailAddress
+
+    log.info("Updating email address for premises id $premisesId")
+    val premises = approvedPremisesRepository.findByIdOrNull(premisesId)
+      ?: throw SeedException("Premises not found for premises ID $premisesId")
+
+    premises.emailAddress = emailAddress
+    approvedPremisesRepository.save(premises)
+
+    log.info("Successfully updated premises email address for premises id $premisesId")
+  }
+}
+
+data class PremisesEmailSeedRow(val premisesId: UUID, val emailAddress: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1SoftDelete
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdateActualArrivalDateSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdateApplicationContactDetailsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdateEventNumberSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdatePremisesEmailSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdatePremisesStatusSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdateSpaceBookingSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UsersSeedJob
@@ -104,6 +105,7 @@ class SeedService(
         SeedFileType.approvedPremisesUpdateApplicationContactDetails -> getBean(Cas1UpdateApplicationContactDetailsSeedJob::class)
         SeedFileType.approvedPremisesUpdatePremisesStatus -> getBean(Cas1UpdatePremisesStatusSeedJob::class)
         SeedFileType.approvedPremisesRemovePlacementNonArrivalData -> getBean(Cas1NonArrivalPlacementDataFixSeedJob::class)
+        SeedFileType.approvedPremisesUpdatePremisesEmail -> getBean(Cas1UpdatePremisesEmailSeedJob::class)
         SeedFileType.shortTermAccommodationCreateOmus -> getBean(ShortTermAccommodationCreateOmusSeedJob::class)
         SeedFileType.temporaryAccommodationAssignApplicationToPdu -> getBean(Cas3AssignApplicationToPduSeedJob::class)
         SeedFileType.Cas2UpdateNomisUserEmailAddress -> getBean(Cas2NomisUserEmailSeedJob::class)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/Cas1UpdatePremisesEmailSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/seed/Cas1UpdatePremisesEmailSeedJobTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class Cas1UpdatePremisesEmailSeedJobTest : SeedTestBase() {
+
+  @Test
+  fun `Returns success when email address is updated for a valid premises`() {
+    val premises1 = givenAnApprovedPremises(emailAddress = "premises1@example.com")
+    val premises2 = givenAnApprovedPremises(emailAddress = "premises2before@example.com")
+    val premises3 = givenAnApprovedPremises(emailAddress = "premises3before@example.com")
+
+    seed(
+      SeedFileType.approvedPremisesUpdatePremisesEmail,
+      rowsToCsv(
+        listOf(
+          PremisesEmailSeedRow(
+            premisesId = premises2.id,
+            emailAddress = "premises2after@example.com",
+          ),
+          PremisesEmailSeedRow(
+            premisesId = premises3.id,
+            emailAddress = "premises3after@example.com",
+          ),
+        ),
+      ),
+    )
+
+    val premises1After = approvedPremisesRepository.findByQCode(premises1.qCode)
+    assertThat(premises1After!!.emailAddress).isEqualTo("premises1@example.com")
+
+    val premises2After = approvedPremisesRepository.findByQCode(premises2.qCode)
+    assertThat(premises2After!!.emailAddress).isEqualTo("premises2after@example.com")
+
+    val premises3After = approvedPremisesRepository.findByQCode(premises3.qCode)
+    assertThat(premises3After!!.emailAddress).isEqualTo("premises3after@example.com")
+  }
+
+  @Test
+  fun `Returns failure when email address is updated for a premises which doesn't exist`() {
+    val randomUUID = UUID.randomUUID()
+
+    seed(
+      SeedFileType.approvedPremisesUpdatePremisesEmail,
+      rowsToCsv(
+        listOf(
+          PremisesEmailSeedRow(
+            premisesId = randomUUID,
+            emailAddress = "after@example.com",
+          ),
+        ),
+      ),
+    )
+    assertError(1, "Premises not found for premises ID $randomUUID")
+  }
+
+  private fun rowsToCsv(rows: List<PremisesEmailSeedRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "premises_id",
+        "email_address",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.premisesId.toString())
+        .withQuotedField(it.emailAddress)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+
+  data class PremisesEmailSeedRow(val premisesId: UUID, val emailAddress: String)
+}


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-270

**User Story**

As a developer

I want a seed job that allows me to set/update an AP email address for a premises

So that I can set or change an email address for a premises once it has been created

**Background**

Running the site survey job to add a premises for the first time creates a blank entry in the email field of the premises table.  To update this we have previously ran SQL to add the email address manually.  However since we have had another request to add a new premises, we should bring this work for FM-270 into scope and create a seed job to update the premises email address.
 
If [FM-269](https://dsdmoj.atlassian.net/browse/FM-269) could have been done, this would have prevented having to create this seed job.  However FM-269 requires that the structure of the site survey data is updated which is currently outside scope.

An alternative to this seed job is to make the change using SQL which was previously done for https://dsdmoj.atlassian.net/browse/FM-268, however the seed job is preferred.

[FM-269]: https://dsdmoj.atlassian.net/browse/FM-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ