### PR TITLE
Use `hmpps-kotlin-spring-boot-starter-test`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,13 +74,8 @@ dependencies {
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.14.9")
   testImplementation("com.github.tomakehurst:wiremock-standalone:3.0.1")
-  testImplementation("io.jsonwebtoken:jjwt-api:0.12.6")
-  testRuntimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
-  testRuntimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
-  testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    exclude(module = "mockito-core")
-  }
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.8.2")
 
   testImplementation("com.ninja-squad:springmockk:4.0.2")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -1,20 +1,23 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.util
 
 import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.stereotype.Component
+import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 import java.security.interfaces.RSAPublicKey
 import java.time.Duration
-import java.util.Date
 import java.util.UUID
 
 @Component
 class JwtAuthHelper {
   private val keyPair = Jwts.SIG.RS256.keyPair().build()
+
+  @Autowired
+  private lateinit var jwtAuthHelper: JwtAuthorisationHelper
 
   @Bean
   @Primary
@@ -37,22 +40,16 @@ class JwtAuthHelper {
     authSource: String = if (username == null) "none" else "delius",
     expiryTime: Duration = Duration.ofHours(1),
     jwtId: String = UUID.randomUUID().toString(),
-  ): String = mutableMapOf<String, Any>()
-    .also { it["user_name"] = username ?: "integration-test-client-id" }
-    .also { it["client_id"] = "integration-test-client-id" }
-    .also { it["grant_type"] = "client_credentials" }
-    .also { it["auth_source"] = authSource }
-    .also { roles?.let { roles -> it["authorities"] = roles } }
-    .also { scope?.let { scope -> it["scope"] = scope } }
-    .let {
-      Jwts.builder()
-        .id(jwtId)
-        .subject(username ?: "integration-test-client-id")
-        .claims(it.toMap())
-        .expiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
-        .signWith(keyPair.private, Jwts.SIG.RS256)
-        .compact()
-    }
+  ): String = jwtAuthHelper.createJwtAccessToken(
+    grantType = "client_credentials",
+    clientId = "integration-test-client-id",
+    username = username,
+    scope = scope,
+    roles = roles,
+    authSource = authSource,
+    expiryTime = expiryTime,
+    jwtId = jwtId,
+  )
 
   internal fun createValidNomisAuthorisationCodeJwt(username: String = "username", roles: List<String>? = listOf("ROLE_POM")) = createAuthorizationCodeJwt(
     subject = username,
@@ -97,18 +94,13 @@ class JwtAuthHelper {
     authSource: String = "delius",
     expiryTime: Duration = Duration.ofHours(1),
     jwtId: String = UUID.randomUUID().toString(),
-  ): String = mutableMapOf<String, Any>()
-    .also { it["auth_source"] = authSource }
-    .also { it["user_id"] = UUID.randomUUID().toString() }
-    .also { roles?.let { roles -> it["authorities"] = roles } }
-    .also { scope?.let { scope -> it["scope"] = scope } }
-    .let {
-      Jwts.builder()
-        .setId(jwtId)
-        .setSubject(subject)
-        .addClaims(it.toMap())
-        .setExpiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
-        .signWith(SignatureAlgorithm.RS256, keyPair.private)
-        .compact()
-    }
+  ): String = jwtAuthHelper.createJwtAccessToken(
+    grantType = "authorization_code",
+    clientId = subject,
+    scope = scope,
+    roles = roles,
+    authSource = authSource,
+    expiryTime = expiryTime,
+    jwtId = jwtId,
+  )
 }


### PR DESCRIPTION
Using this library allows us to inherit various test dependencies instead of specifying them explicitly. We can also then make use of the `JwtAuthorisationHelper`, simplifying our code.