### PR TITLE
SAS-602-Refactor-CAS3-suitability-end-point-to-include-accommodation-info

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1SuitableApplication.kt
@@ -9,18 +9,10 @@ data class Cas1SuitableApplication(
   val applicationStatus: ApprovedPremisesApplicationStatus,
   val requestForPlacementStatus: RequestForPlacementStatus?,
   val placementStatus: Cas1SpaceBookingStatus?,
-  val placementHistories: List<Cas1PlacementHistory>,
+  val premises: Cas1SuitablePremisesDto?,
 )
 
-data class Cas1PlacementHistory(
-  val dateApplied: LocalDate,
-  val requestForPlacementStatus: RequestForPlacementStatus,
-  val placementStatus: Cas1SpaceBookingStatus?,
-  val premises: SuitablePremisesDto?,
-  var isSuitable: Boolean,
-)
-
-data class SuitablePremisesDto(
+data class Cas1SuitablePremisesDto(
   val startDate: LocalDate?,
   val endDate: LocalDate?,
   val addressLine1: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingEntity.kt
@@ -293,7 +293,7 @@ interface Cas3v2BookingRepository : JpaRepository<Cas3BookingEntity, UUID> {
     endDate: LocalDate,
   ): List<Cas3v2OverlapBookingsSearchResult>
 
-  fun findAllByApplicationId(applicationId: UUID): List<Cas3BookingEntity>
+  fun findTopByApplicationIdOrderByCreatedAtDesc(applicationId: UUID): Cas3BookingEntity?
 }
 
 @Suppress("TooManyFunctions")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3SuitableApplication.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
+import java.time.LocalDate
 import java.util.UUID
 
 data class Cas3SuitableApplication(
@@ -10,4 +11,15 @@ data class Cas3SuitableApplication(
   val applicationStatus: ApplicationStatus,
   val assessmentStatus: TemporaryAccommodationAssessmentStatus?,
   val bookingStatus: Cas3BookingStatus?,
+  val premises: Cas3SuitablePremisesDto?,
+)
+
+data class Cas3SuitablePremisesDto(
+  val startDate: LocalDate?,
+  val endDate: LocalDate?,
+  val name: String?,
+  val addressLine1: String,
+  val addressLine2: String?,
+  val town: String?,
+  val postcode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
@@ -5,6 +5,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3SubmitApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.v2.Cas3v2BookingService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
@@ -70,11 +71,27 @@ class Cas3ApplicationService(
       compareBy { it.createdAt },
     )
     ?.let { application ->
+
+      val booking = cas3v2BookingService.getLatestBooking(application.id)
+
+      val premises = booking?.premises?.let {
+        Cas3SuitablePremisesDto(
+          startDate = booking.arrivalDate,
+          endDate = booking.departureDate,
+          name = it.name,
+          addressLine1 = it.addressLine1,
+          addressLine2 = it.addressLine2,
+          town = it.town,
+          postcode = it.postcode,
+        )
+      }
+
       Cas3SuitableApplication(
         id = application.id,
         applicationStatus = application.getStatus(),
         assessmentStatus = application.getLatestAssessment()?.deriveAssessmentStatus(),
-        bookingStatus = cas3v2BookingService.getLatestBookingStatus(application.id),
+        bookingStatus = booking?.status,
+        premises = premises,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
@@ -38,7 +38,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.serviceScopeM
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -71,7 +70,6 @@ class Cas3v2BookingService(
   private val workingDayService: WorkingDayService,
   private val userAccessService: UserAccessService,
   private val cas3AssessmentService: Cas3AssessmentService,
-  private val featureFlagService: FeatureFlagService,
 ) {
   companion object {
     const val ARRIVAL_AFTER_LATEST_DATE_LIMIT_DAYS: Long = 14
@@ -568,7 +566,5 @@ class Cas3v2BookingService(
 
   fun Cas3BookingEntity.lastUnavailableDate() = workingDayService.addWorkingDays(this.departureDate, this.turnaround?.workingDayCount ?: 0)
 
-  fun getLatestBookingStatus(applicationId: UUID): Cas3BookingStatus? = cas3BookingRepository.findAllByApplicationId(applicationId)
-    .maxByOrNull { it.createdAt }
-    ?.status
+  fun getLatestBooking(applicationId: UUID): Cas3BookingEntity? = cas3BookingRepository.findTopByApplicationIdOrderByCreatedAtDesc(applicationId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
@@ -1,9 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlacementHistory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SuitableApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SuitablePremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SuitablePremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
@@ -43,14 +44,9 @@ class Cas1ExternalApplicationService(
           )
         } else {
           rfp.placements.map { placement ->
-            println(placement)
-            println("hello")
-            println(placement.premises.id)
-            println(placement.premises.name)
-
             val premises = cas1PremisesService.findPremisesById(placement.premises.id)
               ?.let {
-                SuitablePremisesDto(
+                Cas1SuitablePremisesDto(
                   startDate = placement.expectedArrivalDate,
                   endDate = placement.expectedDepartureDate,
                   postcode = it.postcode,
@@ -82,9 +78,9 @@ class Cas1ExternalApplicationService(
       Cas1SuitableApplication(
         id = application.id,
         applicationStatus = application.status,
-        placementHistories = placementHistories,
         requestForPlacementStatus = suitablePlacement?.requestForPlacementStatus,
         placementStatus = suitablePlacement?.placementStatus,
+        premises = suitablePlacement?.premises,
       )
     }
 
@@ -102,5 +98,13 @@ class Cas1ExternalApplicationService(
     ApprovedPremisesApplicationStatus.PENDING_PLACEMENT_REQUEST to 9,
     ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT to 10,
     ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED to 11,
+  )
+
+  private data class Cas1PlacementHistory(
+    val dateApplied: LocalDate,
+    val requestForPlacementStatus: RequestForPlacementStatus,
+    val placementStatus: Cas1SpaceBookingStatus?,
+    val premises: Cas1SuitablePremisesDto?,
+    var isSuitable: Boolean,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalApplicationsTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
@@ -55,6 +56,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             applicationStatus = ApplicationStatus.submitted,
             assessmentStatus = null,
             bookingStatus = null,
+            premises = null,
           )
 
           val response = webTestClient.get()
@@ -88,6 +90,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             applicationStatus = ApplicationStatus.inProgress,
             null,
             bookingStatus = null,
+            premises = null,
           )
 
           val response = webTestClient.get()
@@ -125,7 +128,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             withSubmittedAt(OffsetDateTime.now())
           }
 
-          cas3BookingEntityFactory.produceAndPersist {
+          val booking = cas3BookingEntityFactory.produceAndPersist {
             withPremises(premises)
             withBedspace(bedspace)
             withApplication(application)
@@ -141,6 +144,15 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             applicationStatus = ApplicationStatus.submitted,
             assessmentStatus = null,
             bookingStatus = Cas3BookingStatus.confirmed,
+            premises = Cas3SuitablePremisesDto(
+              startDate = booking.arrivalDate,
+              endDate = booking.departureDate,
+              name = premises.name,
+              addressLine1 = premises.addressLine1,
+              addressLine2 = premises.addressLine2,
+              town = premises.town,
+              postcode = premises.postcode,
+            ),
           )
 
           val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3SubmitApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
@@ -157,7 +160,7 @@ class Cas3ApplicationServiceTest {
         inProgressApplicationNewer,
         inProgressApplicationOlder,
       )
-      every { mockCas3v2BookingService.getLatestBookingStatus(inProgressApplicationNewer.id) } returns null
+      every { mockCas3v2BookingService.getLatestBooking(inProgressApplicationNewer.id) } returns null
 
       assertThat(
         cas3ApplicationService.getSuitableApplicationByCrn(crn),
@@ -167,6 +170,7 @@ class Cas3ApplicationServiceTest {
           ApplicationStatus.inProgress,
           null,
           bookingStatus = null,
+          premises = null,
         ),
       )
     }
@@ -227,7 +231,7 @@ class Cas3ApplicationServiceTest {
         submittedApplication3,
       )
 
-      every { mockCas3v2BookingService.getLatestBookingStatus(submittedApplication2.id) } returns null
+      every { mockCas3v2BookingService.getLatestBooking(submittedApplication2.id) } returns null
 
       assertThat(
         cas3ApplicationService.getSuitableApplicationByCrn(crn),
@@ -237,6 +241,7 @@ class Cas3ApplicationServiceTest {
           ApplicationStatus.submitted,
           null,
           bookingStatus = null,
+          premises = null,
         ),
       )
     }
@@ -275,7 +280,7 @@ class Cas3ApplicationServiceTest {
         submittedApplication3,
       )
 
-      every { mockCas3v2BookingService.getLatestBookingStatus(submittedApplication2.id) } returns null
+      every { mockCas3v2BookingService.getLatestBooking(submittedApplication2.id) } returns null
 
       assertThat(
         cas3ApplicationService.getSuitableApplicationByCrn(crn),
@@ -285,6 +290,7 @@ class Cas3ApplicationServiceTest {
           ApplicationStatus.submitted,
           null,
           bookingStatus = null,
+          premises = null,
         ),
       )
     }
@@ -314,7 +320,7 @@ class Cas3ApplicationServiceTest {
         submittedApplication,
       )
 
-      every { mockCas3v2BookingService.getLatestBookingStatus(submittedApplication.id) } returns null
+      every { mockCas3v2BookingService.getLatestBooking(submittedApplication.id) } returns null
 
       assertThat(
         cas3ApplicationService.getSuitableApplicationByCrn(crn),
@@ -324,6 +330,7 @@ class Cas3ApplicationServiceTest {
           ApplicationStatus.submitted,
           TemporaryAccommodationAssessmentStatus.readyToPlace,
           bookingStatus = null,
+          premises = null,
         ),
       )
     }
@@ -353,7 +360,18 @@ class Cas3ApplicationServiceTest {
         submittedApplication,
       )
 
-      every { mockCas3v2BookingService.getLatestBookingStatus(submittedApplication.id) } returns Cas3BookingStatus.provisional
+      val premises = Cas3PremisesEntityFactory()
+        .produce()
+
+      val booking = Cas3BookingEntityFactory()
+        .withDefaults()
+        .withStatus(Cas3BookingStatus.provisional)
+        .withPremises(premises)
+        .withArrivalDate(LocalDate.now().plusMonths(1))
+        .withDepartureDate(LocalDate.now().plusMonths(2))
+        .produce()
+
+      every { mockCas3v2BookingService.getLatestBooking(submittedApplication.id) } returns booking
 
       assertThat(
         cas3ApplicationService.getSuitableApplicationByCrn(crn),
@@ -363,6 +381,15 @@ class Cas3ApplicationServiceTest {
           ApplicationStatus.submitted,
           TemporaryAccommodationAssessmentStatus.readyToPlace,
           bookingStatus = Cas3BookingStatus.provisional,
+          premises = Cas3SuitablePremisesDto(
+            startDate = booking.arrivalDate,
+            endDate = booking.departureDate,
+            name = booking.premises.name,
+            addressLine1 = booking.premises.addressLine1,
+            addressLine2 = booking.premises.addressLine2,
+            town = booking.premises.town,
+            postcode = booking.premises.postcode,
+          ),
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
@@ -71,7 +71,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
@@ -104,7 +103,6 @@ class Cas3v2BookingServiceTest {
   private val mockDepartureRepository = mockk<Cas3DepartureRepository>()
   private val mockDepartureReasonRepository = mockk<DepartureReasonRepository>()
   private val mockMoveOnCategoryRepository = mockk<MoveOnCategoryRepository>()
-  private val mockFeatureFlagService = mockk<FeatureFlagService>()
   private val mockExtensionRepository = mockk<Cas3ExtensionRepository>()
   private val mockOverstayRepository = mockk<Cas3OverstayRepository>()
 
@@ -128,7 +126,6 @@ class Cas3v2BookingServiceTest {
     cas3DomainEventService = mockCas3DomainEventService,
     userAccessService = mockUserAccessService,
     cas3AssessmentService = mockCas3AssessmentService,
-    featureFlagService = mockFeatureFlagService,
   )
 
   private val cas3BookingService = createCas3v2BookingService()
@@ -1412,7 +1409,7 @@ class Cas3v2BookingServiceTest {
       every { mockCancellationRepository.save(any()) } answers { it.invocation.args[0] as Cas3CancellationEntity }
       every { mockCas3DomainEventService.saveBookingCancelledEvent(any(Cas3BookingEntity::class), any()) } just Runs
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
-      every { mockCas3AssessmentService.acceptAssessment(user, any(), any()) } returns CasResult.Success(assessmentEntity!!)
+      every { mockCas3AssessmentService.acceptAssessment(user, any(), any()) } returns CasResult.Success(assessmentEntity)
       mockkStatic(Sentry::class)
 
       val result = cas3BookingService.createCancellation(
@@ -2478,64 +2475,30 @@ class Cas3v2BookingServiceTest {
   }
 
   @Nested
-  inner class GetLatestBookingStatus {
+  inner class GetLatestBooking {
     private val applicationId = UUID.randomUUID()
 
     @Test
     fun `returns null when no bookings exist for application`() {
-      every { mockBookingRepository.findAllByApplicationId(applicationId) } returns emptyList()
+      every { mockBookingRepository.findTopByApplicationIdOrderByCreatedAtDesc(applicationId) } returns null
 
-      val result = cas3BookingService.getLatestBookingStatus(applicationId)
+      val result = cas3BookingService.getLatestBooking(applicationId)
 
       assertThat(result).isNull()
     }
 
     @Test
-    fun `returns booking status when single booking exists`() {
+    fun `returns booking when booking exists`() {
       val booking = Cas3BookingEntityFactory()
         .withDefaults()
         .withStatus(Cas3BookingStatus.confirmed)
         .produce()
 
-      every { mockBookingRepository.findAllByApplicationId(applicationId) } returns listOf(booking)
+      every { mockBookingRepository.findTopByApplicationIdOrderByCreatedAtDesc(applicationId) } returns booking
 
-      val result = cas3BookingService.getLatestBookingStatus(applicationId)
+      val result = cas3BookingService.getLatestBooking(applicationId)
 
-      assertThat(result).isEqualTo(Cas3BookingStatus.confirmed)
-    }
-
-    @Test
-    fun `returns latest booking status when multiple bookings exist`() {
-      val olderBooking = Cas3BookingEntityFactory()
-        .withDefaults()
-        .withStatus(Cas3BookingStatus.provisional)
-        .withCreatedAt(OffsetDateTime.now().minusDays(5))
-        .produce()
-
-      val newerBooking = Cas3BookingEntityFactory()
-        .withDefaults()
-        .withStatus(Cas3BookingStatus.arrived)
-        .withCreatedAt(OffsetDateTime.now())
-        .produce()
-
-      every { mockBookingRepository.findAllByApplicationId(applicationId) } returns listOf(olderBooking, newerBooking)
-
-      val result = cas3BookingService.getLatestBookingStatus(applicationId)
-
-      assertThat(result).isEqualTo(Cas3BookingStatus.arrived)
-    }
-
-    @Test
-    fun `returns null when booking has no status`() {
-      val booking = Cas3BookingEntityFactory()
-        .withDefaults()
-        .produce()
-
-      every { mockBookingRepository.findAllByApplicationId(applicationId) } returns listOf(booking)
-
-      val result = cas3BookingService.getLatestBookingStatus(applicationId)
-
-      assertThat(result).isNull()
+      assertThat(result).isEqualTo(booking)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/external/Cas1ExternalApplicationsTest.kt
@@ -3,11 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.external
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlacementHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
@@ -97,21 +96,13 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
               applicationStatus = ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED,
               requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
               placementStatus = Cas1SpaceBookingStatus.UPCOMING,
-              placementHistories = listOf(
-                Cas1PlacementHistory(
-                  placementStatus = Cas1SpaceBookingStatus.UPCOMING,
-                  requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
-                  premises = SuitablePremisesDto(
-                    startDate = booking.expectedArrivalDate,
-                    endDate = booking.expectedDepartureDate,
-                    addressLine1 = premises.addressLine1,
-                    addressLine2 = premises.addressLine2,
-                    town = premises.town,
-                    postcode = premises.postcode,
-                  ),
-                  dateApplied = booking.expectedArrivalDate,
-                  isSuitable = true,
-                ),
+              premises = Cas1SuitablePremisesDto(
+                startDate = booking.expectedArrivalDate,
+                endDate = booking.expectedDepartureDate,
+                addressLine1 = premises.addressLine1,
+                addressLine2 = premises.addressLine2,
+                town = premises.town,
+                postcode = premises.postcode,
               ),
             )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
@@ -11,12 +11,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1PlacementHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SuitablePremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
@@ -108,36 +107,7 @@ class Cas1ExternalApplicationServiceTest {
           applicationStatus = awaitingPlacementApplication.status,
           requestForPlacementStatus = requestForPlacement2.status,
           placementStatus = null,
-          placementHistories = listOf(
-            Cas1PlacementHistory(
-              dateApplied = requestForPlacement2.statusSetDate,
-              requestForPlacementStatus = requestForPlacement2.status,
-              placementStatus = null,
-              premises = null,
-              isSuitable = true,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = requestForPlacement4.statusSetDate,
-              requestForPlacementStatus = requestForPlacement4.status,
-              placementStatus = null,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = requestForPlacement1.statusSetDate,
-              requestForPlacementStatus = requestForPlacement1.status,
-              placementStatus = null,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = requestForPlacement3.statusSetDate,
-              requestForPlacementStatus = requestForPlacement3.status,
-              placementStatus = null,
-              premises = null,
-              isSuitable = false,
-            ),
-          ),
+          premises = null,
         ),
       )
     }
@@ -257,91 +227,13 @@ class Cas1ExternalApplicationServiceTest {
           applicationStatus = awaitingPlacementApplication.status,
           requestForPlacementStatus = requestForPlacement3.status,
           placementStatus = placement7.status,
-          placementHistories = listOf(
-            Cas1PlacementHistory(
-              dateApplied = placement8.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement2.status,
-              placementStatus = placement8.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement10.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement2.status,
-              placementStatus = placement10.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement9.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement2.status,
-              placementStatus = placement9.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement7.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement3.status,
-              placementStatus = placement7.status,
-              premises = SuitablePremisesDto(
-                startDate = placement7.expectedArrivalDate,
-                endDate = placement7.expectedDepartureDate,
-                addressLine1 = premisesEntity.addressLine1,
-                addressLine2 = premisesEntity.addressLine2,
-                town = premisesEntity.town,
-                postcode = premisesEntity.postcode,
-              ),
-              isSuitable = true,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement1.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement1.status,
-              placementStatus = placement1.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = requestForPlacement4.statusSetDate,
-              requestForPlacementStatus = requestForPlacement4.status,
-              placementStatus = null,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement2.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement1.status,
-              placementStatus = placement2.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement3.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement1.status,
-              placementStatus = placement3.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement4.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement3.status,
-              placementStatus = placement4.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement6.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement3.status,
-              placementStatus = placement6.status,
-              premises = null,
-              isSuitable = false,
-            ),
-            Cas1PlacementHistory(
-              dateApplied = placement5.statusSetDate!!,
-              requestForPlacementStatus = requestForPlacement3.status,
-              placementStatus = placement5.status,
-              premises = null,
-              isSuitable = false,
-            ),
+          premises = Cas1SuitablePremisesDto(
+            startDate = placement7.expectedArrivalDate,
+            endDate = placement7.expectedDepartureDate,
+            addressLine1 = premisesEntity.addressLine1,
+            addressLine2 = premisesEntity.addressLine2,
+            town = premisesEntity.town,
+            postcode = premisesEntity.postcode,
           ),
         ),
       )
@@ -407,7 +299,7 @@ class Cas1ExternalApplicationServiceTest {
       )
         .withStatus(RequestForPlacementStatus.placementBooked).produce()
 
-      val premises = SuitablePremisesDto(
+      val premises = Cas1SuitablePremisesDto(
         startDate = booking.expectedArrivalDate,
         endDate = booking.expectedDepartureDate,
         addressLine1 = premisesEntity.addressLine1,
@@ -429,15 +321,7 @@ class Cas1ExternalApplicationServiceTest {
         applicationStatus = application.status,
         requestForPlacementStatus = requestForPlacement.status,
         placementStatus = placement.status,
-        placementHistories = listOf(
-          Cas1PlacementHistory(
-            requestForPlacementStatus = requestForPlacement.status,
-            placementStatus = placement.status,
-            premises = premises,
-            dateApplied = placement.statusSetDate!!,
-            isSuitable = true,
-          ),
-        ),
+        premises = premises,
       )
       val result = service.getSuitableApplicationByCrn(application.crn)
 
@@ -454,7 +338,7 @@ class Cas1ExternalApplicationServiceTest {
       val suitableApplication = Cas1SuitableApplication(
         id = suitableApprovedPremisesApplication.id,
         applicationStatus = suitableApprovedPremisesApplication.status,
-        placementHistories = listOf(),
+        premises = null,
         requestForPlacementStatus = null,
         placementStatus = null,
       )
@@ -505,7 +389,7 @@ class Cas1ExternalApplicationServiceTest {
       val suitableApplication = Cas1SuitableApplication(
         id = latestAwaitingPlacementApplication.id,
         applicationStatus = ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT,
-        placementHistories = listOf(),
+        premises = null,
         requestForPlacementStatus = null,
         placementStatus = null,
       )
@@ -554,7 +438,7 @@ class Cas1ExternalApplicationServiceTest {
       val suitableApplication = Cas1SuitableApplication(
         id = latestStartedApplication.id,
         applicationStatus = ApprovedPremisesApplicationStatus.STARTED,
-        placementHistories = listOf(),
+        premises = null,
         requestForPlacementStatus = null,
         placementStatus = null,
       )


### PR DESCRIPTION
Added premises info to suitable application as this is needed to help determine the location of the next accommodation.

I've also removed placementHistories from CAS1 application as it is not needed for MVP