### PR TITLE
Fix Swagger UI & Disable in Prod/PreProd

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -46,6 +46,9 @@ generic-service:
     NOTIFY_MODE: TEST_AND_GUEST_LIST
     NOTIFY_LOG_EMAILS: false
 
+    SPRINGDOC_API_DOCS_ENABLED: false
+    SPRINGDOC_SWAGGER_UI_ENABLED: false
+    
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -46,6 +46,9 @@ generic-service:
     NOTIFY_LOG_EMAILS: false
     HMPPS_SQS_USE_WEB_TOKEN: true
 
+    SPRINGDOC_API_DOCS_ENABLED: false
+    SPRINGDOC_SWAGGER_UI_ENABLED: false
+
     URL-TEMPLATES_FRONTEND_APPLICATION: https://approved-premises.hmpps.service.justice.gov.uk/applications/#id
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,8 +150,6 @@ spring:
 
 springdoc:
   swagger-ui:
-    # advised by https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/10.x.md#1021
-    version: 5.32.2
     urls-primary-name: "All CAS"
   remove-broken-reference-definitions: false
   writer-with-order-by-keys: true


### PR DESCRIPTION
This is fixed by removing an incorrect swagger-ui pin

This pin was added when trying to fix an issue with nulls and swagger ui. The ultimate solution was to pin the `springdoc-openapi-starter-webmvc-ui` version instead

This PR also disables swagger/open api in prod/preprod