### PR TITLE
Use hmpps owasp supression list

### DIFF
--- a/.cas-api-dependency-check-ignore.xml
+++ b/.cas-api-dependency-check-ignore.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- If adding an entry to this file, also ignore the vulnerability in github here - https://github.com/ministryofjustice/hmpps-approved-premises-api/security/code-scanning -->
+<!-- This is in addition to the baseline ignore file provided by hmpps-gradle-spring-boot
+     see https://github.com/ministryofjustice/hmpps-gradle-spring-boot#owasp-dependency-check-and-suppression-files -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
   kotlin("plugin.spring") version "2.3.20"
   kotlin("plugin.jpa") version "2.3.20"
   id("dev.detekt") version "2.0.0-alpha.2"
-  id("org.owasp.dependencycheck") version "12.2.1"
 }
 
 kotlin {
@@ -216,7 +215,7 @@ detekt {
 }
 
 dependencyCheck {
-  suppressionFile = ".dependencycheckignore.xml"
+  suppressionFiles.add(".cas-api-dependency-check-ignore.xml")
 }
 
 tasks.withType<dev.detekt.gradle.Detekt>().configureEach {


### PR DESCRIPTION
Before this commit we define our own owasp supression file that overwrote the hmpps version. Following guidance from the [hmpps gradle plugin](https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/README.md#owasp-dependency-check-and-suppression-files) we have changed how this is configured to supplement the baseline supressions