### PR TITLE
Improve CAS2v2 return types and documentation

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -37,6 +37,9 @@ complexity:
       # dependencies required by each one that would violate this rule.
       - org.springframework.stereotype.*
       - uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1Controller
+      - uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.controller.Cas2Controller
+      - uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.controller.Cas2v2Controller
+      - uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller.Cas3Controller
       # Entities typically have large constructors, reflecting the columns in the database tables. Trying to reduce
       # the number of arguments is non-trivial and may result in worse performance and an unnecessarily fragmented
       # database design.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2UserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2UserEntity.kt
@@ -19,6 +19,10 @@ import java.util.UUID
 
 enum class Cas2UserType(val authSource: String) {
   DELIUS("delius"),
+
+  /**
+   * AKA DPS
+   */
   NOMIS("nomis"),
   EXTERNAL("auth"),
   ;
@@ -83,6 +87,10 @@ data class Cas2UserEntity(
   // Nomis specific fields that are only expected to have values if the
   // accountType is Cas2UserType.NOMIS
   var nomisStaffId: Long? = null,
+
+  /**
+   * Corresponds to a prison code
+   */
   var activeNomisCaseloadId: String? = null,
   var nomisAccountType: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2ApplicationController.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import jakarta.transaction.Transactional
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -9,8 +11,8 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import tools.jackson.databind.json.JsonMapper
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplication
@@ -46,14 +48,20 @@ class Cas2v2ApplicationController(
   private val cas2OffenderService: Cas2OffenderService,
   private val userService: Cas2v2UserService,
 ) {
+
+  @Operation(summary = "List all applications according to miscellaneous parameters")
   @GetMapping("/applications")
   @PaginationHeaders
-  @SuppressWarnings("LongParameterList")
   fun applicationsGet(
     @RequestParam isSubmitted: Boolean?,
     @RequestParam page: Int?,
+    @Parameter(description = "Use of prisonCode is limited for users with referer roles (ROLE_CAS2_COURT_BAIL_REFERRER or ROLE_CAS2_PRISON_BAIL_REFERRER). See limitByUser documentation")
     @RequestParam prisonCode: String?,
     @RequestParam applicationOrigin: ApplicationOrigin?,
+    @Parameter(
+      description = """Defaults to true. If true returns applications created by the calling user. If the user does not have a refer role (ROLE_CAS2_COURT_BAIL_REFERRER or ROLE_CAS2_PRISON_BAIL_REFERRER), 
+      |and prisonCode is specified, it must match the user's active case load id""",
+    )
     @RequestParam limitByUser: Boolean?,
     @RequestParam crnOrNomsNumber: String?,
   ): ResponseEntity<List<ModelCas2v2ApplicationSummary>> {
@@ -81,10 +89,16 @@ class Cas2v2ApplicationController(
     ).body(getPersonNamesAndTransformToSummaries(applications))
   }
 
+  @Operation(
+    description = "Get an application by ID. Access is allowed if one of the following rules is met: " +
+      "1. The calling user created the application, " +
+      "2. The calling user has ROLE_CAS2_PRISON_BAIL_REFERRER and the application is a submitted prison bail application, " +
+      "3. The calling user is a NOMIS user and the application corresponds to an offender in a prison matching the calling user active case load id",
+  )
   @GetMapping("/applications/{applicationId}")
   fun applicationsApplicationIdGet(
     @PathVariable applicationId: UUID,
-  ): ResponseEntity<Application> {
+  ): ResponseEntity<Cas2v2Application> {
     val user = userService.getUserForRequest()
 
     val applicationResult = cas2v2ApplicationService
@@ -97,12 +111,13 @@ class Cas2v2ApplicationController(
     return ResponseEntity.ok(getPersonDetailAndTransform(application))
   }
 
+  @Operation(description = "Create a new Application. This will persist a non-submitted application and the response will include the assigned application ID")
   @Transactional
   @Suppress("ThrowsCount")
   @PostMapping("/applications")
   fun applicationsPost(
     @RequestBody body: NewCas2v2Application,
-  ): ResponseEntity<Application> {
+  ): ResponseEntity<Cas2v2Application> {
     val user = userService.getUserForRequest()
 
     val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(body.crn)) {
@@ -132,13 +147,14 @@ class Cas2v2ApplicationController(
       .body(cas2v2ApplicationsTransformer.transformJpaAndFullPersonToApi(application, personInfo))
   }
 
+  @Operation(description = "Update a non submitted application. An application can only be updated if it's created by the calling user, unsubmitted and not abandoned")
   @Suppress("TooGenericExceptionThrown")
   @Transactional
   @PutMapping("/applications/{applicationId}")
   fun applicationsApplicationIdPut(
     @PathVariable applicationId: UUID,
     @RequestBody body: UpdateApplication,
-  ): ResponseEntity<Application> {
+  ): ResponseEntity<Cas2v2Application> {
     val user = userService.getUserForRequest()
 
     val serializedData = jsonMapper.writeValueAsString(body.data)
@@ -158,6 +174,7 @@ class Cas2v2ApplicationController(
     return ResponseEntity.ok(getPersonDetailAndTransform(entity))
   }
 
+  @Operation(description = "Abandon an application. Application must be unsubmitted and created by the calling user")
   @Transactional
   @PutMapping("/applications/{applicationId}/abandon")
   fun applicationsApplicationIdAbandonPut(
@@ -185,7 +202,7 @@ class Cas2v2ApplicationController(
   @SuppressWarnings("ThrowsCount")
   private fun getPersonDetailAndTransform(
     application: Cas2ApplicationEntity,
-  ): Application {
+  ): Cas2v2Application {
     val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(application.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(application.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2AssessmentsController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.controller
 
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -32,6 +33,8 @@ class Cas2v2AssessmentsController(
   private val cas2v2StatusUpdateService: Cas2v2StatusUpdateService,
   private val cas2v2UserService: Cas2v2UserService,
 ) {
+
+  @Operation(description = "Get an assessment. There are no constraints on assessments returned")
   @GetMapping("/assessments/{assessmentId}")
   fun assessmentsAssessmentIdGet(
     @PathVariable assessmentId: UUID,
@@ -41,6 +44,7 @@ class Cas2v2AssessmentsController(
     return ResponseEntity.ok(cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity))
   }
 
+  @Operation(description = "Update an assessment. There are no constraints on who can access this endpoint")
   @PutMapping("/assessments/{assessmentId}")
   fun assessmentsAssessmentIdPut(
     @PathVariable assessmentId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2SubmissionsController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.controller
 
+import io.swagger.v3.oas.annotations.Operation
 import jakarta.transaction.Transactional
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -39,6 +40,7 @@ class Cas2v2SubmissionsController(
   private val userService: Cas2v2UserService,
 ) {
 
+  @Operation(description = "Get all submitted applications, paged. There are no constraints on assessments returned")
   @GetMapping("/submissions")
   fun submissionsGet(
     @RequestParam page: Int?,
@@ -55,6 +57,7 @@ class Cas2v2SubmissionsController(
     ).body(getPersonNamesAndTransformToSummaries(applications))
   }
 
+  @Operation(description = "Get a submitted application. There are no constraints on who can access this endpoint")
   @GetMapping("/submissions/{applicationId}")
   fun submissionsApplicationIdGet(
     @PathVariable applicationId: UUID,
@@ -67,6 +70,7 @@ class Cas2v2SubmissionsController(
     return ResponseEntity.ok(getPersonDetailAndTransform(application))
   }
 
+  @Operation(description = "Submit an application. The application must have been created by the calling user, and not already submitted or abandoned")
   @Transactional
   @PostMapping("/submissions")
   fun submissionsPost(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ApplicationService.kt
@@ -142,7 +142,7 @@ class Cas2v2ApplicationService(
     user: Cas2UserEntity,
     applicationOrigin: ApplicationOrigin = ApplicationOrigin.homeDetentionCurfew,
     bailHearingDate: LocalDate? = null,
-  ) = validated<Cas2ApplicationEntity> {
+  ) = validated {
     val offenderDetailsResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(crn)
 
     val offenderDetails = when (offenderDetailsResult) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2ApplicationsTransformer.kt
@@ -31,7 +31,7 @@ class Cas2v2ApplicationsTransformer(
 
   fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2v2Application = transformJpaAndFullPersonToApi(jpa, personTransformer.transformModelToPersonApi(personInfo))
 
-  fun transformJpaAndFullPersonToApi(jpa: Cas2ApplicationEntity, fullPerson: Person): Cas2v2Application = Cas2v2Application(
+  fun transformJpaAndFullPersonToApi(jpa: Cas2ApplicationEntity, fullPerson: Person) = Cas2v2Application(
     id = jpa.id,
     person = fullPerson,
     createdBy = cas2v2UserTransformer.transformJpaToApi(jpa.createdByUser),


### PR DESCRIPTION
This commit adds specific Cas2v2 response types on CAS2v2 API endpoints that previously returned a generic type.

It also adds documentation explaining what each endpoint does, where it’s not self explanatory