### PR TITLE
Update Swagger UI version to 5.32.1 in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -145,8 +145,8 @@ spring:
 
 springdoc:
   swagger-ui:
-    # advised by https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/7.x.md (7.1.4)
-    version: 5.20.0
+    # advised by 19a83d1b-f255-4d27-a00f-89d20c4c592c (10.0.6)
+    version: 5.32.1
     urls-primary-name: "All CAS"
   remove-broken-reference-definitions: false
   writer-with-order-by-keys: true


### PR DESCRIPTION
Upgrading Swagger UI from 5.20.0 to 5.32.1 in preparation for upgrading the Gradle Spring Boot plugin and to resolve vulnerabilities [CVE-2026-0540](https://nvd.nist.gov/vuln/detail/CVE-2026-0540) and [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599).

See: https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/10.x.md#1006 which says that swagger ui can be pinned to 5.32.1 for HMPPS Gradle Spring Boot Plugin version 10.0.6.  We're currently on version 9.1.2 but looking to upgrade to 10.0.6.