### PR TITLE
Add ability to run admin jobs without curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY --chown=appuser:appgroup /script/run_seed_from_excel_job ./
 COPY --chown=appuser:appgroup /script/run_seed_from_excel_directory_job ./
 COPY --chown=appuser:appgroup /script/run_migration_job ./
 COPY --chown=appuser:appgroup /script/clear_cache ./
+COPY --chown=appuser:appgroup /script/invoke_admin_command ./
 RUN mkdir /tmp/seed && chown appuser:appgroup /tmp/seed && chmod +x /app/run_seed_job && chmod +x /app/run_seed_from_excel_job && chmod +x /app/run_seed_from_excel_directory_job && chmod +x /app/run_migration_job && chmod +x /app/clear_cache
 
 ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-XX:+AlwaysActAsServerClassMachine", "-javaagent:agent.jar", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,3 +241,7 @@ tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
     exclude("**/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/**")
   }
 }
+
+tasks.register("printRuntimeClasspath") {
+  println(sourceSets.main.get().runtimeClasspath.asPath)
+}

--- a/script/invoke_admin_command
+++ b/script/invoke_admin_command
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+invoke_admin_command() {
+  COMMAND="$1"
+  JAVA_TOOL_OPTIONS="-Xmx50m"
+
+  if [[ "$OSTYPE" =~ ^darwin ]]; then
+      cd $script_dir/..
+      java -cp "../build/classes/kotlin/main:$( ./gradlew --quiet printRuntimeClasspath )" $COMMAND
+  else
+      java -cp app.jar $COMMAND
+  fi
+}

--- a/script/run_migration_job
+++ b/script/run_migration_job
@@ -1,14 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/run_migration_job: Run a migration job for given type.  e.g.
 #                           script/run_migration_job update_all_users_from_community_api
 
 set -e
 
-curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/migration-job' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "jobType": "'$1'"
-}'
+cd "$(dirname "$0")"
+script_dir="$(pwd)"
+. "$script_dir"/invoke_admin_command
+
+invoke_admin_command "uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd.RunMigrationJobCommand $1"
 
 echo "Requested job - check the application logs for processing status"

--- a/script/run_seed_from_excel_directory_job
+++ b/script/run_seed_from_excel_directory_job
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -11,11 +11,10 @@ then
   exit 1
 fi
 
-curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/seedFromExcel/directory' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "seedType": "'"$SEED_JOB_ID"'",
-    "directoryName": "'"$DIRECTORY_NAME"'"
-}'
+cd "$(dirname "$0")"
+script_dir="$(pwd)"
+. "$script_dir"/invoke_admin_command
+
+invoke_admin_command "uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd.RunSeedFromExcelDirectoryJobCommand $1 $2"
 
 echo "Requested job - check the application logs for processing status"

--- a/script/run_seed_from_excel_job
+++ b/script/run_seed_from_excel_job
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/run_seed_job_from_excel: Run a seed job for given type and name of XLSX file in seed directory.  e.g.
 #                      script/run_seed_job_from_excel approved_premises ap_upload
@@ -15,11 +15,11 @@ then
   exit 1
 fi
 
-curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/seedFromExcel/file' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "seedType": "'"$SEED_JOB_ID"'",
-    "fileName": "'"$FILE_NAME"'"
-}'
+cd "$(dirname "$0")"
+script_dir="$(pwd)"
+. "$script_dir"/invoke_admin_command
+
+invoke_admin_command "uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd.RunSeedFromExcelJobCommand $1 $2"
 
 echo "Requested job - check the application logs for processing status"
+

--- a/script/run_seed_job
+++ b/script/run_seed_job
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/run_seed_job: Run a seed job for given type and name of CSV file in seed directory.  e.g.
 #                      script/run_seed_job approved_premises ap_upload
@@ -6,11 +6,10 @@
 
 set -e
 
-curl --fail --show-error --location --request POST 'http://127.0.0.1:8080/seed' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "seedType": "'$1'",
-    "fileName": "'$2'"
-}'
+cd "$(dirname "$0")"
+script_dir="$(pwd)"
+. "$script_dir"/invoke_admin_command
+
+invoke_admin_command "uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd.RunSeedJobCommand $1 $2"
 
 echo "Requested job - check the application logs for processing status"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/InvokeAdminJobEndpoint.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/InvokeAdminJobEndpoint.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlin.system.exitProcess
+
+@SuppressWarnings("MagicNumber", "TooGenericExceptionCaught")
+object InvokeAdminJobEndpoint {
+
+  fun invokeEndpoint(
+    path: String,
+    map: Map<String, String>,
+  ) {
+    try {
+      val client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .build()
+
+      val jsonBody = JsonMapper().writeValueAsString(map)
+
+      val url = "http://127.0.0.1:8080/$path"
+      println("Invoking $url with arguments $map")
+
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofSeconds(30))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+        .build()
+
+      val response = client.send(
+        request,
+        HttpResponse.BodyHandlers.ofString(),
+      )
+
+      if (response.statusCode() !in 200..299) {
+        System.err.println(
+          "Request failed (${response.statusCode()}):\n${response.body()}",
+        )
+        exitProcess(1)
+      }
+
+      println("Job triggered successfully.")
+    } catch (ex: Exception) {
+      System.err.println("Request failed: ${ex.message}")
+      exitProcess(1)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunMigrationJobCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunMigrationJobCommand.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd
+
+import kotlin.system.exitProcess
+
+object RunMigrationJobCommand {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    if (args.isEmpty()) {
+      System.err.println("Usage: RunMigrationJobCommand <migration_job_id>")
+      exitProcess(1)
+    }
+
+    InvokeAdminJobEndpoint.invokeEndpoint(
+      "migration-job",
+      mapOf(
+        "jobType" to args[0],
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunSeedFromExcelDirectoryJobCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunSeedFromExcelDirectoryJobCommand.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd
+
+import kotlin.system.exitProcess
+
+object RunSeedFromExcelDirectoryJobCommand {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    if (args.size < 2) {
+      System.err.println("Usage: RunSeedFromExcelDirectoryJobCommand <seed_type> <directory_name>")
+      exitProcess(1)
+    }
+
+    InvokeAdminJobEndpoint.invokeEndpoint(
+      "seedFromExcel/directory",
+      mapOf(
+        "seedType" to args[0],
+        "directoryName" to args[1],
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunSeedFromExcelJobCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunSeedFromExcelJobCommand.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd
+
+import kotlin.system.exitProcess
+
+object RunSeedFromExcelJobCommand {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    if (args.size < 2) {
+      System.err.println("Usage: RunSeedFromExcelJobCommand <seed_type> <file_name>")
+      exitProcess(1)
+    }
+
+    InvokeAdminJobEndpoint.invokeEndpoint(
+      "seedFromExcel/file",
+      mapOf(
+        "seedType" to args[0],
+        "fileName" to args[1],
+      ),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunSeedJobCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cmd/RunSeedJobCommand.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cmd
+
+import kotlin.system.exitProcess
+
+object RunSeedJobCommand {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    if (args.size < 2) {
+      System.err.println("Usage: RunSeedJobCommand <seed_type> <file_name>")
+      exitProcess(1)
+    }
+
+    InvokeAdminJobEndpoint.invokeEndpoint(
+      "seed",
+      mapOf(
+        "seedType" to args[0],
+        "fileName" to args[1],
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Curl is no longer available in our docker base image.

Curl was previously used to invoke administration endpoints that were limited to calls originating from localhost (e.g seed/migration).

This commit adds a small Kotlin client for each of the administration endpoints and updates the admin scripts to make use of this client to call the endpoints instead. This is a temporary solution to allow us to continue running admin tasks.