### PR TITLE
Remove `bootRunLocal`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,20 +115,6 @@ sourceSets {
   }
 }
 
-// this is deprecated in favour of bootRunDebug, which does not set an active profile
-// it will be removed once ap-tools has been updated to use bootRunDebug
-tasks.register("bootRunLocal") {
-  group = "application"
-  description = "Runs this project as a Spring Boot application with the local profile"
-  doFirst {
-    tasks.bootRun.configure {
-      systemProperty("spring.profiles.active", "local")
-      jvmArgs("-Xmx512m", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=32323")
-    }
-  }
-  finalizedBy("bootRun")
-}
-
 tasks.register("bootRunDebug") {
   group = "application"
   description = "Runs this project as a Spring Boot application with debug configuration"


### PR DESCRIPTION
This has long been superceeded by `bootRunDebug`

