### PR TITLE
Add seed job to correct CAS3 postcodes.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SeedFileType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SeedFileType.kt
@@ -47,4 +47,5 @@ enum class SeedFileType(@get:JsonValue val value: String) {
   approvedPremisesCancelOutOfServiceBeds("approved_premises_cancel_out_of_service_beds"),
   approvedPremisesUpdateOutOfServiceBeds("approved_premises_update_out_of_service_beds"),
   approvedPremisesClosePremises("approved_premises_close_premises"),
+  cas3UpdatePremisesPostcode("cas3_update_premises_postcode"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/seed/Cas3UpdatePremisesPostcodeSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/seed/Cas3UpdatePremisesPostcodeSeedJob.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.seed
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesRepository
+import java.util.UUID
+
+@Component
+class Cas3UpdatePremisesPostcodeSeedJob(
+  private val cas3PremisesRepository: Cas3PremisesRepository,
+) : uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.SeedJob<Cas3UpdatePostcodeRow>(
+  requiredHeaders = setOf("cas3PremisesId", "postcode"),
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  override fun deserializeRow(columns: Map<String, String>) = Cas3UpdatePostcodeRow(
+    cas3PremisesId = UUID.fromString(columns["cas3PremisesId"]),
+    postcode = columns["postcode"]!!.trim(),
+  )
+
+  override fun processRow(row: Cas3UpdatePostcodeRow) {
+    val cas3PremisesId = row.cas3PremisesId
+    val postcode = row.postcode
+
+    cas3PremisesRepository.findByIdOrNull(cas3PremisesId)?.let {
+      log.info("Updating postcode from {} to {} for CAS3 Premises with id: {}", it.postcode, postcode, cas3PremisesId)
+      it.postcode = postcode
+      cas3PremisesRepository.save(it)
+    } ?: log.warn("Cas3Premises with id: {} not found", cas3PremisesId)
+  }
+}
+
+data class Cas3UpdatePostcodeRow(
+  val cas3PremisesId: UUID,
+  val postcode: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/seed/SeedService.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.seed.Cas2v2Applic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.seed.Cas2v2UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.seed.Cas3AssignApplicationToPduSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.seed.Cas3ReferralRejectionSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.seed.Cas3UpdatePremisesPostcodeSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.seed.Cas3UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.findRootCause
@@ -120,6 +121,7 @@ class SeedService(
         SeedFileType.approvedPremisesCancelOutOfServiceBeds -> getBean(Cas1CancelOutOfServiceBedsByPremisesJob::class)
         SeedFileType.approvedPremisesUpdateOutOfServiceBeds -> getBean(Cas1UpdateOutOfServiceBedsByPremisesJob::class)
         SeedFileType.approvedPremisesClosePremises -> getBean(Cas1ClosePremisesSeedJob::class)
+        SeedFileType.cas3UpdatePremisesPostcode -> getBean(Cas3UpdatePremisesPostcodeSeedJob::class)
       }
 
       val seedStarted = LocalDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/seed/Cas3UpdatePremisesPostcodeSeedJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/seed/Cas3UpdatePremisesPostcodeSeedJobTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.seed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.givens.givenACas3Premises
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.seed.Cas3UpdatePostcodeRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
+import java.util.UUID
+
+class Cas3UpdatePremisesPostcodeSeedJobTest : SeedTestBase() {
+  @Test
+  fun `successfully updates a postcode for a cas3 premises`() {
+    val cas3PremisesId = UUID.randomUUID()
+    val postcode = "SOME TEST POSTCODE (!)"
+    givenACas3Premises(id = cas3PremisesId, postCode = postcode)
+
+    val contents = rowsToCsv(listOf(Cas3UpdatePostcodeRow(cas3PremisesId = cas3PremisesId, postcode = "AA11 223")))
+
+    seed(SeedFileType.cas3UpdatePremisesPostcode, contents)
+
+    val updated = cas3PremisesRepository.findByIdOrNull(cas3PremisesId)!!
+    assertThat(updated.postcode).isEqualTo("AA11 223")
+  }
+
+  private fun rowsToCsv(rows: List<Cas3UpdatePostcodeRow>): String {
+    val builder = CsvBuilder()
+      .withUnquotedFields("cas3PremisesId", "postcode")
+      .newRow()
+
+    rows.forEach {
+      builder
+        .withQuotedFields(it.cas3PremisesId, it.postcode)
+        .newRow()
+    }
+
+    return builder.build()
+  }
+}


### PR DESCRIPTION
This PR creates a seed job so a postcode can be updated by providing the cas3premisesId and the new value in a csv file.