### PR TITLE
FM-496 - Use latest hmpps gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.2.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.2.5"
   kotlin("plugin.spring") version "2.3.20"
   kotlin("plugin.jpa") version "2.3.20"
   id("dev.detekt") version "2.0.0-alpha.2"


### PR DESCRIPTION
See https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/10.x.md

pins netty version due to vulnerability and supresses a false positive vulnerability