### PR TITLE
Set duration on CAS1 seeded test apps

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
@@ -243,6 +243,7 @@ class Cas1ApplicationSeedService(
         releaseType = ReleaseTypeOption.licence,
         targetLocation = postcodeDistrictRepository.findAll()[0].outcode,
         arrivalDate = LocalDate.of(2030, 1, 1),
+        duration = 28,
         sentenceType = SentenceTypeOption.ipp,
         situation = SituationOption.bailSentence,
         applicantUserDetails = Cas1ApplicationUserDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -371,7 +371,7 @@ class ApprovedPremisesApplicationEntity(
   /**
    * If a request for placement was made in the original application, this value
    * will provide the requested arrival date at midnight in UTC
-   * (See [ApplicationService.getArrivalDate])
+   * (See [Cas1ApplicationCreationService.getArrivalDate])
    *
    * Ideally we'd persist this as a date only (as is provided by the UI)
    */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -147,6 +147,9 @@ data class PlacementApplicationEntity(
    */
   var expectedArrival: LocalDate? = null,
 
+  /**
+   * If [submittedAt] is not null, this value will be set. Use [placementDates()] to access.
+   */
   var requestedDuration: Int? = null,
 
   var authorisedDuration: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequestEntity.kt
@@ -220,7 +220,7 @@ data class PlacementRequestEntity(
    * This property is used to identify such instances
    *
    * Note that we also populate [PlacementApplicationPlaceholderEntity] for any initial request
-   * for placements to support reporting on initial requests before a [PlcementRequestEntity]
+   * for placements to support reporting on initial requests before a [PlacementRequestEntity]
    * exists
    */
   fun isForLegacyInitialRequestForPlacement() = placementApplication == null


### PR DESCRIPTION
The value of `Cas1Application.duration` should always be set of the `arrivalDate` has been set. This commit fixes the seeded test applications to ensure this is the case.

This logic was broken as part of the migration work to ensure all placement requests have a corresponding placement application