### PR TITLE
Rename `SPLIT_INDEX` to `splitIndex` in `split_tests`

### DIFF
--- a/script/split_tests
+++ b/script/split_tests
@@ -5,7 +5,7 @@ SPLIT_TOTAL=$2
 
 TESTS="$(find src/test/kotlin -type d -name integration | \
   xargs -I{} find "{}" -type f -name "*Test.kt" | \
-  awk -v splitTotal=$SPLIT_TOTAL -v splitIndex=$SPLIT_INDEX 'NR % splitTotal == $SPLIT_INDEX % splitTotal' | \
+  awk -v splitTotal=$SPLIT_TOTAL -v splitIndex=$SPLIT_INDEX 'NR % splitTotal == splitIndex % splitTotal' | \
   tr '\n' ',' | sed 's/,$//')"
 
 echo "test-suite=$TESTS" >> "$GITHUB_OUTPUT"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -79,8 +79,6 @@ class ExceptionHandling(
 
     log.error("Unhandled exception type, returning generic 500 response", throwable)
 
-    sentryService.captureException(throwable)
-
     // We throw this instead of an InternalServerErrorProblem to avoid the Sentry Alert
     // being raised again by [ExceptionHandling.logInternalServerErrorProblem]
     return UnhandledExceptionProblem(


### PR DESCRIPTION
API pipeline is currently splitting the tests into 12 jobs however the same integration tests are run in each of the 12 jobs.

See [here](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/24074147344/job/70218328292#step:7:3) and [here](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/24074147344/job/70218328297#step:7:3).

Since `SPLIT_INDEX` is undefined in the script the awk command in `split_tests` is using a default value of 0 instead of the value passed to the script as a command line argument.

It is doing:  `awk 'NR % 12 ==  0 % 12'` for each of the 12 runs which will write the same test files to the `TESTS` environment variable which is used by the gradle task.

This PR fixes the typo and fixes the cause of an [integration test](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/b400645cea72905134dbfe76c2ddc49758ba3e43/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ExceptionHandlingTest.kt#L251) that should have been failing in the pipeline due to duplicate `sentryService.captureException()` calls.

For the `UnhandledException` scenario we would have logged this exception twice all along, however we have recently changed `ExceptionHandling` to use `sentryService.captureException()` throughout instead of `Sentry.captureException()` and `sentryService.captureException()` combined and since this scenario logged to Sentry twice (but only using `SentryService` once), this issue had been masked.  