### PR TITLE
Update Swagger UI version to 5.32.1 in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -145,8 +145,8 @@ spring:
 
 springdoc:
   swagger-ui:
-    # advised by https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/7.x.md (7.1.4)
-    version: 5.20.0
+    # advised by https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/10.x.md#pin-swagger-ui-to-latest-version-5321 (10.0.6)
+    version: 5.32.1
     urls-primary-name: "All CAS"
   remove-broken-reference-definitions: false
   writer-with-order-by-keys: true


### PR DESCRIPTION
Upgrades Swagger UI dependency from `5.20.0` to `5.32.1`.

We are planning to upgrade the HMPPS Gradle Spring Boot Plugin from version `9.1.2` to `10.1.2` and current guidelines for version `10.0.6` are to pin the Swagger UI library in `application.yml` to `5.32.1`.  See [here](https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/10.x.md#1006).

Doing this should also address vulnerabilities [CVE-2026-0540](https://nvd.nist.gov/vuln/detail/CVE-2026-0540) and [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599).