### PR TITLE
FM-574 Trim and uppercase post code when creating CAS 3 v2 domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2DomainEventBuilder.kt
@@ -338,7 +338,7 @@ class Cas3v2DomainEventBuilder(
     premises = Premises(
       addressLine1 = booking.premises.addressLine1,
       addressLine2 = booking.premises.addressLine2,
-      postcode = booking.premises.postcode,
+      postcode = booking.premises.postcode.trim().uppercase(),
       town = booking.premises.town,
       region = booking.premises.probationDeliveryUnit.probationRegion.name,
     ),
@@ -391,7 +391,7 @@ class Cas3v2DomainEventBuilder(
     premises = Premises(
       addressLine1 = booking.premises.addressLine1,
       addressLine2 = booking.premises.addressLine2,
-      postcode = booking.premises.postcode,
+      postcode = booking.premises.postcode.trim().uppercase(),
       town = booking.premises.town,
       region = booking.premises.probationDeliveryUnit.probationRegion.name,
     ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2DomainEventBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2DomainEventBuilderTest.kt
@@ -156,7 +156,7 @@ class Cas3v2DomainEventBuilderTest {
     val notes = "Some notes about the arrival"
 
     val probationRegion = probationRegionEntity()
-    val premises = cas3PremisesEntity(probationRegion)
+    val premises = cas3PremisesEntity(probationRegion, postcode = "dk8 4ag ")
     val user = userEntity(probationRegion)
     val application = temporaryAccommodationApplicationEntity(user, probationRegion)
 
@@ -178,7 +178,7 @@ class Cas3v2DomainEventBuilderTest {
       assertThat(data.bookingUrl.toString()).isEqualTo("http://api/premises/${premises.id}/bookings/${booking.id}")
       assertThat(data.premises.addressLine1).isEqualTo(premises.addressLine1)
       assertThat(data.premises.addressLine2).isEqualTo(premises.addressLine2)
-      assertThat(data.premises.postcode).isEqualTo(premises.postcode)
+      assertThat(data.premises.postcode).isEqualTo("DK8 4AG")
       assertThat(data.premises.town).isEqualTo(premises.town)
       assertThat(data.premises.region).isEqualTo(premises.probationDeliveryUnit.probationRegion.name)
       assertThat(data.arrivedAt).isEqualTo(arrivalDateTime)
@@ -237,7 +237,7 @@ class Cas3v2DomainEventBuilderTest {
     val moveOnCategoryLabel = "RTC"
 
     val probationRegion = probationRegionEntity()
-    val premises = cas3PremisesEntity(probationRegion)
+    val premises = cas3PremisesEntity(probationRegion, postcode = "dk8 4ag ")
     val user = userEntity(probationRegion)
     val application = temporaryAccommodationApplicationEntity(user, probationRegion)
     val booking = cas3BookingEntity(premises, application)
@@ -261,7 +261,7 @@ class Cas3v2DomainEventBuilderTest {
       assertThat(data.bookingUrl.toString()).isEqualTo("http://api/premises/${premises.id}/bookings/${booking.id}")
       assertThat(data.premises.addressLine1).isEqualTo(premises.addressLine1)
       assertThat(data.premises.addressLine2).isEqualTo(premises.addressLine2)
-      assertThat(data.premises.postcode).isEqualTo(premises.postcode)
+      assertThat(data.premises.postcode).isEqualTo("DK8 4AG")
       assertThat(data.premises.town).isEqualTo(premises.town)
       assertThat(data.premises.region).isEqualTo(premises.probationDeliveryUnit.probationRegion.name)
       assertThat(data.departedAt).isEqualTo(departureDateTime.toInstant())
@@ -552,13 +552,14 @@ class Cas3v2DomainEventBuilderTest {
     .withProbationRegion(probationRegion)
     .produce()
 
-  private fun cas3PremisesEntity(probationRegion: ProbationRegionEntity) = Cas3PremisesEntityFactory()
+  private fun cas3PremisesEntity(probationRegion: ProbationRegionEntity, postcode: String? = null) = Cas3PremisesEntityFactory()
     .withProbationDeliveryUnit(
       ProbationDeliveryUnitEntityFactory()
         .withProbationRegion(probationRegion)
         .produce(),
     )
     .withLocalAuthorityArea(LocalAuthorityEntityFactory().produce())
+    .apply { if (postcode != null) withPostcode(postcode) }
     .produce()
 
   private fun probationRegionEntity() = ProbationRegionEntityFactory()


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-574

We have some existing postcodes with trailing spaces in the database. Furthermore, when postcodes are entered in NDelius they are automatically uppercased.

To ensure compatibility with NDelius trim and uppercase all postcodes before adding them to domain events in `Cas3v2DomainEventBuilder`

`postcode` is required to construct `CAS3PersonArrivedEventDetails` in `createCas3PersonArrivedEventDetails()` which is called by `getPersonArrivedDomainEvent()` and `buildPersonArrivedUpdatedDomainEvent()`. 

`postcode` is also required to construct `CAS3PersonDepartedEventDetails` in `buildCAS3PersonDepartedEventDetail()` which is called by `getPersonDepartedDomainEvent()` and `buildDepartureUpdatedDomainEvent`().

Tasks:

Trim and uppercase post code during instantiation of `CAS3PersonArrivedEventDetails` and `CAS3PersonDepartedEventDetails`.

