### PR TITLE
Add full request/response logging in ITs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.8.2")
 
   testImplementation("com.ninja-squad:springmockk:4.0.2")
+  testImplementation("org.zalando:logbook-spring-boot-starter:4.0.3")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.6.3")
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -224,7 +224,14 @@ notify:
 scheduling:
   enable: false
 
-logging.level.org.springframework.jdbc.core.JdbcTemplate: debug
+logbook:
+  format:
+    style: json
+
+logging:
+  level:
+    logging.level.org.springframework.jdbc.core.JdbcTemplate: debug
+    org.zalando.logbook: TRACE
 
 refresh-inmate-details-cache:
   lock-at-least-for: 1s


### PR DESCRIPTION
Once we've upgraded to spring 4 we can enable the jackson 3 based pretty printer using 

```
import org.springframework.context.annotation.Bean
import org.springframework.context.annotation.Configuration
import org.zalando.logbook.HttpLogFormatter
import org.zalando.logbook.json.JsonHttpLogFormatter


@Configuration
class LogbookConfig {

  @Bean
  fun httpLogFormatter(): HttpLogFormatter {
    return JsonHttpLogFormatter()
  }

}
```