### PR TITLE
Add micrometer registry to trackconnection pool

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,10 @@ dependencies {
   implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:7.7.0")
   implementation("org.jetbrains.kotlinx:dataframe-excel:0.15.0")
 
+  val appinsightsCore = "core:2.6.4"
+  implementation("io.micrometer:micrometer-registry-azure-monitor:1.16.5")
+  implementation("com.microsoft.azure:applicationinsights-$appinsightsCore")
+
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
   testImplementation("io.mockk:mockk:1.14.9")
   testImplementation("org.wiremock.integrations:wiremock-spring-boot:4.2.1")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ApplicationInsightsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ApplicationInsightsConfiguration.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import io.micrometer.azuremonitor.AzureMonitorConfig
+import io.micrometer.azuremonitor.AzureMonitorMeterRegistry
+import io.micrometer.core.instrument.Clock.SYSTEM
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ApplicationInsightsConfiguration {
+
+  @Bean
+  @ConditionalOnProperty("applicationinsights.connection.string")
+  fun azureMonitorMeterRegistry(@Value($$"${applicationinsights.connection.string}") connectionString: String): AzureMonitorMeterRegistry = AzureMonitorMeterRegistry(
+    object : AzureMonitorConfig {
+      override fun get(key: String): String? = null
+      override fun connectionString(): String = connectionString
+    },
+    SYSTEM,
+  )
+}


### PR DESCRIPTION
This is required as of spring boot 4. This is following the approach used here -> https://github.com/ministryofjustice/hmpps-nomis-prisoner-api/pull/1729/changes/ba25a86396150327709e4e36461ec20d0c9bf154

I've checked this in test and metrics continue to appear