### PR TITLE
FM-491: Site Closure Seed Job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SeedFileType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SeedFileType.kt
@@ -46,4 +46,5 @@ enum class SeedFileType(@get:JsonValue val value: String) {
   cas2UpdateAssessmentStatus("cas2_update_assessment_status"),
   approvedPremisesCancelOutOfServiceBeds("approved_premises_cancel_out_of_service_beds"),
   approvedPremisesUpdateOutOfServiceBeds("approved_premises_update_out_of_service_beds"),
+  approvedPremisesClosePremises("approved_premises_close_premises"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ClosePremisesSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ClosePremisesSeedJob.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedColumns
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCasResultIsSuccess
+import java.time.LocalDate
+import java.util.UUID
+
+@Component
+class Cas1ClosePremisesSeedJob(
+  private val approvedPremisesRepository: ApprovedPremisesRepository,
+  private val bedRepository: BedRepository,
+  private val cas1OutOfServiceBedService: Cas1OutOfServiceBedService,
+) : SeedJob<Cas1ClosePremisesSeedJob.CsvRow>(
+  requiredHeaders = setOf(
+    "premises_id",
+    "closure_date",
+    "notes",
+  ),
+) {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>): CsvRow {
+    val seedColumns = SeedColumns(columns)
+
+    return CsvRow(
+      premisesId = seedColumns.getUuidOrNull("premises_id")!!,
+      closureDate = seedColumns.getLocalDateOrNull("closure_date")!!,
+      notes = seedColumns.getStringOrNull("notes"),
+    )
+  }
+
+  override fun processRow(row: CsvRow) {
+    val premisesId = row.premisesId
+    val closureDate = row.closureDate
+
+    log.info("Closing premises id $premisesId on $closureDate")
+
+    val approvedPremises = approvedPremisesRepository.findByIdOrNull(premisesId)
+      ?: error("Could not find approved premises with id $premisesId")
+
+    val beds = bedRepository.findByRoomPremisesId(premisesId)
+    log.info("Setting end date for ${beds.size} beds for premises id $premisesId to $closureDate")
+    beds.forEach { bed ->
+      bed.endDate = closureDate
+      bedRepository.save(bed)
+    }
+
+    val activeOutOfServiceBeds = cas1OutOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId)
+    log.info("Setting end date for ${activeOutOfServiceBeds.size} active out of service beds for premises id $premisesId to $closureDate")
+    activeOutOfServiceBeds.forEach { outOfServiceBed ->
+      val result = cas1OutOfServiceBedService.updateOutOfServiceBed(
+        outOfServiceBedId = outOfServiceBed.id,
+        startDate = outOfServiceBed.startDate,
+        endDate = closureDate,
+        reasonId = outOfServiceBed.reason.id,
+        referenceNumber = outOfServiceBed.referenceNumber,
+        notes = row.notes ?: outOfServiceBed.notes ?: "Site Closure",
+        createdBy = null,
+      )
+      ensureEntityFromCasResultIsSuccess(result)
+    }
+
+    log.info("Updating allow new space bookings for premises id $premisesId to false")
+    approvedPremises.allowNewSpaceBookings = false
+    approvedPremisesRepository.save(approvedPremises)
+  }
+
+  data class CsvRow(
+    val premisesId: UUID,
+    val closureDate: LocalDate,
+    val notes: String?,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -11,6 +11,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1CancelOutOfServiceBedsByPremisesJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1ClosePremisesSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1CreateTestApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1CruManagementAreaSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1DomainEventReplaySeedJob
@@ -118,6 +119,7 @@ class SeedService(
         SeedFileType.cas2UpdateAssessmentStatus -> getBean(Cas2UpdateAssessmentStatusSeedJob::class)
         SeedFileType.approvedPremisesCancelOutOfServiceBeds -> getBean(Cas1CancelOutOfServiceBedsByPremisesJob::class)
         SeedFileType.approvedPremisesUpdateOutOfServiceBeds -> getBean(Cas1UpdateOutOfServiceBedsByPremisesJob::class)
+        SeedFileType.approvedPremisesClosePremises -> getBean(Cas1ClosePremisesSeedJob::class)
       }
 
       val seedStarted = LocalDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/Cas1ClosePremisesSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/Cas1ClosePremisesSeedJobTest.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremisesBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOutOfServiceBed
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import java.time.LocalDate
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class Cas1ClosePremisesSeedJobTest : SeedTestBase() {
+
+  @Test
+  fun `Closing a premises updates all beds, active out-of-service beds and disables new space bookings`() {
+    val premises = givenAnApprovedPremises()
+    val otherPremises = givenAnApprovedPremises()
+
+    val bed1 = givenAnApprovedPremisesBed(premises = premises)
+    val bed2 = givenAnApprovedPremisesBed(premises = premises)
+    val otherBed = givenAnApprovedPremisesBed(premises = otherPremises)
+
+    val oosb1 = givenAnOutOfServiceBed(bed = bed1)
+    val otherOosb = givenAnOutOfServiceBed(bed = otherBed)
+
+    val closureDate = LocalDate.now().plusMonths(6)
+
+    seed(
+      SeedFileType.approvedPremisesClosePremises,
+      rowsToCsv(
+        listOf(
+          SiteClosureCsvRow(
+            premisesId = premises.id.toString(),
+            closureDate = closureDate.toString(),
+            notes = "Closing premises",
+          ),
+        ),
+      ),
+    )
+
+    val updatedPremises = approvedPremisesRepository.findById(premises.id).get()
+    assertThat(updatedPremises.allowNewSpaceBookings).isFalse()
+
+    val updatedBed1 = bedRepository.findById(bed1.id).get()
+    assertThat(updatedBed1.endDate).isEqualTo(closureDate)
+
+    val updatedBed2 = bedRepository.findById(bed2.id).get()
+    assertThat(updatedBed2.endDate).isEqualTo(closureDate)
+
+    val updatedOosb1 = cas1OutOfServiceBedTestRepository.findById(oosb1.id).get()
+    assertThat(updatedOosb1.endDate).isEqualTo(closureDate)
+
+    val otherPremisesAfter = approvedPremisesRepository.findById(otherPremises.id).get()
+    assertThat(otherPremisesAfter.allowNewSpaceBookings).isTrue()
+
+    val otherBedAfter = bedRepository.findById(otherBed.id).get()
+    assertThat(otherBedAfter.endDate).isNull()
+
+    val otherOosbAfter = cas1OutOfServiceBedTestRepository.findById(otherOosb.id).get()
+    assertThat(otherOosbAfter.endDate).isNotEqualTo(closureDate)
+  }
+
+  private fun rowsToCsv(rows: List<SiteClosureCsvRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields(
+        "premises_id",
+        "closure_date",
+        "notes",
+      )
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedField(it.premisesId)
+        .withQuotedField(it.closureDate)
+        .withQuotedField(it.notes ?: "")
+        .newRow()
+    }
+
+    return builder.build()
+  }
+
+  data class SiteClosureCsvRow(
+    val premisesId: String,
+    val closureDate: String,
+    val notes: String?,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/unit/seed/Cas1ClosePremisesSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/unit/seed/Cas1ClosePremisesSeedJobTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.unit.seed
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verifyOrder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1ClosePremisesSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1OutOfServiceBedService
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class Cas1ClosePremisesSeedJobTest {
+  @MockK
+  private lateinit var approvedPremisesRepository: ApprovedPremisesRepository
+
+  @MockK
+  private lateinit var bedRepository: BedRepository
+
+  @MockK
+  private lateinit var cas1OutOfServiceBedService: Cas1OutOfServiceBedService
+
+  @InjectMockKs
+  private lateinit var seedJob: Cas1ClosePremisesSeedJob
+
+  @Nested
+  inner class DeserializeRow {
+    @Test
+    fun `Deserializes CSV row correctly`() {
+      val expectedPremisesId = UUID.randomUUID()
+      val inputRow = mapOf(
+        "premises_id" to expectedPremisesId.toString(),
+        "closure_date" to "2025-05-10",
+      )
+
+      val actual = seedJob.deserializeRow(inputRow)
+
+      assertThat(actual.premisesId).isEqualTo(expectedPremisesId)
+      assertThat(actual.closureDate).isEqualTo(LocalDate.of(2025, 5, 10))
+    }
+  }
+
+  @Nested
+  inner class ProcessRow {
+    @Test
+    fun `Updates premises, beds and out-of-service beds correctly`() {
+      val premisesId = UUID.randomUUID()
+      val closureDate = LocalDate.of(2025, 12, 31)
+      val row = Cas1ClosePremisesSeedJob.CsvRow(
+        premisesId = premisesId,
+        closureDate = closureDate,
+        notes = null,
+      )
+
+      val premises = ApprovedPremisesEntityFactory()
+        .withDefaults()
+        .withId(premisesId)
+        .withAllowNewSpaceBookings(true)
+        .produce()
+
+      val room = RoomEntityFactory()
+        .withDefaults()
+        .withPremises(premises)
+        .produce()
+
+      val bed1 = BedEntityFactory()
+        .withDefaults()
+        .withRoom(room)
+        .withEndDate(null)
+        .produce()
+
+      val bed2 = BedEntityFactory()
+        .withDefaults()
+        .withRoom(room)
+        .withEndDate(LocalDate.of(2026, 1, 1))
+        .produce()
+
+      val oosb1 = Cas1OutOfServiceBedEntityFactory()
+        .withBed(bed1)
+        .produce()
+      oosb1.revisionHistory += Cas1OutOfServiceBedRevisionEntityFactory()
+        .withOutOfServiceBed(oosb1)
+        .produce()
+
+      every { approvedPremisesRepository.findByIdOrNull(premisesId) } returns premises
+      every { approvedPremisesRepository.save(any()) } returnsArgument 0
+      every { bedRepository.findByRoomPremisesId(premisesId) } returns listOf(bed1, bed2)
+      every { bedRepository.save(any()) } returnsArgument 0
+      every { cas1OutOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId) } returns listOf(oosb1)
+      every {
+        cas1OutOfServiceBedService.updateOutOfServiceBed(
+          outOfServiceBedId = any(),
+          startDate = any(),
+          endDate = any(),
+          reasonId = any(),
+          referenceNumber = any(),
+          notes = any(),
+          createdBy = any(),
+        )
+      } returns CasResult.Success(oosb1)
+
+      seedJob.processRow(row)
+
+      verifyOrder {
+        approvedPremisesRepository.findByIdOrNull(premisesId)
+        bedRepository.findByRoomPremisesId(premisesId)
+        bedRepository.save(match { it.id == bed1.id && it.endDate?.isEqual(closureDate) == true })
+        bedRepository.save(match { it.id == bed2.id && it.endDate?.isEqual(closureDate) == true })
+        cas1OutOfServiceBedService.getActiveOutOfServiceBedsForPremisesId(premisesId)
+        cas1OutOfServiceBedService.updateOutOfServiceBed(
+          outOfServiceBedId = oosb1.id,
+          startDate = oosb1.startDate,
+          endDate = closureDate,
+          reasonId = oosb1.reason.id,
+          referenceNumber = oosb1.referenceNumber,
+          notes = oosb1.notes,
+          createdBy = null,
+        )
+        approvedPremisesRepository.save(match { it.id == premisesId && !it.allowNewSpaceBookings })
+      }
+
+      confirmVerified()
+    }
+  }
+}


### PR DESCRIPTION
Added a seed job for site closures.
- Closes available beds up to the specified closure date
- Updates the OOSDB end date to match the closure date
- Disables new space bookings for the premises

