### PR TITLE
Remove duplicate apType on assessment accept

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1AssessmentAcceptance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas1AssessmentAcceptance.kt
@@ -10,8 +10,6 @@ data class Cas1AssessmentAcceptance(
 
   @get:JsonProperty("placementDates") val placementDates: PlacementDates? = null,
 
-  @get:JsonProperty("apType") val apType: ApType? = null,
-
   @get:JsonProperty("notes") val notes: String? = null,
 
   @get:JsonProperty("agreeWithShortNoticeReason") val agreeWithShortNoticeReason: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
@@ -295,7 +295,6 @@ class Cas1ApplicationSeedService(
           expectedArrival = application.arrivalDate!!.toLocalDate(),
           duration = 28,
         ),
-        apType = ApType.normal,
         notes = null,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1AssessmentsController.kt
@@ -160,7 +160,6 @@ class Cas1AssessmentsController(
       document = serializedData,
       placementRequirements = cas1AssessmentAcceptance.requirements,
       placementDates = cas1AssessmentAcceptance.placementDates,
-      apType = cas1AssessmentAcceptance.apType,
       notes = cas1AssessmentAcceptance.notes,
       agreeWithShortNoticeReason = cas1AssessmentAcceptance.agreeWithShortNoticeReason,
       agreeWithShortNoticeReasonComments = cas1AssessmentAcceptance.agreeWithShortNoticeReasonComments,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementRequirementsEntity.kt
@@ -40,6 +40,13 @@ data class PlacementRequirementsEntity(
   @JoinColumn(name = "assessment_id")
   val assessment: ApprovedPremisesAssessmentEntity,
 
+  /**
+   * Note - these characteristics _may_ also include the characteristic
+   * for the ap type, if non-standard (this is down to the UI providing it)
+   *
+   * Due to this ambiguity, if ap Type is required, use the [apType] property
+   * instead
+   */
   @ManyToMany
   @JoinTable(
     name = "placement_requirements_essential_criteria",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentDomainEventService.kt
@@ -148,7 +148,7 @@ class Cas1AssessmentDomainEventService(
     assessment: AssessmentEntity,
     offenderDetails: OffenderDetailSummary,
     placementDates: PlacementDates?,
-    apType: ApType?,
+    apType: ApType,
     acceptingUser: UserEntity,
   ) {
     val domainEventId = UUID.randomUUID()
@@ -198,7 +198,7 @@ class Cas1AssessmentDomainEventService(
           ),
         ),
         metadata = mapOf(
-          MetaDataName.CAS1_REQUESTED_AP_TYPE to apType?.asApprovedPremisesType()?.name,
+          MetaDataName.CAS1_REQUESTED_AP_TYPE to apType.asApprovedPremisesType().name,
         ),
         schemaVersion = 2,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
@@ -271,7 +270,6 @@ class Cas1AssessmentService(
     document: String?,
     placementRequirements: PlacementRequirements,
     placementDates: PlacementDates?,
-    apType: ApType?,
     notes: String?,
     agreeWithShortNoticeReason: Boolean? = null,
     agreeWithShortNoticeReasonComments: String? = null,
@@ -325,7 +323,7 @@ class Cas1AssessmentService(
       assessment = assessment,
       offenderDetails = caseSummary.asOffenderDetailSummary(),
       placementDates = placementDates,
-      apType = apType,
+      apType = placementRequirements.type,
       acceptingUser = acceptingUser,
     )
     cas1AssessmentEmailService.assessmentAccepted(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1ApplicationV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1ApplicationV2ReportTest.kt
@@ -13,10 +13,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AppealDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewAppeal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewClarificationNote
@@ -1040,7 +1040,7 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
       this,
       assessmentId,
       assessorJwt,
-      AssessmentAcceptance(
+      Cas1AssessmentAcceptance(
         document = mapOf("document" to "value"),
         requirements = placementRequirements,
         placementDates = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1ApplicationV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1ApplicationV2ReportTest.kt
@@ -1027,7 +1027,7 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
     val desirableCriteria = listOf(PlacementCriteria.isRecoveryFocussed, PlacementCriteria.acceptsSexOffenders)
 
     val placementRequirements = PlacementRequirements(
-      type = ApType.normal,
+      type = apType,
       location = postCodeDistrictFactory.produceAndPersist().outcode,
       radius = 50,
       essentialCriteria = essentialCriteria,
@@ -1044,7 +1044,6 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
         document = mapOf("document" to "value"),
         requirements = placementRequirements,
         placementDates = null,
-        apType = apType,
         agreeWithShortNoticeReason = agreeWithShortNoticeReason,
         agreeWithShortNoticeReasonComments = agreeWithShortNoticeReasonComments,
         reasonForLateApplication = reasonForLateApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -733,7 +733,6 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
             duration = duration,
           )
         },
-        apType = ApType.normal,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewBookingNotMade
@@ -724,7 +724,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       this,
       assessmentId,
       assessorJwt,
-      AssessmentAcceptance(
+      Cas1AssessmentAcceptance(
         document = mapOf("document" to "value"),
         requirements = placementRequirements,
         placementDates = expectedArrival?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementReportTest.kt
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
@@ -739,7 +739,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
       this,
       assessmentId,
       assessorJwt,
-      AssessmentAcceptance(
+      Cas1AssessmentAcceptance(
         document = mapOf("document" to "value"),
         requirements = placementRequirements,
         placementDates = expectedArrival?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementReportTest.kt
@@ -748,7 +748,6 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
             duration = duration,
           )
         },
-        apType = ApType.normal,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
@@ -781,7 +781,6 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
             duration = duration!!,
           )
         },
-        apType = ApType.normal,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcce
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewPlacementApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewReallocation
@@ -771,7 +772,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       this,
       assessmentId,
       assessorJwt,
-      AssessmentAcceptance(
+      Cas1AssessmentAcceptance(
         document = mapOf("document" to "value"),
         requirements = placementRequirements,
         placementDates = expectedArrival?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -122,7 +122,7 @@ class Cas1SimpleApiClient {
    *
    * Once we've migrated these existing entries to also
    * have an entry in placement_applications, we can remove
-   * this function, and remove
+   * this function, and remove [AssessmentAcceptance]
    */
   fun assessmentAcceptLegacyBehaviour(
     integrationTestBase: IntegrationTestBase,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SimpleApiClient.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentRejection
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1AssessmentAcceptance
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewArrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1NewSpaceBookingCancellation
@@ -101,7 +102,7 @@ class Cas1SimpleApiClient {
     integrationTestBase: IntegrationTestBase,
     assessmentId: UUID,
     assessorJwt: String,
-    body: AssessmentAcceptance,
+    body: Cas1AssessmentAcceptance,
   ) {
     integrationTestBase.webTestClient.post()
       .uri("/cas1/assessments/$assessmentId/acceptance")
@@ -121,7 +122,7 @@ class Cas1SimpleApiClient {
    *
    * Once we've migrated these existing entries to also
    * have an entry in placement_applications, we can remove
-   * this function
+   * this function, and remove
    */
   fun assessmentAcceptLegacyBehaviour(
     integrationTestBase: IntegrationTestBase,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
@@ -902,7 +902,7 @@ class Cas1AssessmentServiceTest {
         .withData("{\"test\": \"data\"}")
 
       placementRequirements = PlacementRequirements(
-        type = ApType.normal,
+        type = ApType.esap,
         location = "AB123",
         radius = 50,
         desirableCriteria = listOf(),
@@ -1144,7 +1144,7 @@ class Cas1AssessmentServiceTest {
         )
       } returns placementRequirementEntity
 
-      every { cas1AssessmentDomainEventService.assessmentAccepted(any(), any(), any(), any(), any(), any()) } just Runs
+      every { cas1AssessmentDomainEventService.assessmentAccepted(any(), any(), any(), any(), ApType.esap, any()) } just Runs
 
       every { cas1AssessmentEmailServiceMock.assessmentAccepted(any()) } just Runs
 
@@ -1282,7 +1282,6 @@ class Cas1AssessmentServiceTest {
         "{\"test\": \"data\"}",
         placementRequirements,
         placementDates,
-        null,
         notes,
       )
 


### PR DESCRIPTION
Before this commit the `apType` on the `Cas1AssessmentAcceptance` type was defined in two places:

1. As `apType: ApType?`
2. As `requirements.apType: ApType`

The former was only used when creating the domain event. The later was persisted to the `placementRequest.placementRequirements`

This commit removes `apType: ApType?` and replaces its usage with the non-nullable `requirements.apType: ApType`