### PR TITLE
FM-496 Align dev and test memory usage

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -5,15 +5,15 @@ generic-service:
   serviceAccountName: hmpps-community-accommodation-api-service-account
   replicaCount: 2
 
-  ingress:
-    host: approved-premises-api-dev.hmpps.service.justice.gov.uk
-    tlsSecretName: hmpps-approved-premises-api-dev-cert
-
   resources:
     limits:
       memory: 2Gi
     requests:
       memory: 1.5Gi
+
+  ingress:
+    host: approved-premises-api-dev.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-approved-premises-api-dev-cert
 
   env:
     JAVA_TOOL_OPTIONS: "-Xmx800m"

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -11,12 +11,12 @@ generic-service:
 
   resources:
     limits:
-      memory: 1.5Gi
+      memory: 2Gi
     requests:
-      memory: 1Gi
+      memory: 1.5Gi
 
   env:
-    JAVA_TOOL_OPTIONS: "-Xmx400m"
+    JAVA_TOOL_OPTIONS: "-Xmx800m"
     SPRING_PROFILES_ACTIVE: dev
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.nonprod.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -7,9 +7,9 @@ generic-service:
 
   resources:
     limits:
-      memory: 3Gi
+      memory: 2Gi
     requests:
-      memory: 2.5Gi
+      memory: 1.5Gi
 
   ingress:
     host: approved-premises-api-test.hmpps.service.justice.gov.uk


### PR DESCRIPTION
During the spring boot 4 upgrade we discovered that there was insufficient heap memory allocated in dev for spring boot 4 to start. Once it had started heap memory usage settled down to a similar level as that used by spring boot 3.

This commit increases the heap size in `dev` to `800mb`, matching the current usage from `test`. This commit also decreases the total RAM in test to 2GB, as 3GB was not required.