### PR TITLE
FM-367 Use nonprod severity for nonprod environments

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -145,7 +145,7 @@ generic-service:
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod
   rdsAlertsDatabases:
     cloud-platform-914625011536d5f1: "community accommodation"
   # API pool users = 20 per pod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -114,7 +114,7 @@ generic-service:
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod
   rdsAlertsDatabases:
     cloud-platform-e683abb0b1eddb61: "community accommodation"
   # API pool users = 20 per pod

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -145,7 +145,7 @@ generic-service:
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod
   rdsAlertsDatabases:
     cloud-platform-f3a9f9984df2d0e7: "community accommodation"
   # API pool users = 20 per pod


### PR DESCRIPTION
This will ensure that non prod prometheus alerts will be sent to the non prod slack channel