### PR TITLE
Don’t raise sentry alert for resource not found

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/problem/ExceptionHandling.kt
@@ -49,7 +49,7 @@ class ExceptionHandling(
 
   @ExceptionHandler(NoResourceFoundException::class)
   fun handleNoResourceFoundException(ex: NoResourceFoundException): ResponseEntity<ProblemDetail> {
-    sentryService.captureException(ex)
+    log.warn("Resource not found", ex)
     return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(APPLICATION_PROBLEM_JSON).body(NotFoundResourceProblem().toProblemDetail())
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/problem/ExceptionHandlingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/problem/ExceptionHandlingTest.kt
@@ -93,7 +93,9 @@ class ExceptionHandlingTest {
     assertThat(problem.status).isEqualTo(expectedProblem.status)
     assertThat(problem.detail).isEqualTo(expectedProblem.detail)
 
-    verify { mockSentryService.captureException(throwable) }
+    loggerExtension.assertError("Resource not found", throwable)
+
+    verify(exactly = 0) { mockSentryService.captureException(throwable) }
   }
 
   @Test


### PR DESCRIPTION
This follows the hmpps kotlin template behaviour, and ensures failure to find swagger-ui/open api documents in production where they are disabled does not result in alerts being raised.