### PR TITLE
Chore: Ensure generate type job passes pull-requests: write permission

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,6 +50,7 @@ jobs:
   ui_generate_types:
     permissions:
       contents: read
+      pull-requests: write
     needs: e2e
     name: Run the generate types job for all the CAS UIs
     uses: ./.github/workflows/generate-ui-types.yml


### PR DESCRIPTION
Should fix nested workflow permission error: https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/24459627897