### PR TITLE
Fix active profile logging

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/EnvironmentService.kt
@@ -13,7 +13,7 @@ class EnvironmentService(
 
   @PostConstruct
   fun logProfiles() {
-    log.info("Active profiles are ${environment.activeProfiles}")
+    log.info("Active profiles are ${environment.activeProfiles.toList()}")
   }
 
   fun isLocalDev() = profileActive("localdev")


### PR DESCRIPTION
Before this commit we were applying `toString` on an array, which doesn’t produce a useful output

