### PR TITLE
Migration to rename PSS referall rejection reason

### DIFF
--- a/src/main/resources/db/migration/all/20260429162730__c3_rename_pss_rejection_reason.sql
+++ b/src/main/resources/db/migration/all/20260429162730__c3_rename_pss_rejection_reason.sql
@@ -1,0 +1,3 @@
+UPDATE referral_rejection_reasons
+SET name = 'Not enough time on their licence'
+WHERE id = '88c3b8d5-77c8-4c52-84f0-ec9073e4df50';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -931,7 +931,7 @@ class ReferenceDataTest : IntegrationTestBase() {
       {"id":"155ee6dc-ac2a-40d2-a350-90b63fb34a06","name":"No bedspace available in PDU","isActive":true},
       {"id":"21b8569c-ef2e-4059-8676-323098d16aa5","name":"No recourse to public funds (NRPF)","isActive":true},
       {"id":"f47ac10b-58cc-4372-a567-0e02b2c3d474","name":"Not eligible (e.g. already released into the community, HDC)","isActive":true},
-      {"id":"88c3b8d5-77c8-4c52-84f0-ec9073e4df50","name":"Not enough time on their licence or post-sentence supervision (PSS)","isActive":true},
+      {"id":"88c3b8d5-77c8-4c52-84f0-ec9073e4df50","name":"Not enough time on their licence","isActive":true},
       {"id":"a1c7d402-77b5-4335-a67b-eba6a71c70bf","name":"Not enough time to place","isActive":true},
       {"id":"f47ac10b-58cc-4372-a567-0e02b2c3d475","name":"Other alternative accommodation provided (e.g. friends or family)","isActive":true},
       {"id":"f47ac10b-58cc-4372-a567-0e02b2c3d476","name":"Out of region referral","isActive":true},


### PR DESCRIPTION
### This PR should be merged on 30th April 2026

Based on ticket [FM-373](https://dsdmoj.atlassian.net/browse/FM-373)

Added a migration to rename `There was not enough time on their licence or post-sentence supervision (PSS)` to `Not enough time on their licence`.

I tried to do a temporary rename in the CAS3 UI, but after rejecting an assessment the old name was appearing in the assessment summary.

[FM-373]: https://dsdmoj.atlassian.net/browse/FM-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ