### PR TITLE
FM-495: Use spring problem

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
 
-  implementation("org.zalando:problem-spring-web-starter:0.29.1")
-
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.zalando.problem.AbstractThrowableProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationNote
@@ -129,7 +128,7 @@ class Cas2AssessmentsController(
     is AuthorisableActionResult.Success -> result.entity
   }
 
-  private fun throwProblem(problem: AbstractThrowableProblem): Unit = throw problem
+  private fun throwProblem(problem: RuntimeException): Unit = throw problem
 
   private fun <EntityType : Any> processValidation(validationResult: ValidatableActionResult<EntityType>): Any = when (validationResult) {
     is ValidatableActionResult.GeneralValidationError -> throwProblem(BadRequestProblem(errorDetail = validationResult.message))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
@@ -123,17 +123,15 @@ class Cas2AssessmentsController(
     assessmentId: UUID,
     result: AuthorisableActionResult<ValidatableActionResult<EntityType>>,
   ): Any = when (result) {
-    is AuthorisableActionResult.NotFound -> throwProblem(NotFoundProblem(assessmentId, "Cas2Application"))
-    is AuthorisableActionResult.Unauthorised -> throwProblem(ForbiddenProblem())
+    is AuthorisableActionResult.NotFound -> throw(NotFoundProblem(assessmentId, "Cas2Application"))
+    is AuthorisableActionResult.Unauthorised -> throw(ForbiddenProblem())
     is AuthorisableActionResult.Success -> result.entity
   }
 
-  private fun throwProblem(problem: RuntimeException): Unit = throw problem
-
   private fun <EntityType : Any> processValidation(validationResult: ValidatableActionResult<EntityType>): Any = when (validationResult) {
-    is ValidatableActionResult.GeneralValidationError -> throwProblem(BadRequestProblem(errorDetail = validationResult.message))
-    is ValidatableActionResult.FieldValidationError -> throwProblem(BadRequestProblem(invalidParams = validationResult.validationMessages.mapValues { ParamDetails(it.value) }))
-    is ValidatableActionResult.ConflictError -> throwProblem(ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message))
+    is ValidatableActionResult.GeneralValidationError -> throw(BadRequestProblem(errorDetail = validationResult.message))
+    is ValidatableActionResult.FieldValidationError -> throw(BadRequestProblem(invalidParams = validationResult.validationMessages.mapValues { ParamDetails(it.value) }))
+    is ValidatableActionResult.ConflictError -> throw(ConflictProblem(id = validationResult.conflictingEntityId, conflictReason = validationResult.message))
     is ValidatableActionResult.Success -> validationResult.entity
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ApiProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ApiProblem.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import org.springframework.http.ProblemDetail
+
+abstract class ApiProblem(override val message: String) : RuntimeException(message) {
+  abstract fun toProblemDetail(): ProblemDetail?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
@@ -1,31 +1,33 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
 class BadRequestProblem(
   @JsonIgnore val invalidParams: Map<String, ParamDetails>? = null,
   @JsonIgnore val errorDetail: String? = null,
-) : AbstractThrowableProblem(null, "Bad Request", Status.BAD_REQUEST, errorDetail ?: "There is a problem with your request") {
-  override fun getCause(): Exceptional? = null
+) : RuntimeException(listOfNotNull("Bad Request", errorDetail, invalidParams).joinToString(": ")) {
 
-  override val message: String
-    get() = listOfNotNull(this.title, this.detail, this.invalidParams).joinToString(": ")
-
-  override fun getParameters(): MutableMap<String, Any> = mutableMapOf(
-    "invalid-params" to (
-      invalidParams?.map {
-        ParamError(
-          propertyName = it.key,
-          errorType = it.value.errorType,
-          entityId = it.value.entityId,
-          value = it.value.value,
-        )
-      } ?: emptyList()
-      ),
-  )
+  fun toProblemDetail(): ProblemDetail {
+    val detail = errorDetail ?: "There is a problem with your request"
+    val problemDetail = FlattenedProblemDetail(HttpStatus.BAD_REQUEST, detail)
+    problemDetail.title = "Bad Request"
+    if (invalidParams != null) {
+      problemDetail.setProperty(
+        "invalid-params",
+        invalidParams.map {
+          ParamError(
+            propertyName = it.key,
+            errorType = it.value.errorType,
+            entityId = it.value.entityId,
+            value = it.value.value,
+          )
+        },
+      )
+    }
+    return problemDetail
+  }
 }
 
 data class ParamDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
@@ -11,7 +11,20 @@ class BadRequestProblem(
 
   override fun toProblemDetail(): ProblemDetail {
     val detail = errorDetail ?: "There is a problem with your request"
-    val problemDetail = FlattenedProblemDetail(HttpStatus.BAD_REQUEST, detail)
+    val problemDetail = InvalidParamsProblemDetail(
+      HttpStatus.BAD_REQUEST,
+      detail,
+      invalidParams?.flatMap { (field, paramDetails) ->
+        listOf(
+          ParamError(
+            propertyName = field,
+            errorType = paramDetails.errorType,
+            entityId = paramDetails.entityId,
+            value = paramDetails.value,
+          ),
+        )
+      },
+    )
     problemDetail.title = "Bad Request"
     if (invalidParams != null) {
       problemDetail.setProperty(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/BadRequestProblem.kt
@@ -7,9 +7,9 @@ import org.springframework.http.ProblemDetail
 class BadRequestProblem(
   @JsonIgnore val invalidParams: Map<String, ParamDetails>? = null,
   @JsonIgnore val errorDetail: String? = null,
-) : RuntimeException(listOfNotNull("Bad Request", errorDetail, invalidParams).joinToString(": ")) {
+) : ApiProblem(listOfNotNull("Bad Request", errorDetail, invalidParams).joinToString(": ")) {
 
-  fun toProblemDetail(): ProblemDetail {
+  override fun toProblemDetail(): ProblemDetail {
     val detail = errorDetail ?: "There is a problem with your request"
     val problemDetail = FlattenedProblemDetail(HttpStatus.BAD_REQUEST, detail)
     problemDetail.title = "Bad Request"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class ConflictProblem(id: Any, conflictReason: String) : AbstractThrowableProblem(null, "Conflict", Status.CONFLICT, "$conflictReason: $id") {
-  override fun getCause(): Exceptional? = null
+class ConflictProblem(id: Any, conflictReason: String) : RuntimeException("$conflictReason: $id") {
+
+  val msg = "$conflictReason: $id"
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, message ?: msg).apply {
+    title = "Conflict"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ConflictProblem.kt
@@ -3,11 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class ConflictProblem(id: Any, conflictReason: String) : RuntimeException("$conflictReason: $id") {
+class ConflictProblem(id: Any, conflictReason: String) : ApiProblem("$conflictReason: $id") {
 
-  val msg = "$conflictReason: $id"
-
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, message ?: msg).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, message).apply {
     title = "Conflict"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -204,13 +204,21 @@ class ExceptionHandling(
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).contentType(APPLICATION_PROBLEM_JSON).body(problem.toProblemDetail())
   }
 
+  @ExceptionHandler(UnauthenticatedProblem::class)
+  fun handleUnauthenticatedProblemException(ex: UnauthenticatedProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).contentType(APPLICATION_PROBLEM_JSON).body(
+      UnauthenticatedProblem().toProblemDetail(),
+    )
+  }
+
   @ExceptionHandler(Throwable::class)
   fun handleGenericException(ex: Throwable): ResponseEntity<ProblemDetail> {
     sentryService.captureException(ex)
     // Check if JDBCConnectionException is in the cause chain
     if (isTypeInThrowableChain(ex, JDBCConnectionException::class.java)) {
       val problem = ServiceUnavailableProblem(detail = "Error acquiring a database connection")
-      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(problem.toProblemDetail())
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).contentType(APPLICATION_PROBLEM_JSON).body(problem.toProblemDetail())
     }
 
     log.error("Unhandled exception type, returning generic 500 response", ex)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import org.hibernate.exception.JDBCConnectionException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON
+import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
@@ -15,100 +17,90 @@ import org.springframework.security.authentication.AuthenticationCredentialsNotF
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import org.springframework.web.util.ContentCachingRequestWrapper
-import org.zalando.problem.Problem
-import org.zalando.problem.Status
-import org.zalando.problem.StatusType
-import org.zalando.problem.ThrowableProblem
-import org.zalando.problem.spring.web.advice.ProblemHandling
-import org.zalando.problem.spring.web.advice.io.MessageNotReadableAdviceTrait
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DeserializationValidationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isTypeInThrowableChain
 
 @ControllerAdvice
+@Suppress("TooManyFunctions")
 class ExceptionHandling(
   private val jsonMapper: JsonMapper,
   private val deserializationValidationService: DeserializationValidationService,
   private val sentryService: SentryService,
-) : ProblemHandling,
-  MessageNotReadableAdviceTrait {
+) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun toProblem(throwable: Throwable, status: StatusType): ThrowableProblem? {
-    sentryService.captureException(throwable)
-
-    if (throwable is AuthenticationCredentialsNotFoundException) {
-      return UnauthenticatedProblem()
-    }
-
-    if (throwable is AccessDeniedException) {
-      return ForbiddenProblem()
-    }
-
-    if (throwable is NoResourceFoundException) {
-      return NotFoundResourceProblem()
-    }
-
-    if (throwable is MissingRequestHeaderException) {
-      return BadRequestProblem(
-        errorDetail = "Missing required header ${throwable.headerName}",
-      )
-    }
-
-    if (throwable is MissingServletRequestParameterException) {
-      return BadRequestProblem(
-        errorDetail = "Missing required query parameter ${throwable.parameterName}",
-      )
-    }
-
-    if (throwable is MethodArgumentTypeMismatchException) {
-      return BadRequestProblem(
-        errorDetail = "Invalid type for query parameter ${throwable.parameter.parameterName} expected ${throwable.parameter.parameterType.name}",
-      )
-    }
-
-    if (isTypeInThrowableChain(throwable, JDBCConnectionException::class.java)) {
-      return ServiceUnavailableProblem(
-        detail = "Error acquiring a database connection",
-      )
-    }
-
-    log.error("Unhandled exception type, returning generic 500 response", throwable)
-
-    // We throw this instead of an InternalServerErrorProblem to avoid the Sentry Alert
-    // being raised again by [ExceptionHandling.logInternalServerErrorProblem]
-    return UnhandledExceptionProblem(
-      detail = "There was an unexpected problem",
-    )
+  @ExceptionHandler(AuthenticationCredentialsNotFoundException::class)
+  fun handleAuthenticationCredentialsNotFoundException(ex: AuthenticationCredentialsNotFoundException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).contentType(APPLICATION_PROBLEM_JSON).body(UnauthenticatedProblem().toProblemDetail())
   }
 
-  override fun handleMessageNotReadableException(
+  @ExceptionHandler(AccessDeniedException::class)
+  fun handleAccessDeniedException(ex: AccessDeniedException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).contentType(APPLICATION_PROBLEM_JSON).body(ForbiddenProblem().toProblemDetail())
+  }
+
+  @ExceptionHandler(NoResourceFoundException::class)
+  fun handleNoResourceFoundException(ex: NoResourceFoundException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(APPLICATION_PROBLEM_JSON).body(NotFoundResourceProblem().toProblemDetail())
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException::class)
+  fun handleMissingRequestHeaderException(ex: MissingRequestHeaderException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    val problem = BadRequestProblem(errorDetail = "Missing required header ${ex.headerName}")
+    logBadRequestProblem(problem)
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(problem.toProblemDetail())
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException::class)
+  fun handleMissingServletRequestParameterException(ex: MissingServletRequestParameterException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    val problem = BadRequestProblem(errorDetail = "Missing required query parameter ${ex.parameterName}")
+    logBadRequestProblem(problem)
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(problem.toProblemDetail())
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+  fun handleMethodArgumentTypeMismatchException(ex: MethodArgumentTypeMismatchException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    val problem = BadRequestProblem(
+      errorDetail = "Invalid type for query parameter ${ex.parameter.parameterName} expected ${ex.parameter.parameterType.name}",
+    )
+    logBadRequestProblem(problem)
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(problem.toProblemDetail())
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException::class)
+  fun handleMessageNotReadableException(
     exception: HttpMessageNotReadableException,
     request: NativeWebRequest,
-  ): ResponseEntity<Problem> {
-    val responseBuilder = Problem.builder()
-      .withStatus(Status.BAD_REQUEST)
-      .withTitle("Bad Request")
-
+  ): ResponseEntity<ProblemDetail> {
     when (exception.cause) {
       is MismatchedInputException -> {
         val mismatchedInputException = exception.cause as MismatchedInputException
 
         val requestBody = request.getNativeRequest(ContentCachingRequestWrapper::class.java)
-        val jsonTree = jsonMapper.readTree(String(requestBody.contentAsByteArray))
+        val jsonTree = jsonMapper.readTree(String(requestBody!!.contentAsByteArray))
 
         if (expectedArrayButGotObject(jsonTree, mismatchedInputException)) {
-          responseBuilder.withDetail("Expected an array but got an object")
-          return ResponseEntity<Problem>(responseBuilder.build(), HttpStatus.BAD_REQUEST)
+          val problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Expected an array but got an object")
+          problemDetail.title = "Bad Request"
+          return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(problemDetail)
         }
 
         if (expectedObjectButGotArray(jsonTree, mismatchedInputException)) {
-          responseBuilder.withDetail("Expected an object but got an array")
-          return ResponseEntity<Problem>(responseBuilder.build(), HttpStatus.BAD_REQUEST)
+          val problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Expected an object but got an array")
+          problemDetail.title = "Bad Request"
+          return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(problemDetail)
         }
 
         val badRequestProblem = if (rootIsArray(mismatchedInputException)) {
@@ -133,13 +125,96 @@ class ExceptionHandling(
 
         logBadRequestProblem(badRequestProblem)
 
-        return ResponseEntity(badRequestProblem, HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(badRequestProblem.toProblemDetail())
       }
-      else ->
-        responseBuilder.withDetail(exception.message)
+      else -> {
+        val problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.message ?: "Bad Request")
+        problemDetail.title = "Bad Request"
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(problemDetail)
+      }
+    }
+  }
+
+  @ExceptionHandler(BadRequestProblem::class)
+  fun handleBadRequestProblem(ex: BadRequestProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    logBadRequestProblem(ex)
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(NotFoundProblem::class)
+  fun handleNotFoundProblem(ex: NotFoundProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(ForbiddenProblem::class)
+  fun handleForbiddenProblem(ex: ForbiddenProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(ConflictProblem::class)
+  fun handleConflictProblem(ex: ConflictProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.CONFLICT).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(NotAllowedProblem::class)
+  fun handleNotAllowedProblem(ex: NotAllowedProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(NotFoundResourceProblem::class)
+  fun handleNotFoundResourceProblem(ex: NotFoundResourceProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(ServiceUnavailableProblem::class)
+  fun handleServiceUnavailableProblem(ex: ServiceUnavailableProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(NotImplementedProblem::class)
+  fun handleNotImplementedProblem(ex: NotImplementedProblem): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    logNotImplementedProblem(ex)
+    return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(UnhandledExceptionProblem::class)
+  fun handleUnhandledExceptionProblem(ex: UnhandledExceptionProblem): ResponseEntity<ProblemDetail> {
+    logInternalServerErrorProblem(ex)
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(InternalServerErrorProblem::class)
+  fun handleInternalServerErrorProblem(ex: InternalServerErrorProblem): ResponseEntity<ProblemDetail> {
+    logInternalServerErrorProblem(ex)
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(APPLICATION_PROBLEM_JSON).body(ex.toProblemDetail())
+  }
+
+  @ExceptionHandler(JDBCConnectionException::class)
+  fun handleJDBCConnectionException(ex: JDBCConnectionException): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    val problem = ServiceUnavailableProblem(detail = "Error acquiring a database connection")
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).contentType(APPLICATION_PROBLEM_JSON).body(problem.toProblemDetail())
+  }
+
+  @ExceptionHandler(Throwable::class)
+  fun handleGenericException(ex: Throwable): ResponseEntity<ProblemDetail> {
+    sentryService.captureException(ex)
+    // Check if JDBCConnectionException is in the cause chain
+    if (isTypeInThrowableChain(ex, JDBCConnectionException::class.java)) {
+      val problem = ServiceUnavailableProblem(detail = "Error acquiring a database connection")
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(problem.toProblemDetail())
     }
 
-    return ResponseEntity<Problem>(responseBuilder.build(), HttpStatus.BAD_REQUEST)
+    log.error("Unhandled exception type, returning generic 500 response", ex)
+    throw ex
   }
 
   private fun isInputTypeArray(mismatchedInputException: MismatchedInputException): Boolean {
@@ -154,26 +229,15 @@ class ExceptionHandling(
     return true
   }
 
-  override fun log(throwable: Throwable, problem: Problem, request: NativeWebRequest, status: HttpStatus) {
-    when (problem) {
-      is BadRequestProblem -> logBadRequestProblem(problem)
-      is InternalServerErrorProblem -> logInternalServerErrorProblem(problem)
-      is NotImplementedProblem -> logNotImplementedProblem(problem)
-      else -> {
-        super<ProblemHandling>.log(throwable, problem, request, status)
-      }
-    }
-  }
-
   private fun logBadRequestProblem(problem: BadRequestProblem) = log.error("Bad Request. Error Detail: ${problem.errorDetail ?: "None"}, Invalid Params: [${problem.invalidParams?.entries?.joinToString(",") { "${it.key}=${it.value}" } ?: "None"}]")
 
-  private fun logInternalServerErrorProblem(problem: InternalServerErrorProblem) {
-    log.error("Internal Server Error. Error Detail: ${problem.detail ?: "None"}")
-    sentryService.captureException(problem)
+  private fun logInternalServerErrorProblem(ex: RuntimeException) {
+    log.error("Internal Server Error. Error Detail: ${ex.message ?: "None"}")
+    sentryService.captureException(ex)
   }
 
   private fun logNotImplementedProblem(problem: NotImplementedProblem) {
-    log.error("Not Implemented. Error Detail: ${problem.detail ?: "None"}")
+    log.error("Not Implemented. Error Detail: ${problem.message ?: "None"}")
     sentryService.captureException(problem)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -214,7 +214,8 @@ class ExceptionHandling(
     }
 
     log.error("Unhandled exception type, returning generic 500 response", ex)
-    throw ex
+    val problem = UnhandledExceptionProblem(detail = "There was an unexpected problem")
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem.toProblemDetail())
   }
 
   private fun isInputTypeArray(mismatchedInputException: MismatchedInputException): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/FlattenedProblemDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/FlattenedProblemDetail.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+class FlattenedProblemDetail(status: HttpStatus, detail: String) : ProblemDetail(status.value()) {
+  init {
+    this.detail = detail
+  }
+
+  @JsonAnyGetter
+  fun getFlattenedProperties(): Map<String, Any>? = properties
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/FlattenedProblemDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/FlattenedProblemDetail.kt
@@ -4,6 +4,16 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
+/**
+ * FlattenedProblemDetail adds an extra @JsonAnyGetter exposing properties, but ProblemDetail still serialises the properties
+ * field itself. That currently leads to duplicated data in responses (e.g. both a top-level invalid-params and also
+ * properties.invalid-params).  Therefore, invalid-params appears twice in the JSON returned to the client.
+ *
+ * The most appropriate place for it is in properties.invalid-params and correct according to the spec, however we currently include
+ * invalid-params in the root of the JSON response tree and the UI client will presumably expect it to be in this format.  Consequently
+ * leaving it in twice seems the most appropriate thing to do - this meets the spec and guidance but also means we don't need to change
+ * existing logic and potentially client (UI) logic.
+ */
 class FlattenedProblemDetail(status: HttpStatus, detail: String) : ProblemDetail(status.value()) {
   init {
     this.detail = detail

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
@@ -1,15 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class ForbiddenProblem(detail: String? = null) :
-  AbstractThrowableProblem(
-    null,
-    "Forbidden",
-    Status.FORBIDDEN,
-    detail ?: "You are not authorized to access this endpoint",
-  ) {
-  override fun getCause(): Exceptional? = null
+class ForbiddenProblem(detail: String? = null) : RuntimeException(detail ?: "You are not authorized to access this endpoint") {
+
+  val msg = detail ?: "You are not authorized to access this endpoint"
+  val title = "Forbidden"
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, message ?: msg).apply {
+    title = this@ForbiddenProblem.title
+    status = HttpStatus.FORBIDDEN.value()
+    detail = msg
+  }
+
+  override val message: String?
+    get() = "$title: $msg"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ForbiddenProblem.kt
@@ -3,17 +3,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class ForbiddenProblem(detail: String? = null) : RuntimeException(detail ?: "You are not authorized to access this endpoint") {
+class ForbiddenProblem(detail: String? = null) : ApiProblem(detail ?: "You are not authorized to access this endpoint") {
 
-  val msg = detail ?: "You are not authorized to access this endpoint"
   val title = "Forbidden"
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, message ?: msg).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, message).apply {
     title = this@ForbiddenProblem.title
     status = HttpStatus.FORBIDDEN.value()
-    detail = msg
+    detail = message
   }
-
-  override val message: String?
-    get() = "$title: $msg"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/InternalServerErrorProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/InternalServerErrorProblem.kt
@@ -1,9 +1,16 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class InternalServerErrorProblem(detail: String) : AbstractThrowableProblem(null, "Internal Server Error", Status.INTERNAL_SERVER_ERROR, detail) {
-  override fun getCause(): Exceptional? = null
+class InternalServerErrorProblem(val detail: String) : RuntimeException(detail) {
+
+  val title = "Internal Server Error"
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, detail).apply {
+    title = this@InternalServerErrorProblem.title
+  }
+
+  override val message: String?
+    get() = "$title: $detail"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/InternalServerErrorProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/InternalServerErrorProblem.kt
@@ -3,14 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class InternalServerErrorProblem(val detail: String) : RuntimeException(detail) {
+class InternalServerErrorProblem(detail: String) : ApiProblem(detail) {
 
   val title = "Internal Server Error"
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, detail).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, message).apply {
     title = this@InternalServerErrorProblem.title
   }
-
-  override val message: String?
-    get() = "$title: $detail"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/InvalidParamsProblemDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/InvalidParamsProblemDetail.kt
@@ -14,11 +14,16 @@ import org.springframework.http.ProblemDetail
  * leaving it in twice seems the most appropriate thing to do - this meets the spec and guidance but also means we don't need to change
  * existing logic and potentially client (UI) logic.
  */
-class FlattenedProblemDetail(status: HttpStatus, detail: String) : ProblemDetail(status.value()) {
+class InvalidParamsProblemDetail(
+  status: HttpStatus,
+  detail: String,
+  private val invalidParams: List<ParamError>? = null,
+) : ProblemDetail(status.value()) {
+
   init {
     this.detail = detail
   }
 
   @JsonAnyGetter
-  fun getFlattenedProperties(): Map<String, Any>? = properties
+  fun getAdditionalTopLevelProperties() = invalidParams?.let { mapOf("invalid-params" to it) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotAllowedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotAllowedProblem.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class NotAllowedProblem(detail: String) : AbstractThrowableProblem(null, "Not Allowed", Status.METHOD_NOT_ALLOWED, detail) {
-  override fun getCause(): Exceptional? = null
+class NotAllowedProblem(val detail: String) : RuntimeException(detail) {
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.METHOD_NOT_ALLOWED, detail).apply {
+    title = "Not Allowed"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotAllowedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotAllowedProblem.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class NotAllowedProblem(val detail: String) : RuntimeException(detail) {
+class NotAllowedProblem(detail: String) : ApiProblem(detail) {
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.METHOD_NOT_ALLOWED, detail).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.METHOD_NOT_ALLOWED, message).apply {
     title = "Not Allowed"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundProblem.kt
@@ -1,9 +1,22 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class NotFoundProblem(id: Any, entityType: String, identifier: String? = null) : AbstractThrowableProblem(null, "Not Found", Status.NOT_FOUND, "No $entityType with ${identifier ?: "an ID"} of $id could be found") {
-  override fun getCause(): Exceptional? = null
+class NotFoundProblem(id: Any, entityType: String, identifier: String? = null) : RuntimeException("No $entityType with ${identifier ?: "an ID"} of $id could be found") {
+
+  val title = "Not Found"
+  val msg = "No $entityType with ${identifier ?: "an ID"} of $id could be found"
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(
+    HttpStatus.NOT_FOUND,
+    message ?: "Not Found",
+  ).apply {
+    title = this@NotFoundProblem.title
+    status = HttpStatus.NOT_FOUND.value()
+    detail = msg
+  }
+
+  override val message: String?
+    get() = "$title: $msg"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundProblem.kt
@@ -3,20 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class NotFoundProblem(id: Any, entityType: String, identifier: String? = null) : RuntimeException("No $entityType with ${identifier ?: "an ID"} of $id could be found") {
+class NotFoundProblem(id: Any, entityType: String, identifier: String? = null) : ApiProblem("No $entityType with ${identifier ?: "an ID"} of $id could be found") {
 
   val title = "Not Found"
-  val msg = "No $entityType with ${identifier ?: "an ID"} of $id could be found"
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(
     HttpStatus.NOT_FOUND,
-    message ?: "Not Found",
+    message,
   ).apply {
     title = this@NotFoundProblem.title
     status = HttpStatus.NOT_FOUND.value()
-    detail = msg
+    detail = message
   }
-
-  override val message: String?
-    get() = "$title: $msg"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundResourceProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundResourceProblem.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class NotFoundResourceProblem : AbstractThrowableProblem(null, "Not Found", Status.NOT_FOUND, "Resource not found") {
-  override fun getCause(): Exceptional? = null
+class NotFoundResourceProblem : RuntimeException("Resource not found") {
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "Resource not found").apply {
+    title = "Not Found"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundResourceProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotFoundResourceProblem.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class NotFoundResourceProblem : RuntimeException("Resource not found") {
+class NotFoundResourceProblem : ApiProblem("Resource not found") {
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "Resource not found").apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "Resource not found").apply {
     title = "Not Found"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotImplementedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotImplementedProblem.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class NotImplementedProblem(detail: String) : AbstractThrowableProblem(null, "Not Implemented", Status.NOT_IMPLEMENTED, detail) {
-  override fun getCause(): Exceptional? = null
+class NotImplementedProblem(val detail: String) : RuntimeException(detail) {
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_IMPLEMENTED, detail).apply {
+    title = "Not Implemented"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotImplementedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/NotImplementedProblem.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class NotImplementedProblem(val detail: String) : RuntimeException(detail) {
+class NotImplementedProblem(detail: String) : ApiProblem(detail) {
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_IMPLEMENTED, detail).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_IMPLEMENTED, message).apply {
     title = "Not Implemented"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ServiceUnavailableProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ServiceUnavailableProblem.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class ServiceUnavailableProblem(detail: String) : AbstractThrowableProblem(null, "Service Unavailable", Status.SERVICE_UNAVAILABLE, detail) {
-  override fun getCause(): Exceptional? = null
+class ServiceUnavailableProblem(val detail: String) : RuntimeException(detail) {
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE, detail).apply {
+    title = "Service Unavailable"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ServiceUnavailableProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ServiceUnavailableProblem.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class ServiceUnavailableProblem(val detail: String) : RuntimeException(detail) {
+class ServiceUnavailableProblem(detail: String) : ApiProblem(detail) {
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE, detail).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE, message).apply {
     title = "Service Unavailable"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class UnauthenticatedProblem(detail: String = "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") : AbstractThrowableProblem(null, "Unauthenticated", Status.UNAUTHORIZED, detail) {
-  override fun getCause(): Exceptional? = null
+class UnauthenticatedProblem(val detail: String = "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") : RuntimeException(detail) {
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, message ?: detail).apply {
+    title = "Unauthenticated"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnauthenticatedProblem.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class UnauthenticatedProblem(val detail: String = "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") : RuntimeException(detail) {
+class UnauthenticatedProblem(detail: String = "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint") : ApiProblem(detail) {
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, message ?: detail).apply {
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, message).apply {
     title = "Unauthenticated"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnhandledExceptionProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnhandledExceptionProblem.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 
-import org.zalando.problem.AbstractThrowableProblem
-import org.zalando.problem.Exceptional
-import org.zalando.problem.Status
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 
-class UnhandledExceptionProblem(detail: String) : AbstractThrowableProblem(null, "Internal Server Error", Status.INTERNAL_SERVER_ERROR, detail) {
-  override fun getCause(): Exceptional? = null
+class UnhandledExceptionProblem(detail: String) : RuntimeException(detail) {
+
+  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(
+    HttpStatus.INTERNAL_SERVER_ERROR,
+    message ?: "There was an unexpected problem",
+  ).apply {
+    title = "Internal Server Error"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnhandledExceptionProblem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/UnhandledExceptionProblem.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.problem
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
-class UnhandledExceptionProblem(detail: String) : RuntimeException(detail) {
+class UnhandledExceptionProblem(detail: String) : ApiProblem(detail) {
 
-  fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(
+  override fun toProblemDetail(): ProblemDetail = ProblemDetail.forStatusAndDetail(
     HttpStatus.INTERNAL_SERVER_ERROR,
     message ?: "There was an unexpected problem",
   ).apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2OffenderServiceTest.kt
@@ -484,7 +484,7 @@ class Cas2OffenderServiceTest {
       )
 
       val error = assertThrows<ForbiddenProblem> { offenderService.getFullInfoForPersonOrThrow(crn) }
-      assertThat(error.message).isEqualTo("Forbidden: Offender $crn is Restricted.")
+      assertThat(error.message).isEqualTo("Offender $crn is Restricted.")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ExceptionHandlingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ExceptionHandlingTest.kt
@@ -255,15 +255,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/authentication-credentials-not-found-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .returnResult<String>()
+        .expectBody()
+        .returnResult()
 
       assertJsonEquals(
-        actual = validationResult.responseBody.blockFirst(),
+        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
         expected = """
           {
+            "type" : "about:blank",
             "title" : "Unauthenticated",
             "status" : 401,
-            "detail" : "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint"
+            "detail" : "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint",
+            "instance" : "/authentication-credentials-not-found-exception",
+            "properties" : null
           }
           """,
       )
@@ -279,15 +283,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/access-denied-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .returnResult<String>()
+        .expectBody()
+        .returnResult()
 
       assertJsonEquals(
-        actual = validationResult.responseBody.blockFirst(),
+        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
         expected = """
           {
+            "type" : "about:blank",
             "title" : "Forbidden",
             "status" : 403,
-            "detail" : "You are not authorized to access this endpoint"
+            "detail" : "You are not authorized to access this endpoint",
+            "instance" : "/access-denied-exception",
+            "properties" : null
           }
           """,
       )
@@ -302,15 +310,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/no-resource-found-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .returnResult<String>()
+        .expectBody()
+        .returnResult()
 
       assertJsonEquals(
-        actual = validationResult.responseBody.blockFirst(),
+        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
         expected = """
           {
+            "type" : "about:blank",
             "title" : "Not Found",
             "status" : 404,
-            "detail" : "Resource not found"
+            "detail" : "Resource not found",
+            "instance" : "/no-resource-found-exception",
+            "properties" : null
           }
           """,
       )
@@ -325,16 +337,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/missing-request-header-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .returnResult<String>()
+        .expectBody()
+        .returnResult()
 
       assertJsonEquals(
-        actual = validationResult.responseBody.blockFirst(),
+        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
         expected = """
           {
-            "title" : "Bad Request",
             "status" : 400,
             "detail" : "Missing required header X-Required-Header",
-            "invalid-params" : []
+            "type" : "about:blank",
+            "title" : "Bad Request",
+            "instance" : "/missing-request-header-exception",
+            "properties" : null
           }
           """,
       )
@@ -354,11 +369,13 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
       assertJsonEquals(
         actual = validationResult.responseBody.blockFirst(),
         expected = """
-            {
-              "title" : "Bad Request",
+            {              
               "status" : 400,
               "detail" : "Missing required query parameter requiredProperty",
-              "invalid-params": []
+              "type" : "about:blank",
+              "title" : "Bad Request",
+              "instance" : "/missing-servlet-request-parameter-exception",
+              "properties" : null
             }
           """,
       )
@@ -406,15 +423,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/jdbc-connection-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .returnResult<String>()
+        .expectBody()
+        .returnResult()
 
       assertJsonEquals(
-        actual = validationResult.responseBody.blockFirst(),
+        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
         expected = """
           {        
-            "detail" : "Error acquiring a database connection",
+            "type" : "about:blank",
             "title" : "Service Unavailable",
-            "status" : 503
+            "status" : 503,
+            "detail" : "Error acquiring a database connection",
+            "instance" : "/jdbc-connection-exception",
+            "properties" : null
           }
           """,
       )
@@ -435,9 +456,12 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         actual = validationResult.responseBody.blockFirst(),
         expected = """
            {        
-            "detail" : "There was an unexpected problem",
+            "type":"about:blank",
             "title" : "Internal Server Error",
-            "status" : 500
+            "status" : 500,
+            "detail" : "There was an unexpected problem",
+            "instance" : "/illegal-argument-exception",
+            "properties" : null
            }
           """,
       )
@@ -460,13 +484,16 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         actual = validationResult.responseBody.blockFirst(),
         expected = """
           {        
+            "type" : "about:blank",
             "title" : "Bad Request",
             "status" : 400,
-            "detail" : "Expected an array but got an object"
+            "detail" : "Expected an array but got an object",
+            "instance" : "/deserialization-test/array",
+            "properties" : null
           }
           """,
       )
-      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/json")
+      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/problem+json")
     }
 
     @Test
@@ -485,13 +512,16 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         actual = validationResult.responseBody.blockFirst(),
         expected = """
           {        
+            "type" : "about:blank",
             "title" : "Bad Request",
             "status" : 400,
-            "detail" : "Expected an object but got an array"
+            "detail" : "Expected an object but got an array",
+            "instance" : "/deserialization-test/object",
+            "properties" : null
           }
           """,
       )
-      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/json")
+      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/problem+json")
     }
 
     @Test
@@ -531,9 +561,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         actual = validationResult.responseBody.blockFirst(),
         expected = """
           {        
-            "title" : "Bad Request",
             "status" : 400,
             "detail" : "There is a problem with your request",
+            "type" : "about:blank",
+            "title" : "Bad Request",
+            "instance" : "/deserialization-test/array",
+            "properties" : {
+              "invalid-params" : [{
+                "propertyName" : "$[0].requiredInt",
+                "errorType" : "expectedNumber",
+                "entityId" : null, 
+                "value" : null
+              }]
+            },
             "invalid-params" : [{
               "propertyName" : "$[0].requiredInt",
               "errorType" : "expectedNumber",
@@ -544,7 +584,7 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
           """,
       )
 
-      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/json")
+      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/problem+json")
     }
 
     @Test
@@ -584,9 +624,19 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         actual = validationResult.responseBody.blockFirst(),
         expected = """
           {        
-            "title" : "Bad Request",
             "status" : 400,
             "detail" : "There is a problem with your request",
+            "type":"about:blank",
+            "title" : "Bad Request",
+            "instance":"/deserialization-test/object",
+            "properties" : {
+              "invalid-params" : [{
+                "propertyName" : "$.requiredInt",
+                "errorType" : "expectedNumber",
+                "entityId" : null, 
+                "value" : null
+              }]
+            },
             "invalid-params" : [{
               "propertyName" : "$.requiredInt",
               "errorType" : "expectedNumber",
@@ -596,7 +646,7 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
           }
           """,
       )
-      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/json")
+      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/problem+json")
     }
 
     @Test
@@ -615,13 +665,16 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         actual = validationResult.responseBody.blockFirst(),
         expected = """
           {        
+            "type" : "about:blank",
             "title" : "Bad Request",
             "status" : 400,
-            "detail" : "JSON parse error: Unexpected character ('i' (code 105)): was expecting double-quote to start field name"
+            "detail" : "JSON parse error: Unexpected character ('i' (code 105)): was expecting double-quote to start field name",
+            "instance" : "/deserialization-test/object",
+            "properties" : null
           }
           """,
       )
-      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/json")
+      assertThat(validationResult.responseHeaders.contentType?.toString()).isEqualTo("application/problem+json")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ExceptionHandlingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ExceptionHandlingTest.kt
@@ -255,11 +255,10 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/authentication-credentials-not-found-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .expectBody()
-        .returnResult()
+        .returnResult<String>()
 
       assertJsonEquals(
-        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
+        actual = validationResult.responseBody.blockFirst(),
         expected = """
           {
             "type" : "about:blank",
@@ -283,11 +282,10 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/access-denied-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .expectBody()
-        .returnResult()
+        .returnResult<String>()
 
       assertJsonEquals(
-        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
+        actual = validationResult.responseBody.blockFirst(),
         expected = """
           {
             "type" : "about:blank",
@@ -310,11 +308,10 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/no-resource-found-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .expectBody()
-        .returnResult()
+        .returnResult<String>()
 
       assertJsonEquals(
-        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
+        actual = validationResult.responseBody.blockFirst(),
         expected = """
           {
             "type" : "about:blank",
@@ -337,11 +334,10 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/missing-request-header-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .expectBody()
-        .returnResult()
+        .returnResult<String>()
 
       assertJsonEquals(
-        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
+        actual = validationResult.responseBody.blockFirst(),
         expected = """
           {
             "status" : 400,
@@ -423,11 +419,10 @@ class ExceptionHandlingTest : InitialiseDatabasePerClassTestBase() {
         .uri("/jdbc-connection-exception")
         .header("Authorization", "Bearer $jwt")
         .exchange()
-        .expectBody()
-        .returnResult()
+        .returnResult<String>()
 
       assertJsonEquals(
-        actual = validationResult.responseBody?.toString(Charsets.UTF_8),
+        actual = validationResult.responseBody.blockFirst(),
         expected = """
           {        
             "type" : "about:blank",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/problem/ExceptionHandlingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/problem/ExceptionHandlingTest.kt
@@ -24,7 +24,6 @@ import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import org.springframework.web.util.ContentCachingRequestWrapper
-import org.zalando.problem.Status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ExceptionHandling
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
@@ -52,13 +51,12 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns UnauthenticatedProblem when exception is AuthenticationCredentialsNotFoundException and exception captured in Sentry`() {
     val throwable = AuthenticationCredentialsNotFoundException("")
-    val statusType = Status.UNAUTHORIZED
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleAuthenticationCredentialsNotFoundException(throwable).body!!
 
-    val expectedProblem = UnauthenticatedProblem()
+    val expectedProblem = UnauthenticatedProblem().toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo(expectedProblem.detail)
@@ -69,13 +67,12 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns ForbiddenProblem problem when exception is AccessDeniedException and exception captured in Sentry`() {
     val throwable = SpringAccessDeniedException("")
-    val statusType = Status.FORBIDDEN
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleAccessDeniedException(throwable).body!!
 
-    val expectedProblem = ForbiddenProblem()
+    val expectedProblem = ForbiddenProblem().toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo(expectedProblem.detail)
@@ -86,11 +83,10 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns NotFoundResourceProblem problem when exception is NoResourceFoundException and exception captured in Sentry`() {
     val throwable = NoResourceFoundException(HttpMethod.GET, "")
-    val statusType = Status.NOT_FOUND
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleNoResourceFoundException(throwable).body!!
 
-    val expectedProblem = NotFoundResourceProblem()
+    val expectedProblem = NotFoundResourceProblem().toProblemDetail()
 
     assertThat(problem!!.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
@@ -103,13 +99,12 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns BadRequestProblem problem when exception is MissingRequestHeaderException and exception captured in Sentry`() {
     val throwable = MissingRequestHeaderException("Authorisation", mockk<MethodParameter>())
-    val statusType = Status.BAD_REQUEST
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleMissingRequestHeaderException(throwable).body!!
 
-    val expectedProblem = BadRequestProblem()
+    val expectedProblem = BadRequestProblem().toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo("Missing required header Authorisation")
@@ -120,13 +115,12 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns BadRequestProblem problem when exception is MissingServletRequestParameterException and exception captured in Sentry`() {
     val throwable = MissingServletRequestParameterException("id", "")
-    val statusType = Status.BAD_REQUEST
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleMissingServletRequestParameterException(throwable).body!!
 
-    val expectedProblem = BadRequestProblem()
+    val expectedProblem = BadRequestProblem().toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo("Missing required query parameter id")
@@ -141,13 +135,12 @@ class ExceptionHandlingTest {
     every { methodParameter.parameterType } returns Int::class.java
 
     val throwable = MethodArgumentTypeMismatchException(null, null, "", methodParameter, null)
-    val statusType = Status.BAD_REQUEST
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleMethodArgumentTypeMismatchException(throwable).body!!
 
-    val expectedProblem = BadRequestProblem()
+    val expectedProblem = BadRequestProblem().toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo("Invalid type for query parameter id expected int")
@@ -158,13 +151,12 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns ServiceUnavailableProblem problem when exception is cause chain of JDBCConnectionException and exception captured in Sentry`() {
     val throwable = RuntimeException("wrapper", JDBCConnectionException("", SQLException()))
-    val statusType = Status.SERVICE_UNAVAILABLE
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleGenericException(throwable).body!!
 
-    val expectedProblem = ServiceUnavailableProblem("Error acquiring a database connection")
+    val expectedProblem = ServiceUnavailableProblem("Error acquiring a database connection").toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo("Error acquiring a database connection")
@@ -175,13 +167,12 @@ class ExceptionHandlingTest {
   @Test
   fun `Returns UnhandledExceptionProblem problem when exception is unhandled (IllegalStateException), logs error and exception captured in Sentry`() {
     val throwable = IllegalStateException()
-    val statusType = Status.INTERNAL_SERVER_ERROR
 
-    val problem = exceptionHandling.toProblem(throwable, statusType)
+    val problem = exceptionHandling.handleGenericException(throwable).body!!
 
-    val expectedProblem = UnhandledExceptionProblem("There was an unexpected problem")
+    val expectedProblem = UnhandledExceptionProblem("There was an unexpected problem").toProblemDetail()
 
-    assertThat(problem!!.type).isEqualTo(expectedProblem.type)
+    assertThat(problem.type).isEqualTo(expectedProblem.type)
     assertThat(problem.title).isEqualTo(expectedProblem.title)
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo("There was an unexpected problem")
@@ -211,8 +202,8 @@ class ExceptionHandlingTest {
     val response = exceptionHandling.handleMessageNotReadableException(throwable, mockRequest)
 
     assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
-    assertThat(response.body.title).isEqualTo("Bad Request")
-    assertThat(response.body.detail).isEqualTo("Expected an array but got an object")
+    assertThat(response.body!!.title).isEqualTo("Bad Request")
+    assertThat(response.body!!.detail).isEqualTo("Expected an array but got an object")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -324,7 +324,7 @@ class OffenderServiceTest {
       assertThatThrownBy {
         offenderService.canAccessOffenders("distinguished.name", (0..500).map { "$it" })
       }.isInstanceOf(InternalServerErrorProblem::class.java)
-        .hasMessage("Internal Server Error: Cannot request access details for more than 500 CRNs. 501 have been provided.")
+        .hasMessage("Cannot request access details for more than 500 CRNs. 501 have been provided.")
     }
 
     @Test
@@ -996,7 +996,7 @@ class OffenderServiceTest {
           laoStrategy = LaoStrategy.NeverRestricted,
         )
       }.isInstanceOf(InternalServerErrorProblem::class.java)
-        .hasMessage("Internal Server Error: Cannot request more than 500 CRNs. A batch size of 501 has been requested.")
+        .hasMessage("Cannot request more than 500 CRNs. A batch size of 501 has been requested.")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApAreaMappingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApAreaMappingServiceTest.kt
@@ -154,7 +154,7 @@ class Cas1ApAreaMappingServiceTest {
           username,
         )
       }.hasMessage(
-        "Internal Server Error: Could not find a delius team mapping for delius user J_ALUCARD " +
+        "Could not find a delius team mapping for delius user J_ALUCARD " +
           "with probation region PR1 and teams " +
           "[CODE_NOT_IN_MAPPING, OTHER_CODE_NOT_IN_MAPPING]",
       )
@@ -183,7 +183,7 @@ class Cas1ApAreaMappingServiceTest {
           staffUserDetails.username!!,
         )
       }.hasMessage(
-        "Internal Server Error: Could not find AP Area for code Mids",
+        "Could not find AP Area for code Mids",
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -676,7 +676,7 @@ class Cas1DomainEventServiceTest {
 
       assertThatThrownBy {
         domainEventService.replay(id)
-      }.hasMessage("Not Found: No DomainEvent with an ID of d37c9dd3-8ec8-4362-9525-1e85bcb36e79 could be found")
+      }.hasMessage("No DomainEvent with an ID of d37c9dd3-8ec8-4362-9525-1e85bcb36e79 could be found")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
@@ -1089,7 +1089,7 @@ class Cas1PlacementApplicationServiceTest {
             placementApplication.id,
           ),
         )
-      }.hasMessage("Internal Server Error: Withdrawing a ${triggeringEntity.name} should not cascade to PlacementApplications")
+      }.hasMessage("Withdrawing a ${triggeringEntity.name} should not cascade to PlacementApplications")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/UserTransformerTest.kt
@@ -324,7 +324,7 @@ class UserTransformerTest {
 
       assertThatThrownBy {
         userTransformer.transformJpaToApi(user, approvedPremises)
-      }.hasMessage("Internal Server Error: CAS1 user ${user.id} should have AP Area Set")
+      }.hasMessage("CAS1 user ${user.id} should have AP Area Set")
     }
 
     @Test


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-495

Now that additional unit and integration test coverage has been added, this PR removes the dependency on Zalando Spring Problem so we can use the default Spring Problem libraries which are part of the Spring Framework.

This PR now uses the `@ExceptionHandler` annotations and associated handle methods.

