### PR TITLE
FM-592 align openapi config with hmpps template

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Authorization: Bearer {the JWT}
 
 ## Coding Notes
 
+## Divergence from the hmpps kotlin template
+
+HMPPS provide a [kotlin template project](https://github.com/ministryofjustice/hmpps-template-kotlin)
+
+Whilst we should remain aligned with the template, there are some areas that we diverge
+
+* We use pattern matching rules to apply security, where as the sample [ResourceSecurityTest](https://github.com/ministryofjustice/hmpps-template-kotlin/blob/main/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/ResourceSecurityTest.kt) expects use of @PreAuthorize annotations. For this reason we do not include this test. AuthTest provides from top level authentication tests, and each individual end test ensures a token is required with a suitable role
+
 ### Load tests
 
 * Load tests are managed in the [hmpps-load-testing-probation](https://github.com/ministryofjustice/hmpps-load-testing-probation) repo
@@ -102,12 +110,11 @@ other commands you may need.
 ### Environments
 
 [Details of the different environments and their roles can be found in
-Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4330226204/Environments).
+Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/5001478252/CAS+Environments+URLs).
 
 ## Release process
 
-Our release process aligns with the other CAS teams and as such [lives in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process). 
-The steps are also available in the pull request checklist[PULL_REQUEST_TEMPLATE](/.github/PULL_REQUEST_TEMPLATE/full_template.md).
+Our release process aligns with the other CAS teams and as such [lives in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process).
 
 ## Docker Build
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
   implementation("io.micrometer:micrometer-registry-azure-monitor:1.16.5")
   implementation("com.microsoft.azure:applicationinsights-$appinsightsCore")
 
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.2")
+  implementation("uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.14.9")
   testImplementation("org.wiremock.integrations:wiremock-spring-boot:4.2.1")
@@ -90,9 +93,9 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-webtestclient")
   testImplementation("org.zalando:logbook-spring-boot-starter:4.0.4")
 
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.2")
-
-  implementation("uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE")
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.41") {
+    exclude(group = "io.swagger.core.v3")
+  }
 }
 
 springBoot {
@@ -210,8 +213,8 @@ allOpen {
 
 tasks {
   withType<JavaExec> {
-    jvmArgs!!.plus("--add-opens")
-    jvmArgs!!.plus("java.base/java.lang=ALL-UNNAMED")
+    jvmArgs.plus("--add-opens")
+    jvmArgs.plus("java.base/java.lang=ALL-UNNAMED")
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/PaginationHeaders.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/PaginationHeaders.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api
 
 import io.swagger.v3.oas.annotations.headers.Header
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/cas1/AssessmentsCas1.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/cas1/AssessmentsCas1.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentRejection
@@ -25,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewClarifi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1UpdateAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1UpdatedClarificationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
 
 @RestController
 interface AssessmentsCas1 {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssignmentType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
@@ -23,7 +24,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2Offende
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.net.URI

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2ApplicationController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2v2Application
@@ -31,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ParamDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.ValidatableActionResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.PageCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCasResultIsSuccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BookingController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCancellation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewConfirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewExtension
@@ -54,7 +55,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderDetailSe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.time.OffsetDateTime
 import java.time.ZoneOffset

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -1,7 +1,8 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import io.swagger.v3.core.converter.AnnotatedType
 import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.core.jackson.ModelResolver
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.media.Content
@@ -10,16 +11,18 @@ import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.responses.ApiResponse
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.boot.info.BuildProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Problem
 
 @Configuration
-class SwaggerConfiguration {
+class OpenApiConfiguration(buildProperties: BuildProperties) {
+  private val version: String = buildProperties.version!!
 
   companion object {
     init {
-      io.swagger.v3.core.jackson.ModelResolver.enumsAsRef = true
+      ModelResolver.enumsAsRef = true
     }
   }
 
@@ -28,7 +31,7 @@ class SwaggerConfiguration {
     .info(
       Info()
         .title("Approved Premises")
-        .version("1.0.0")
+        .version(version)
         .description("Swagger Documentation for Approved Premises API"),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Appeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSortField
@@ -54,7 +55,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1RequestForPlacementService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1WithdrawableService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1LaoStrategy
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AppealTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1UsersController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUserRole
@@ -27,7 +28,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.BadRequestProble
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.swagger.PaginationHeaders
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,6 @@ info.app:
 spring:
   application:
     name: approved-premises-api
-  codec:
-    # note that we use configuration in web-clients: for any WebClients we construct ourselves
-    max-in-memory-size: 40MB
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/OpenApiDocsTest.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import io.swagger.v3.parser.OpenAPIV3Parser
+import net.minidev.json.JSONArray
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.info.BuildProperties
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType
+
+class OpenApiDocsTest : IntegrationTestBase() {
+  @LocalServerPort
+  private val port: Int = 0
+
+  @Autowired
+  private lateinit var buildProperties: BuildProperties
+
+  @Test
+  fun `open api docs are available`() {
+    webTestClient.get()
+      .uri("/swagger-ui/index.html?configUrl=/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `open api docs redirect to correct page`() {
+    webTestClient.get()
+      .uri("/swagger-ui.html")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().is3xxRedirection
+      .expectHeader().value("Location") { it.contains("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config") }
+  }
+
+  @Test
+  fun `the open api json contains documentation`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("paths").isNotEmpty
+  }
+
+  @Disabled
+  @Test
+  fun `the swagger json don't contain any duplicate methods`() {
+    // Methods in resource classes with the same name end up with operationIds that have _1 and _2 etc. in the name.
+    // When the code is then generated from the api docs we refer to the endpoint by operationId. If a new method is
+    // added or one removed then the _1 / _2 etc. can change order and thus we end up calling a completely different
+    // endpoint next time the code is generated. This test then prevents that from happening by ensuring all endpoints
+    // have method names / operation ids.
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("*..operationId").value<List<String>> { list ->
+        assertThat(list).filteredOn { it.contains("_") }.isEmpty()
+      }
+  }
+
+  @Test
+  fun `the open api json contains the version number`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("info.version").value<String> {
+        assertThat(it).isEqualTo(buildProperties.version)
+      }
+  }
+
+  @Test
+  fun `the open api json is valid`() {
+    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
+    assertThat(result.messages).isEmpty()
+  }
+
+  @Test
+  @Disabled("TODO Enable this test once you have added security schema to OpenApiConfiguration.OpenAPi().components()")
+  fun `the open api json path security requirements are valid`() {
+    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
+
+    // The security requirements of each path don't appear to be validated like they are at https://editor.swagger.io/
+    // We therefore need to grab all the valid security requirements and check that each path only contains those items
+    val securityRequirements = result.openAPI.security.flatMap { it.keys }
+    result.openAPI.paths.forEach { pathItem ->
+      assertThat(pathItem.value.get.security.flatMap { it.keys }).isSubsetOf(securityRequirements)
+    }
+  }
+
+  @ParameterizedTest
+  @Disabled("TODO Enable this test once you have added security schema to OpenApiConfiguration.OpenAPi().components(). Add the security scheme / roles to @CsvSource")
+  @CsvSource(value = ["security-scheme-name, ROLE_"])
+  fun `the security scheme is setup for bearer tokens`(key: String, role: String) {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.$key.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.$key.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.$key.description").value<String> {
+        assertThat(it).contains(role)
+      }
+      .jsonPath("$.components.securitySchemes.$key.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.security[0].$key").isEqualTo(JSONArray().apply { this.add("read") })
+  }
+
+  @Disabled
+  @Test
+  fun `all endpoints have a security scheme defined`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.paths[*][*][?(!@.security)]").doesNotExist()
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,6 +6,10 @@ management.endpoint:
   info.cache.time-to-live: 0
 
 spring:
+  http:
+    codecs:
+      # this is required for open api tests due to the size of our open api doc
+      max-in-memory-size: 10MB
   datasource:
     username: api_user
     password: api_user_password


### PR DESCRIPTION
Miscellaneous changes to our open api configuration to align with the hmpps kotlin template and allow us to start adding the default template tests