### PR TITLE
SAS-467: Referral history API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1ReferralHistory.kt
@@ -9,4 +9,10 @@ data class Cas1ReferralHistory(
   val applicationId: UUID,
   val status: Cas1AssessmentStatus,
   val createdAt: Instant,
+  val referralRejectionReason: String?,
+  val localAuthorityArea: String?,
+  val pdu: String?,
+  val referredBy: String?,
+  val placementAddress: String?,
+  val placementStatus: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ReferralHistory.kt
@@ -9,4 +9,10 @@ data class Cas2v2ReferralHistory(
   val applicationId: UUID,
   val status: String,
   val createdAt: Instant,
+  val referralRejectionReason: String?,
+  val localAuthorityArea: String?,
+  val pdu: String?,
+  val referredBy: String?,
+  val placementAddress: String?,
+  val placementStatus: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/model/Cas2ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/model/Cas2ReferralHistory.kt
@@ -10,4 +10,10 @@ data class Cas2ReferralHistory(
   val applicationId: UUID,
   val status: String,
   val createdAt: Instant,
+  val referralRejectionReason: String?,
+  val localAuthorityArea: String?,
+  val pdu: String?,
+  val referredBy: String?,
+  val placementAddress: String?,
+  val placementStatus: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationsTransformer.kt
@@ -7,6 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateNonAssignable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ReferralHistory
@@ -84,13 +86,31 @@ class Cas2ApplicationsTransformer(
 
   fun transformJpaToCas2ReferralHistory(
     jpa: Cas2ApplicationEntity,
-  ) = Cas2ReferralHistory(
-    id = jpa.assessment!!.id,
-    applicationId = jpa.id,
-    type = ServiceType.CAS2,
-    createdAt = jpa.submittedAt!!.toInstant(),
-    status = jpa.statusUpdates!!.first().label,
-  )
+  ): Cas2ReferralHistory {
+    val latestStatusUpdate = getReferralHistoryStatus(jpa)
+    val rejectionReason = latestStatusUpdate
+      ?.takeIf { it.label in listOf(Cas2StatusUpdateNonAssignable.REFERRAL_CANCELLED.label, Cas2StatusUpdateNonAssignable.REFERRAL_WITHDRAWN.label) }
+      ?.label
+
+    val omu = jpa.referringPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it) }
+    val placementAddress = omu?.prisonName ?: jpa.referringPrisonCode
+
+    return Cas2ReferralHistory(
+      id = jpa.assessment!!.id,
+      applicationId = jpa.id,
+      type = ServiceType.CAS2,
+      createdAt = jpa.submittedAt!!.toInstant(),
+      status = jpa.statusUpdates!!.first().label,
+      referralRejectionReason = rejectionReason,
+      localAuthorityArea = placementAddress,
+      pdu = jpa.preferredAreas,
+      referredBy = jpa.createdByUser.name,
+      placementAddress = placementAddress,
+      placementStatus = latestStatusUpdate?.label,
+    )
+  }
+
+  private fun getReferralHistoryStatus(jpa: Cas2ApplicationEntity): Cas2StatusUpdateEntity? = jpa.statusUpdates?.firstOrNull()
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {
     if (entity.submittedAt !== null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2ApplicationsTransformer.kt
@@ -12,6 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateNonAssignable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OffenderManagementUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import java.util.UUID
@@ -24,6 +26,7 @@ class Cas2v2ApplicationsTransformer(
   private val statusUpdateTransformer: Cas2v2StatusUpdateTransformer,
   private val timelineEventsTransformer: Cas2v2TimelineEventsTransformer,
   private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
+  private val offenderManagementUnitRepository: OffenderManagementUnitRepository,
 ) {
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2v2Application = transformJpaAndFullPersonToApi(jpa, personTransformer.transformModelToPersonApi(personInfo))
@@ -86,13 +89,29 @@ class Cas2v2ApplicationsTransformer(
 
   fun transformJpaToCas2v2ReferralHistory(
     jpa: Cas2ApplicationEntity,
-  ) = Cas2v2ReferralHistory(
-    id = jpa.assessment!!.id,
-    applicationId = jpa.id,
-    type = ServiceType.CAS2v2,
-    createdAt = jpa.submittedAt!!.toInstant(),
-    status = jpa.statusUpdates!!.first().label,
-  )
+  ): Cas2v2ReferralHistory {
+    val latestStatusUpdate = jpa.statusUpdates?.firstOrNull()
+    val rejectionReason = latestStatusUpdate
+      ?.takeIf { it.label in listOf(Cas2StatusUpdateNonAssignable.REFERRAL_CANCELLED.label, Cas2StatusUpdateNonAssignable.REFERRAL_WITHDRAWN.label) }
+      ?.label
+
+    val omu = jpa.referringPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it) }
+    val placementAddress = omu?.prisonName ?: jpa.referringPrisonCode ?: throw IllegalStateException("Missing placement address for CAS2v2 application ${jpa.id}")
+
+    return Cas2v2ReferralHistory(
+      id = jpa.assessment!!.id,
+      applicationId = jpa.id,
+      type = ServiceType.CAS2v2,
+      createdAt = jpa.submittedAt!!.toInstant(),
+      status = jpa.statusUpdates!!.first().label,
+      referralRejectionReason = rejectionReason,
+      localAuthorityArea = placementAddress,
+      pdu = jpa.preferredAreas,
+      referredBy = jpa.createdByUser.name,
+      placementAddress = placementAddress,
+      placementStatus = latestStatusUpdate?.label,
+    )
+  }
 
   private fun getStatus(entity: Cas2ApplicationEntity): ApplicationStatus {
     if (entity.submittedAt !== null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3ReferralHistory.kt
@@ -11,4 +11,10 @@ data class Cas3ReferralHistory(
   val applicationId: UUID,
   val status: TemporaryAccommodationAssessmentStatus,
   val createdAt: Instant,
+  val referralRejectionReason: String?,
+  val localAuthorityArea: String?,
+  val pdu: String?,
+  val referredBy: String?,
+  val placementAddress: String?,
+  val placementStatus: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ReferralH
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
@@ -35,6 +36,7 @@ class Cas3AssessmentTransformer(
   private val assessmentClarificationNoteTransformer: AssessmentClarificationNoteTransformer,
   private val userTransformer: UserTransformer,
   private val jsonMapper: JsonMapper,
+  private val bookingRepository: BookingRepository,
 ) {
   fun transformJpaToApi(
     jpa: TemporaryAccommodationAssessmentEntity,
@@ -78,13 +80,29 @@ class Cas3AssessmentTransformer(
     probationDeliveryUnitName = ase.probationDeliveryUnitName,
   )
 
-  fun transformAssessmentToCas3ReferralHistory(a: TemporaryAccommodationAssessmentEntity): Cas3ReferralHistory = Cas3ReferralHistory(
-    id = a.id,
-    applicationId = a.application.id,
-    createdAt = a.createdAt.toInstant(),
-    status = a.deriveAssessmentStatus(),
-    type = ServiceType.CAS3,
-  )
+  fun transformAssessmentToCas3ReferralHistory(a: TemporaryAccommodationAssessmentEntity): Cas3ReferralHistory {
+    val application = a.typedApplication<TemporaryAccommodationApplicationEntity>()
+
+    val latestBooking = bookingRepository.findLatestCas3BookingEntity(application.id, ServiceName.temporaryAccommodation.value)
+
+    val placementAddress = latestBooking?.let {
+      listOfNotNull(it.premises.addressLine1, it.premises.town, it.premises.postcode).joinToString(", ")
+    }
+
+    return Cas3ReferralHistory(
+      id = a.id,
+      applicationId = application.id,
+      createdAt = a.createdAt.toInstant(),
+      status = a.deriveAssessmentStatus(),
+      type = ServiceType.CAS3,
+      referralRejectionReason = a.referralRejectionReason?.name ?: a.rejectionRationale,
+      localAuthorityArea = application.dutyToReferLocalAuthorityAreaName,
+      pdu = application.probationDeliveryUnit?.name,
+      referredBy = application.createdByUser.name,
+      placementAddress = placementAddress,
+      placementStatus = latestBooking?.status?.value,
+    )
+  }
 
   fun transformApiStatusToDomainSummaryState(status: AssessmentStatus) = when (status) {
     AssessmentStatus.cas1Completed -> DomainAssessmentSummaryStatus.COMPLETED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/BookingEntity.kt
@@ -24,6 +24,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.BookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BookingRecord
@@ -114,6 +115,15 @@ interface BookingRepository : JpaRepository<BookingEntity, UUID> {
   fun findByBedIdAndArrivingBeforeDate(bedId: UUID, date: LocalDate, thisEntityId: UUID?): List<BookingEntity>
 
   fun findAllByApplication(application: ApplicationEntity): List<BookingEntity>
+
+  @Query(
+    "SELECT * FROM bookings WHERE application_id = :applicationId AND service = :service ORDER BY created_at DESC LIMIT 1",
+    nativeQuery = true,
+  )
+  fun findLatestCas3BookingEntity(
+    applicationId: UUID,
+    service: String,
+  ): Cas3BookingEntity?
 
   @Modifying
   @Query("UPDATE BookingEntity b set b.status = :status where b.id = :bookingId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas1SpaceBookingEntity.kt
@@ -24,6 +24,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TransferReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity.Companion.CHARACTERISTICS_OF_INTEREST
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ARSON_SUITABLE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_ENSUITE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS1_PROPERTY_NAME_PREMISES_ACCEPTS_CHILD_SEX_OFFENDERS
@@ -298,6 +299,11 @@ interface Cas1SpaceBookingRepository : JpaRepository<Cas1SpaceBookingEntity, UUI
   ): List<Cas1SpaceBookingEntity>
 
   fun findAllByApplication(application: ApplicationEntity): List<Cas1SpaceBookingEntity>
+
+  @Query("SELECT b FROM Cas1SpaceBookingEntity b WHERE b.application.id = :applicationId ORDER BY b.createdAt DESC")
+  fun findLatestCas1SpaceBooking(
+    applicationId: UUID,
+  ): List<Cas1SpaceBookingEntity>
 
   @Modifying
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -30,6 +31,7 @@ class Cas1AssessmentTransformer(
   private val userTransformer: UserTransformer,
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
+  private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
 ) {
 
   fun transformJpaToCas1Assessment(
@@ -73,13 +75,29 @@ class Cas1AssessmentTransformer(
     dueAt = ase.dueAt!!,
   )
 
-  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity): Cas1ReferralHistory = Cas1ReferralHistory(
-    id = entity.id,
-    applicationId = entity.application.id,
-    createdAt = entity.createdAt.toInstant(),
-    status = getStatusForCas1Assessment(entity),
-    type = ServiceType.CAS1,
-  )
+  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity): Cas1ReferralHistory {
+    val application = entity.cas1Application()
+
+    val latestBooking = cas1SpaceBookingRepository.findLatestCas1SpaceBooking(application.id).firstOrNull()
+
+    val placementAddress = latestBooking?.premises?.let {
+      listOfNotNull(it.addressLine1, it.town, it.postcode).joinToString(", ")
+    }
+
+    return Cas1ReferralHistory(
+      id = entity.id,
+      applicationId = entity.application.id,
+      createdAt = entity.createdAt.toInstant(),
+      status = getStatusForCas1Assessment(entity),
+      type = ServiceType.CAS1,
+      referralRejectionReason = entity.rejectionRationale,
+      localAuthorityArea = application.apArea?.name,
+      pdu = application.cruManagementArea?.name,
+      referredBy = application.createdByUser.name,
+      placementAddress = placementAddress,
+      placementStatus = latestBooking?.getSpaceBookingStatus()?.value,
+    )
+  }
 
   fun transformCas1AssessmentStatusToDomainSummaryState(status: Cas1AssessmentStatus) = when (status) {
     Cas1AssessmentStatus.awaitingResponse -> DomainAssessmentSummaryStatus.AWAITING_RESPONSE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/external/Cas2ExternalReferralHistoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/external/Cas2ExternalReferralHistoryTest.kt
@@ -46,11 +46,15 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
       givenACas2PomUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           val type = ServiceType.CAS2
-          val application1 = createApplication(user, "Status 1")
-          val application2 = createApplication(user, "Status 2")
-          val application3 = createApplication(user, "Status 3")
-          val application4 = createApplication(user, "Status 4")
-          val application5 = createApplication(user, "Status 5")
+          val omu = offenderManagementUnitEntityFactory.produceAndPersist {
+            withPrisonCode("TST")
+            withPrisonName("HMP Test Prison")
+          }
+          val application1 = createApplication(user, "Status 1", referringPrisonCode = omu.prisonCode)
+          val application2 = createApplication(user, "Status 2", referringPrisonCode = omu.prisonCode)
+          val application3 = createApplication(user, "Status 3", referringPrisonCode = omu.prisonCode)
+          val application4 = createApplication(user, "Status 4", referringPrisonCode = omu.prisonCode)
+          val application5 = createApplication(user, "Status 5", referringPrisonCode = omu.prisonCode)
 
           val expectedReferrals = listOf(
             Cas2ReferralHistory(
@@ -59,6 +63,12 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application1.submittedAt!!.toInstant(),
               status = application1.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = null,
+              localAuthorityArea = omu.prisonName,
+              pdu = application1.preferredAreas,
+              referredBy = application1.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application1.statusUpdates!!.first().label,
             ),
             Cas2ReferralHistory(
               id = application2.assessment!!.id,
@@ -66,6 +76,12 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application2.submittedAt!!.toInstant(),
               status = application2.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = null,
+              localAuthorityArea = omu.prisonName,
+              pdu = application2.preferredAreas,
+              referredBy = application2.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application2.statusUpdates!!.first().label,
             ),
             Cas2ReferralHistory(
               id = application3.assessment!!.id,
@@ -73,6 +89,12 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application3.submittedAt!!.toInstant(),
               status = application3.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = null,
+              localAuthorityArea = omu.prisonName,
+              pdu = application3.preferredAreas,
+              referredBy = application3.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application3.statusUpdates!!.first().label,
             ),
             Cas2ReferralHistory(
               id = application4.assessment!!.id,
@@ -80,6 +102,12 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application4.submittedAt!!.toInstant(),
               status = application4.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = null,
+              localAuthorityArea = omu.prisonName,
+              pdu = application4.preferredAreas,
+              referredBy = application4.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application4.statusUpdates!!.first().label,
             ),
             Cas2ReferralHistory(
               id = application5.assessment!!.id,
@@ -87,6 +115,12 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application5.submittedAt!!.toInstant(),
               status = application5.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = null,
+              localAuthorityArea = omu.prisonName,
+              pdu = application5.preferredAreas,
+              referredBy = application5.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application5.statusUpdates!!.first().label,
             ),
           )
 
@@ -106,11 +140,70 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
         }
       }
     }
+
+    @Test
+    fun `Get referral returns enriched fields`() {
+      givenACas2PomUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          val omu = offenderManagementUnitEntityFactory.produceAndPersist {
+            withPrisonCode("TST")
+            withPrisonName("HMP Test Prison")
+          }
+          val cancelledApplication = createApplication(user, "Referral cancelled", preferredAreas = "North West", referringPrisonCode = omu.prisonCode)
+
+          val response = webTestClient.get()
+            .uri("/cas2/external/referrals/$crn")
+            .header("Authorization", "Bearer $clientCredentialsJwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBodyList(Cas2ReferralHistory::class.java)
+            .returnResult()
+            .responseBody
+
+          val matched = response!!.first { it.id == cancelledApplication.assessment!!.id }
+          assertThat(matched.referralRejectionReason).isEqualTo("Referral cancelled")
+          assertThat(matched.placementStatus).isEqualTo("Referral cancelled")
+          assertThat(matched.pdu).isEqualTo("North West")
+          assertThat(matched.referredBy).isEqualTo(user.name)
+          assertThat(matched.localAuthorityArea).isEqualTo(omu.prisonName)
+          assertThat(matched.placementAddress).isEqualTo(omu.prisonName)
+        }
+      }
+    }
+
+    @Test
+    fun `Get referral returns placement address from OMU prison name`() {
+      givenACas2PomUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          val omu = offenderManagementUnitEntityFactory.produceAndPersist {
+            withPrisonCode("TST")
+            withPrisonName("HMP Test Prison")
+          }
+          val applicationWithPrison = createApplication(user, "Active", referringPrisonCode = omu.prisonCode)
+
+          val response = webTestClient.get()
+            .uri("/cas2/external/referrals/$crn")
+            .header("Authorization", "Bearer $clientCredentialsJwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBodyList(Cas2ReferralHistory::class.java)
+            .returnResult()
+            .responseBody
+
+          val matched = response!!.first { it.id == applicationWithPrison.assessment!!.id }
+          assertThat(matched.placementAddress).isEqualTo(omu.prisonName)
+        }
+      }
+    }
   }
 
   private fun createApplication(
     user: Cas2UserEntity,
     label: String,
+    preferredAreas: String? = null,
+    referringPrisonCode: String? = null,
   ): Cas2ApplicationEntity {
     val statusApplication = cas2ApplicationEntityFactory.produceAndPersist {
       withSubmittedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
@@ -121,6 +214,8 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
       withCreatedByUser(user)
       withCrn(crn)
       withSubmittedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+      preferredAreas?.let { withPreferredAreas(it) }
+      referringPrisonCode?.let { withReferringPrisonCode(it) }
       withStatusUpdates(
         mutableListOf(
           cas2StatusUpdateEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/external/Cas2v2ExternalReferralHistoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/external/Cas2v2ExternalReferralHistoryTest.kt
@@ -47,11 +47,15 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
       givenACas2v2PomUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           val type = ServiceType.CAS2v2
-          val application1 = createApplication(user, "Status 1")
-          val application2 = createApplication(user, "Status 2")
-          val application3 = createApplication(user, "Status 3")
-          val application4 = createApplication(user, "Status 4")
-          val application5 = createApplication(user, "Status 5")
+          val omu = offenderManagementUnitEntityFactory.produceAndPersist {
+            withPrisonCode("TST")
+            withPrisonName("HMP Test Prison")
+          }
+          val application1 = createApplication(user, "Referral cancelled", referringPrisonCode = omu.prisonCode)
+          val application2 = createApplication(user, "Referral cancelled", referringPrisonCode = omu.prisonCode)
+          val application3 = createApplication(user, "Referral cancelled", referringPrisonCode = omu.prisonCode)
+          val application4 = createApplication(user, "Referral withdrawn", referringPrisonCode = omu.prisonCode)
+          val application5 = createApplication(user, "Referral withdrawn", referringPrisonCode = omu.prisonCode)
 
           val expectedReferrals = listOf(
             Cas2v2ReferralHistory(
@@ -60,6 +64,12 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application1.submittedAt!!.toInstant(),
               status = application1.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = "Referral cancelled",
+              localAuthorityArea = omu.prisonName,
+              pdu = application1.preferredAreas,
+              referredBy = application1.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application1.statusUpdates!!.first().label,
             ),
             Cas2v2ReferralHistory(
               id = application2.assessment!!.id,
@@ -67,6 +77,12 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application2.submittedAt!!.toInstant(),
               status = application2.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = "Referral cancelled",
+              localAuthorityArea = omu.prisonName,
+              pdu = application2.preferredAreas,
+              referredBy = application2.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application2.statusUpdates!!.first().label,
             ),
             Cas2v2ReferralHistory(
               id = application3.assessment!!.id,
@@ -74,6 +90,12 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application3.submittedAt!!.toInstant(),
               status = application3.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = "Referral cancelled",
+              localAuthorityArea = omu.prisonName,
+              pdu = application3.preferredAreas,
+              referredBy = application3.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application3.statusUpdates!!.first().label,
             ),
             Cas2v2ReferralHistory(
               id = application4.assessment!!.id,
@@ -81,6 +103,12 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application4.submittedAt!!.toInstant(),
               status = application4.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = "Referral withdrawn",
+              localAuthorityArea = omu.prisonName,
+              pdu = application4.preferredAreas,
+              referredBy = application4.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application4.statusUpdates!!.first().label,
             ),
             Cas2v2ReferralHistory(
               id = application5.assessment!!.id,
@@ -88,6 +116,12 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
               createdAt = application5.submittedAt!!.toInstant(),
               status = application5.statusUpdates!!.first().label,
               type = type,
+              referralRejectionReason = "Referral withdrawn",
+              localAuthorityArea = omu.prisonName,
+              pdu = application5.preferredAreas,
+              referredBy = application5.createdByUser.name,
+              placementAddress = omu.prisonName,
+              placementStatus = application5.statusUpdates!!.first().label,
             ),
           )
 
@@ -107,11 +141,70 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
         }
       }
     }
+
+    @Test
+    fun `Get referral returns enriched fields`() {
+      givenACas2v2PomUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          val omu = offenderManagementUnitEntityFactory.produceAndPersist {
+            withPrisonCode("TST")
+            withPrisonName("HMP Test Prison")
+          }
+          val withdrawnApplication = createApplication(user, "Referral withdrawn", preferredAreas = "South East", referringPrisonCode = omu.prisonCode)
+
+          val response = webTestClient.get()
+            .uri("/cas2v2/external/referrals/$crn")
+            .header("Authorization", "Bearer $clientCredentialsJwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBodyList(Cas2v2ReferralHistory::class.java)
+            .returnResult()
+            .responseBody
+
+          val matched = response!!.first { it.id == withdrawnApplication.assessment!!.id }
+          assertThat(matched.referralRejectionReason).isEqualTo("Referral withdrawn")
+          assertThat(matched.placementStatus).isEqualTo("Referral withdrawn")
+          assertThat(matched.pdu).isEqualTo("South East")
+          assertThat(matched.referredBy).isEqualTo(user.name)
+          assertThat(matched.localAuthorityArea).isEqualTo(omu.prisonName)
+          assertThat(matched.placementAddress).isEqualTo(omu.prisonName)
+        }
+      }
+    }
+
+    @Test
+    fun `Get referral returns placement address from OMU prison name`() {
+      givenACas2v2PomUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          val omu = offenderManagementUnitEntityFactory.produceAndPersist {
+            withPrisonCode("TST")
+            withPrisonName("HMP Test Prison")
+          }
+          val applicationWithPrison = createApplication(user, "Active", referringPrisonCode = omu.prisonCode)
+
+          val response = webTestClient.get()
+            .uri("/cas2v2/external/referrals/$crn")
+            .header("Authorization", "Bearer $clientCredentialsJwt")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBodyList(Cas2v2ReferralHistory::class.java)
+            .returnResult()
+            .responseBody
+
+          val matched = response!!.first { it.id == applicationWithPrison.assessment!!.id }
+          assertThat(matched.placementAddress).isEqualTo(omu.prisonName)
+        }
+      }
+    }
   }
 
   private fun createApplication(
     user: Cas2UserEntity,
     label: String,
+    preferredAreas: String? = null,
+    referringPrisonCode: String? = null,
   ): Cas2ApplicationEntity {
     val statusApplication = cas2ApplicationEntityFactory.produceAndPersist {
       withSubmittedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
@@ -122,6 +215,8 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
       withCreatedByUser(user)
       withCrn(crn)
       withSubmittedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
+      preferredAreas?.let { withPreferredAreas(it) }
+      referringPrisonCode?.let { withReferringPrisonCode(it) }
       withStatusUpdates(
         mutableListOf(
           cas2StatusUpdateEntityFactory.produceAndPersist {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2TimelineEventsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OffenderManagementUnitRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.JsonMapperFactory
 import java.time.LocalDate
@@ -36,7 +37,7 @@ class Cas2v2ApplicationTransformerTest {
   private val mockCas2v2StatusUpdateTransformer = mockk<Cas2v2StatusUpdateTransformer>()
   private val mockCas2v2TimelineEventsTransformer = mockk<Cas2v2TimelineEventsTransformer>()
   private val mockCas2v2AssessmentsTransformer = mockk<Cas2v2AssessmentsTransformer>()
-
+  private val mockOffenderManagementUnitRepository = mockk<OffenderManagementUnitRepository>()
   private val objectMapper = JsonMapperFactory.createJackson3JsonMapper()
 
   private val cas2v2ApplicationsTransformer = Cas2v2ApplicationsTransformer(
@@ -46,6 +47,7 @@ class Cas2v2ApplicationTransformerTest {
     mockCas2v2StatusUpdateTransformer,
     mockCas2v2TimelineEventsTransformer,
     mockCas2v2AssessmentsTransformer,
+    mockOffenderManagementUnitRepository,
   )
 
   private val user = Cas2UserEntityFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3PremisesEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3PremisesEntityFactory.kt
@@ -60,6 +60,10 @@ class Cas3PremisesEntityFactory : Factory<Cas3PremisesEntity> {
     this.addressLine2 = { addressLine2 }
   }
 
+  fun withTown(town: String?) = apply {
+    this.town = { town }
+  }
+
   fun withNotes(notes: String) = apply {
     this.notes = { notes }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
@@ -4,13 +4,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.Cas3IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ReferralHistory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
@@ -47,11 +51,23 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
     fun `Get all referrals returns ok`() {
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
-          val assessment1 = createAssessment(user, AssessmentDecision.ACCEPTED)
-          val assessment2 = createAssessment(user, AssessmentDecision.REJECTED)
-          val assessment3 = createAssessment(user, AssessmentDecision.ACCEPTED, OffsetDateTime.now())
-          val assessment4 = createAssessment(user, null, null, user)
-          val assessment5 = createAssessment(user)
+          val premises = cas3PremisesEntityFactory.produceAndPersist {
+            withAddressLine1("10 Test Street")
+            withTown("London")
+            withPostcode("SW1A 1AA")
+            withYieldedLocalAuthorityArea { localAuthorityEntityFactory.produceAndPersist() }
+            withProbationDeliveryUnit(
+              probationDeliveryUnitFactory.produceAndPersist {
+                withProbationRegion(user.probationRegion)
+              },
+            )
+          }
+
+          val assessment1 = createAssessment(user, AssessmentDecision.ACCEPTED, premises = premises)
+          val assessment2 = createAssessment(user, AssessmentDecision.REJECTED, premises = premises)
+          val assessment3 = createAssessment(user, AssessmentDecision.ACCEPTED, OffsetDateTime.now(), premises = premises)
+          val assessment4 = createAssessment(user, null, null, user, premises = premises)
+          val assessment5 = createAssessment(user, premises = premises)
 
           val expectedReferrals = listOf(
             Cas3ReferralHistory(
@@ -60,6 +76,12 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               createdAt = assessment1.createdAt.toInstant(),
               status = TemporaryAccommodationAssessmentStatus.readyToPlace,
               type = ServiceType.CAS3,
+              referralRejectionReason = null,
+              localAuthorityArea = (assessment1.application as TemporaryAccommodationApplicationEntity).dutyToReferLocalAuthorityAreaName,
+              pdu = (assessment1.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
+              referredBy = assessment1.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas3BookingStatus.provisional.value,
             ),
             Cas3ReferralHistory(
               id = assessment2.id,
@@ -67,6 +89,12 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               createdAt = assessment2.createdAt.toInstant(),
               status = TemporaryAccommodationAssessmentStatus.rejected,
               type = ServiceType.CAS3,
+              referralRejectionReason = null,
+              localAuthorityArea = (assessment2.application as TemporaryAccommodationApplicationEntity).dutyToReferLocalAuthorityAreaName,
+              pdu = (assessment2.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
+              referredBy = assessment2.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas3BookingStatus.provisional.value,
             ),
             Cas3ReferralHistory(
               id = assessment3.id,
@@ -74,6 +102,12 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               createdAt = assessment3.createdAt.toInstant(),
               status = TemporaryAccommodationAssessmentStatus.closed,
               type = ServiceType.CAS3,
+              referralRejectionReason = null,
+              localAuthorityArea = (assessment3.application as TemporaryAccommodationApplicationEntity).dutyToReferLocalAuthorityAreaName,
+              pdu = (assessment3.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
+              referredBy = assessment3.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas3BookingStatus.provisional.value,
             ),
             Cas3ReferralHistory(
               id = assessment4.id,
@@ -81,6 +115,12 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               createdAt = assessment4.createdAt.toInstant(),
               status = TemporaryAccommodationAssessmentStatus.inReview,
               type = ServiceType.CAS3,
+              referralRejectionReason = null,
+              localAuthorityArea = (assessment4.application as TemporaryAccommodationApplicationEntity).dutyToReferLocalAuthorityAreaName,
+              pdu = (assessment4.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
+              referredBy = assessment4.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas3BookingStatus.provisional.value,
             ),
             Cas3ReferralHistory(
               id = assessment5.id,
@@ -88,6 +128,12 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               createdAt = assessment5.createdAt.toInstant(),
               status = TemporaryAccommodationAssessmentStatus.unallocated,
               type = ServiceType.CAS3,
+              referralRejectionReason = null,
+              localAuthorityArea = (assessment5.application as TemporaryAccommodationApplicationEntity).dutyToReferLocalAuthorityAreaName,
+              pdu = (assessment5.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
+              referredBy = assessment5.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas3BookingStatus.provisional.value,
             ),
           )
 
@@ -114,6 +160,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
     decision: AssessmentDecision? = null,
     completedAt: OffsetDateTime? = null,
     allocated: UserEntity? = null,
+    premises: Cas3PremisesEntity? = null,
   ): TemporaryAccommodationAssessmentEntity {
     val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
       withCrn(crn)
@@ -121,12 +168,26 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
       withProbationRegion(user.probationRegion)
       withSubmittedAt(OffsetDateTime.now())
     }
-    return temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
+    val assessment = temporaryAccommodationAssessmentEntityFactory.produceAndPersist {
       withApplication(application)
       withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
       withDecision(decision)
       withCompletedAt(completedAt)
       withAllocatedToUser(allocated)
     }
+    if (premises != null) {
+      val bedspace = cas3BedspaceEntityFactory.produceAndPersist {
+        withPremises(premises)
+      }
+      cas3BookingEntityFactory.produceAndPersist {
+        withCrn(crn)
+        withApplication(application)
+        withPremises(premises)
+        withBedspace(bedspace)
+        withStatus(Cas3BookingStatus.provisional)
+        withServiceName(ServiceName.temporaryAccommodation)
+      }
+    }
+    return assessment
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/external/Cas1ExternalReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/external/Cas1ExternalReferralsTest.kt
@@ -5,14 +5,22 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReferralHistory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1CruManagementArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.roundNanosToMillisToAccountForLossOfPrecisionInPostgres
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class Cas1ExternalReferralsTest : IntegrationTestBase() {
@@ -45,11 +53,22 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
     fun `Get all referrals returns ok`() {
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
-          val assessment1 = createCas1Assessment(crn, user, AssessmentDecision.ACCEPTED)
-          val assessment2 = createCas1Assessment(crn, user, AssessmentDecision.REJECTED)
-          val assessment3 = createCas1Assessment(crn, user, AssessmentDecision.ACCEPTED)
-          val assessment4 = createCas1Assessment(crn, user, null, user)
-          val assessment5 = createCas1Assessment(crn, user)
+          val apArea = givenAnApArea(name = "London AP Area")
+          val cruManagementArea = givenACas1CruManagementArea(name = "London CRU")
+          val premises = approvedPremisesEntityFactory.produceAndPersist {
+            withCruManagementArea(cruManagementArea)
+            withAddressLine1("10 Test Street")
+            withTown("London")
+            withPostcode("SW1A 1AA")
+            withProbationRegion(givenAProbationRegion())
+            withLocalAuthorityArea(localAuthorityEntityFactory.produceAndPersist())
+          }
+
+          val assessment1 = createCas1Assessment(crn, user, AssessmentDecision.ACCEPTED, rejectionRationale = "Not suitable", apArea = apArea, cruManagementArea = cruManagementArea, premises = premises)
+          val assessment2 = createCas1Assessment(crn, user, AssessmentDecision.REJECTED, rejectionRationale = "Not suitable", apArea = apArea, cruManagementArea = cruManagementArea, premises = premises)
+          val assessment3 = createCas1Assessment(crn, user, AssessmentDecision.ACCEPTED, rejectionRationale = "Not suitable", apArea = apArea, cruManagementArea = cruManagementArea, premises = premises)
+          val assessment4 = createCas1Assessment(crn, user, null, user, rejectionRationale = "Not suitable", apArea = apArea, cruManagementArea = cruManagementArea, premises = premises)
+          val assessment5 = createCas1Assessment(crn, user, rejectionRationale = "Not suitable", apArea = apArea, cruManagementArea = cruManagementArea, premises = premises)
 
           val expectedReferrals = listOf(
             Cas1ReferralHistory(
@@ -58,6 +77,12 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               createdAt = assessment1.createdAt.toInstant(),
               status = Cas1AssessmentStatus.completed,
               type = ServiceType.CAS1,
+              referralRejectionReason = "Not suitable",
+              localAuthorityArea = apArea.name,
+              pdu = cruManagementArea.name,
+              referredBy = assessment1.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
             ),
             Cas1ReferralHistory(
               id = assessment2.id,
@@ -65,6 +90,12 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               createdAt = assessment2.createdAt.toInstant(),
               status = Cas1AssessmentStatus.completed,
               type = ServiceType.CAS1,
+              referralRejectionReason = "Not suitable",
+              localAuthorityArea = apArea.name,
+              pdu = cruManagementArea.name,
+              referredBy = assessment2.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
             ),
             Cas1ReferralHistory(
               id = assessment3.id,
@@ -72,6 +103,12 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               createdAt = assessment3.createdAt.toInstant(),
               status = Cas1AssessmentStatus.completed,
               type = ServiceType.CAS1,
+              referralRejectionReason = "Not suitable",
+              localAuthorityArea = apArea.name,
+              pdu = cruManagementArea.name,
+              referredBy = assessment3.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
             ),
             Cas1ReferralHistory(
               id = assessment4.id,
@@ -79,6 +116,12 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               createdAt = assessment4.createdAt.toInstant(),
               status = Cas1AssessmentStatus.inProgress,
               type = ServiceType.CAS1,
+              referralRejectionReason = "Not suitable",
+              localAuthorityArea = apArea.name,
+              pdu = cruManagementArea.name,
+              referredBy = assessment4.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
             ),
             Cas1ReferralHistory(
               id = assessment5.id,
@@ -86,6 +129,12 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               createdAt = assessment5.createdAt.toInstant(),
               status = Cas1AssessmentStatus.inProgress,
               type = ServiceType.CAS1,
+              referralRejectionReason = "Not suitable",
+              localAuthorityArea = apArea.name,
+              pdu = cruManagementArea.name,
+              referredBy = assessment5.application.createdByUser.name,
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
             ),
           )
 
@@ -105,21 +154,40 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
     }
   }
 
+  @Suppress("LongParameterList")
   private fun createCas1Assessment(
     crn: String,
     user: UserEntity,
     decision: AssessmentDecision? = null,
     allocated: UserEntity? = null,
+    rejectionRationale: String? = null,
+    apArea: ApAreaEntity? = null,
+    cruManagementArea: Cas1CruManagementAreaEntity? = null,
+    premises: ApprovedPremisesEntity? = null,
   ): ApprovedPremisesAssessmentEntity {
     val application = approvedPremisesApplicationEntityFactory.produceAndPersist {
       withCrn(crn)
       withCreatedByUser(user)
+      if (apArea != null) withApArea(apArea)
+      if (cruManagementArea != null) withCruManagementArea(cruManagementArea)
     }
-    return approvedPremisesAssessmentEntityFactory.produceAndPersist {
+    val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
       withApplication(application)
       withAllocatedToUser(allocated ?: user)
       withDecision(decision)
+      withRejectionRationale(rejectionRationale)
       withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }
+    if (premises != null) {
+      cas1SpaceBookingEntityFactory.produceAndPersist {
+        withPremises(premises)
+        withApplication(application)
+        withPlacementRequest(null)
+        withCreatedBy(user)
+        withCrn(crn)
+        withActualArrivalDate(LocalDate.now())
+      }
+    }
+    return assessment
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -67,6 +68,9 @@ class Cas1AssessmentTransformerTest {
 
   @MockK
   lateinit var approvedPremisesUser: ApprovedPremisesUser
+
+  @MockK
+  lateinit var mockCas1SpaceBookingRepository: Cas1SpaceBookingRepository
 
   private val risksTransformer = RisksTransformer()
   private val jsonMapper = JsonMapperFactory.createJackson3JsonMapper()


### PR DESCRIPTION
Adds additional fields to the “external referrals / referral history” API responses across CAS1/CAS2/CAS2v2/CAS3, including referral metadata and placement/booking details.

Changes:

Extend referral history response models with rejection reason, LA area, PDU, referred-by, and placement details.
Populate the new fields in CAS1/CAS3 transformers using latest booking/space-booking lookups.
Update integration tests to assert the expanded response shapes.