### PR TITLE
Allow null referringPrisonCode in cas2v2 submitted report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2SubmittedApplicationReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2SubmittedApplicationReport.kt
@@ -58,7 +58,7 @@ interface Cas2SubmittedApplicationReportRow {
   fun getSubmittedAt(): String
   fun getPersonNoms(): String
   fun getPersonCrn(): String
-  fun getReferringPrisonCode(): String
+  fun getReferringPrisonCode(): String?
   fun getPreferredAreas(): String?
   fun getHdcEligibilityDate(): LocalDate?
   fun getConditionalReleaseDate(): LocalDate?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/reporting/model/SubmittedApplicationReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/reporting/model/SubmittedApplicationReportRow.kt
@@ -8,7 +8,7 @@ data class SubmittedApplicationReportRow(
   val applicationId: String,
   val personCrn: String,
   val personNoms: String,
-  val referringPrisonCode: String,
+  val referringPrisonCode: String?,
   val preferredAreas: String?,
   val hdcEligibilityDate: LocalDate?,
   val conditionalReleaseDate: LocalDate?,


### PR DESCRIPTION
This fixes an [issue](https://mojdt.slack.com/archives/C08KN9XMRUK/p1777995077350009) with `referringPrisonCode` being null for cas2v2.

