### PR TITLE
Refresh local test configuration

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -162,10 +162,10 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
       localstack:
-        image: localstack/localstack:3.4.0
+        image: localstack/localstack:community-archive
         ports:
-          - 4566:4566
-          - 4571:4571
+          - 4466:4566
+          - 4471:4571
         env:
           ES_PORT_EXTERNAL: 4571
           DOCKER_HOST: 'unix:///var/run/docker.sock'

--- a/script/test-database/docker-compose.test.arm64.yml
+++ b/script/test-database/docker-compose.test.arm64.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   integration_test_database:
-    image: "ghcr.io/baosystems/postgis:15-3.3" # Official PostGIS image doesn't have ARM64 support
+    image: "ghcr.io/baosystems/postgis:14-3.5" # Official PostGIS image doesn't have ARM64 support

--- a/script/test-database/docker-compose.test.yml
+++ b/script/test-database/docker-compose.test.yml
@@ -1,7 +1,7 @@
 name: approved-premises-api-test
 services:
   integration_test_database:
-    image: "postgis/postgis"
+    image: "postgis/postgis:14-3.5"
     # If connecting to this database for investigations, use integration_test_monitor:integration_test_monitor_password
     # If you use api_user as defined below, cloning templates will fail
     # See IntegrationTestDbInitialiser for more information
@@ -27,12 +27,12 @@ services:
       - "6377:6379"
 
   localstack:
-    image: localstack/localstack:3.4.0
+    image: localstack/localstack:community-archive
     container_name: approved-premises-api-test-localstack
     ports:
-      - "4566:4566"
-      - "4571:4571"
-      - "8999:8080"
+      - "4466:4566"
+      - "4471:4571"
+      - "8899:8080"
     environment:
       - SERVICES=sns,sqs
       - DEBUG=${DEBUG- }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -69,6 +69,7 @@ springdoc:
 hmpps.sqs:
   useWebToken: false
   provider: localstack
+  localstackUrl: http://localhost:4466
   topics:
     domainevents:
       arn: "dynamically set per test"


### PR DESCRIPTION
These changes ensure that running `test_database` is sufficient to run integration tests locally, without having to start ap-tools. They also ensure that `test_database` and `ap-tools` can co-exists without port clashes.

Changes made:
* shift localstack instance to ports that don’t clash with ap-tools and configure tests to use these new ports for SQS
* use latest community version of localstack
* use better aligned version of postgis on ARM64