### PR TITLE
FM-367 Add SQS Queue Alerting

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -142,18 +142,21 @@ generic-service:
     ncc-tsc-team-9: "195.95.131.0/24"
     ncc-mvss-team-1: "5.148.8.192/26"
 
-# CloudPlatform AlertManager receiver to route prometheus alerts to slack
-# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
+# These alerts are provided by https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-prometheus-alerts/README.md
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises-nonprod
+  elastiCacheAlertsClusterIds:
+    cp-ede0649d3201fded: "community accommodation"
   rdsAlertsDatabases:
     cloud-platform-914625011536d5f1: "community accommodation"
   # API pool users = 20 per pod
   # Max expected connections for 2 x pods = 40 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 50
-  elastiCacheAlertsClusterIds:
-    cp-ede0649d3201fded: "community accommodation"
-
+  sqsAlertsQueueNames:
+    - "hmpps-community-accommodation-development-cas-2-domain-events-listener-dlq"
+    - "hmpps-community-accommodation-development-cas-2-domain-events-listener-queue"
+  sqsAlertsOldestThreshold: 30
+  sqsAlertsTotalMessagesThreshold: 10
 
 env_details:
   production_env: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -110,17 +110,21 @@ generic-service:
       NOTIFY_GUESTLISTAPIKEY: "NOTIFY_GUESTLISTAPIKEY"
       NOTIFY_EMAILADDRESSES_CAS2ASSESSORS: "NOTIFY_EMAILADDRESSES_CAS2ASSESSORS"
 
-# CloudPlatform AlertManager receiver to route prometheus alerts to slack
-# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
+# These alerts are provided by https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-prometheus-alerts/README.md
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises-nonprod
+  elastiCacheAlertsClusterIds:
+    cp-1faf5cb78c4ab173: "community accommodation"
   rdsAlertsDatabases:
     cloud-platform-e683abb0b1eddb61: "community accommodation"
   # API pool users = 20 per pod
   # Max expected connections for 4 x pods = 80 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 90
-  elastiCacheAlertsClusterIds:
-    cp-1faf5cb78c4ab173: "community accommodation"
+  sqsAlertsQueueNames:
+    - "hmpps-community-accommodation-preprod-cas-2-domain-events-listener-dlq"
+    - "hmpps-community-accommodation-preprod-cas-2-domain-events-listener-queue"
+  sqsAlertsOldestThreshold: 30
+  sqsAlertsTotalMessagesThreshold: 10
 
 env_details:
   production_env: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -110,15 +110,21 @@ generic-service:
       NOTIFY_APIKEY: "NOTIFY_APIKEY"
       NOTIFY_EMAILADDRESSES_CAS2ASSESSORS: "NOTIFY_EMAILADDRESSES_CAS2ASSESSORS"
 
+# These alerts are provided by https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-prometheus-alerts/README.md
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises
+  elastiCacheAlertsClusterIds:
+    cp-76ca3c1a20d6d72a: "community accommodation"
   rdsAlertsDatabases:
     cloud-platform-d9cc5e2e184df473: "community accommodation"
   # API pool users = 20 per pod
   # Max expected connections for 4 x pods = 80 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 90
-  elastiCacheAlertsClusterIds:
-   cp-76ca3c1a20d6d72a: "community accommodation"
+  sqsAlertsQueueNames:
+    - "hmpps-community-accommodation-prod-cas-2-domain-events-listener-dlq"
+    - "hmpps-community-accommodation-prod-cas-2-domain-events-listener-queue"
+  sqsAlertsOldestThreshold: 30
+  sqsAlertsTotalMessagesThreshold: 10
 
 env_details:
   production_env: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -141,17 +141,21 @@ generic-service:
     dxw-vpn: "54.76.254.148/32"
     cyberlab: "51.38.77.66/32"
 
-# CloudPlatform AlertManager receiver to route prometheus alerts to slack
-# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
+# These alerts are provided by https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-prometheus-alerts/README.md
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises-nonprod
+  elastiCacheAlertsClusterIds:
+    cp-377025d1a50411fe: "community accommodation"
   rdsAlertsDatabases:
     cloud-platform-f3a9f9984df2d0e7: "community accommodation"
   # API pool users = 20 per pod
   # Max expected connections for 2 x pods = 40 + additional 10 (buffer for direct connections)
   rdsAlertsConnectionThreshold: 50
-  elastiCacheAlertsClusterIds:
-    cp-377025d1a50411fe: "community accommodation"
+  sqsAlertsQueueNames:
+    - "hmpps-community-accommodation-test-cas-2-domain-events-listener-dlq"
+    - "hmpps-community-accommodation-test-cas-2-domain-events-listener-queue"
+  sqsAlertsOldestThreshold: 30
+  sqsAlertsTotalMessagesThreshold: 10
 
 env_details:
   production_env: false


### PR DESCRIPTION
Configure SQS Queue Monitoring for all environments, ensuring we get alerted if

* there are at least 10 messages in a queue
* there is a message in the queue for more than 10 minutes