### PR TITLE
FM-601 Add CAS 2 cohort property

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2CohortDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2CohortDto.kt
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue
 
 enum class Cas2CohortDto(@get:JsonValue val value: String) {
   HOME_DETENTION_CURFEW("hdc"),
-  BAIL("bail"),
-  COURT("court"),
+  PRISON_BAIL("prisonBail"),
+  COURT_BAIL("courtBail"),
   ALTERNATIVE_TO_CUSTODIAL_RECALL("atcr"),
   HOMELESS_AT_CONDITIONAL_RELEASE_DATE("hcrd"),
   HOMELESS_AT_END_OF_FIXED_TERM_RECALL("hefr"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2CohortDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2CohortDto.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 
-enum class Cas2v2CohortDto(@get:JsonValue val value: String) {
+enum class Cas2CohortDto(@get:JsonValue val value: String) {
   HOME_DETENTION_CURFEW("hdc"),
   BAIL("bail"),
   COURT("court"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2Application.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2Application.kt
@@ -35,4 +35,7 @@ data class Cas2v2Application(
   @get:JsonProperty("timelineEvents") val timelineEvents: List<Cas2TimelineEvent>? = null,
 
   @get:JsonProperty("bailHearingDate") val bailHearingDate: LocalDate? = null,
+
+  @get:JsonProperty("cohort") val cohort: Cas2v2CohortDto? = null,
+
 ) : Application

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2Application.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2Application.kt
@@ -36,6 +36,6 @@ data class Cas2v2Application(
 
   @get:JsonProperty("bailHearingDate") val bailHearingDate: LocalDate? = null,
 
-  @get:JsonProperty("cohort") val cohort: Cas2v2CohortDto? = null,
+  @get:JsonProperty("cohort") val cohort: Cas2CohortDto? = null,
 
 ) : Application

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ApplicationSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ApplicationSummary.kt
@@ -42,5 +42,5 @@ data class Cas2v2ApplicationSummary(
 
   @get:JsonProperty("prisonCode") val prisonCode: String? = null,
 
-  @get:JsonProperty("cohort") val cohort: Cas2v2CohortDto? = null,
+  @get:JsonProperty("cohort") val cohort: Cas2CohortDto? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ApplicationSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ApplicationSummary.kt
@@ -41,4 +41,6 @@ data class Cas2v2ApplicationSummary(
   @get:JsonProperty("bailHearingDate") val bailHearingDate: LocalDate? = null,
 
   @get:JsonProperty("prisonCode") val prisonCode: String? = null,
+
+  @get:JsonProperty("cohort") val cohort: Cas2v2CohortDto? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2CohortDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2CohortDto.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class Cas2v2CohortDto(@get:JsonValue val value: String) {
+  HOME_DETENTION_CURFEW("hdc"),
+  BAIL("bail"),
+  COURT("court"),
+  ALTERNATIVE_TO_CUSTODIAL_RECALL("atcr"),
+  HOMELESS_AT_CONDITIONAL_RELEASE_DATE("hcrd"),
+  HOMELESS_AT_END_OF_FIXED_TERM_RECALL("hefr"),
+  INTENSIVE_SUPERVISION_COURTS("isc"),
+  RISK_ASSESSED_RECALL_REVIEW("rarr"),
+  REFERRAL_FROM_APPROVED_PREMISES("from_ap"),
+  ;
+
+  companion object {
+    @JvmStatic
+    @JsonCreator
+    fun forValue(value: String) = values().first { it.value == value }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/UpdateCas2v2Application.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/UpdateCas2v2Application.kt
@@ -10,4 +10,7 @@ data class UpdateCas2v2Application(
   @get:JsonProperty("data", required = true) override val `data`: Map<String, Any>,
 
   @get:JsonProperty("bailHearingDate") val bailHearingDate: LocalDate? = null,
+
+  @get:JsonProperty("cohort") val cohort: Cas2v2CohortDto? = null,
+
 ) : UpdateApplication

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/UpdateCas2v2Application.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/UpdateCas2v2Application.kt
@@ -11,6 +11,6 @@ data class UpdateCas2v2Application(
 
   @get:JsonProperty("bailHearingDate") val bailHearingDate: LocalDate? = null,
 
-  @get:JsonProperty("cohort") val cohort: Cas2v2CohortDto? = null,
+  @get:JsonProperty("cohort") val cohort: Cas2CohortDto? = null,
 
 ) : UpdateApplication

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
@@ -23,6 +23,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import java.time.LocalDate
@@ -77,6 +78,18 @@ interface Cas2LockableApplicationRepository : JpaRepository<Cas2LockableApplicat
   fun acquirePessimisticLock(id: UUID): Cas2LockableApplicationEntity?
 }
 
+enum class Cas2v2Cohort(val apiType: Cas2v2CohortDto) {
+  HDC(Cas2v2CohortDto.HOME_DETENTION_CURFEW),
+  BAIL(Cas2v2CohortDto.BAIL),
+  COURT(Cas2v2CohortDto.COURT),
+  ATCR(Cas2v2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL),
+  HCRD(Cas2v2CohortDto.HOMELESS_AT_CONDITIONAL_RELEASE_DATE),
+  HEFR(Cas2v2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL),
+  ISC(Cas2v2CohortDto.INTENSIVE_SUPERVISION_COURTS),
+  RARR(Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW),
+  FROM_AP(Cas2v2CohortDto.REFERRAL_FROM_APPROVED_PREMISES),
+}
+
 @Entity
 @Table(name = "cas_2_applications")
 data class Cas2ApplicationEntity(
@@ -127,6 +140,9 @@ data class Cas2ApplicationEntity(
 
   @Enumerated(EnumType.STRING)
   var serviceOrigin: Cas2ServiceOrigin,
+
+  @Enumerated(EnumType.STRING)
+  var cohort: Cas2v2Cohort? = null,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
   fun isCreatedBy(user: Cas2UserEntity): Boolean = createdByUser.id == user.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
@@ -81,8 +81,8 @@ interface Cas2LockableApplicationRepository : JpaRepository<Cas2LockableApplicat
 
 enum class Cas2Cohort(val apiType: Cas2CohortDto) {
   HDC(Cas2CohortDto.HOME_DETENTION_CURFEW),
-  BAIL(Cas2CohortDto.BAIL),
-  COURT(Cas2CohortDto.COURT),
+  PRISON_BAIL(Cas2CohortDto.PRISON_BAIL),
+  COURT_BAIL(Cas2CohortDto.COURT_BAIL),
   ATCR(Cas2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL),
   HCRD(Cas2CohortDto.HOMELESS_AT_CONDITIONAL_RELEASE_DATE),
   HEFR(Cas2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import io.hypersistence.utils.hibernate.type.json.JsonType
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
@@ -88,6 +89,13 @@ enum class Cas2v2Cohort(val apiType: Cas2v2CohortDto) {
   ISC(Cas2v2CohortDto.INTENSIVE_SUPERVISION_COURTS),
   RARR(Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW),
   FROM_AP(Cas2v2CohortDto.REFERRAL_FROM_APPROVED_PREMISES),
+  ;
+
+  companion object {
+    @JvmStatic
+    @JsonCreator
+    fun forValue(value: String) = values().first { it.apiType.value == value }
+  }
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
@@ -24,7 +24,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import java.time.LocalDate
@@ -79,16 +79,16 @@ interface Cas2LockableApplicationRepository : JpaRepository<Cas2LockableApplicat
   fun acquirePessimisticLock(id: UUID): Cas2LockableApplicationEntity?
 }
 
-enum class Cas2v2Cohort(val apiType: Cas2v2CohortDto) {
-  HDC(Cas2v2CohortDto.HOME_DETENTION_CURFEW),
-  BAIL(Cas2v2CohortDto.BAIL),
-  COURT(Cas2v2CohortDto.COURT),
-  ATCR(Cas2v2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL),
-  HCRD(Cas2v2CohortDto.HOMELESS_AT_CONDITIONAL_RELEASE_DATE),
-  HEFR(Cas2v2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL),
-  ISC(Cas2v2CohortDto.INTENSIVE_SUPERVISION_COURTS),
-  RARR(Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW),
-  FROM_AP(Cas2v2CohortDto.REFERRAL_FROM_APPROVED_PREMISES),
+enum class Cas2Cohort(val apiType: Cas2CohortDto) {
+  HDC(Cas2CohortDto.HOME_DETENTION_CURFEW),
+  BAIL(Cas2CohortDto.BAIL),
+  COURT(Cas2CohortDto.COURT),
+  ATCR(Cas2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL),
+  HCRD(Cas2CohortDto.HOMELESS_AT_CONDITIONAL_RELEASE_DATE),
+  HEFR(Cas2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL),
+  ISC(Cas2CohortDto.INTENSIVE_SUPERVISION_COURTS),
+  RARR(Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW),
+  FROM_AP(Cas2CohortDto.REFERRAL_FROM_APPROVED_PREMISES),
   ;
 
   companion object {
@@ -150,7 +150,7 @@ data class Cas2ApplicationEntity(
   var serviceOrigin: Cas2ServiceOrigin,
 
   @Enumerated(EnumType.STRING)
-  var cohort: Cas2v2Cohort? = null,
+  var cohort: Cas2Cohort? = null,
 ) {
   override fun toString() = "Cas2ApplicationEntity: $id"
   fun isCreatedBy(user: Cas2UserEntity): Boolean = createdByUser.id == user.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.springframework.data.domain.Page
@@ -90,4 +92,7 @@ data class Cas2ApplicationSummaryEntity(
   var applicationOrigin: String? = null,
   @Column(name = "service_origin")
   var serviceOrigin: String? = null,
+  @Column(name = "cohort")
+  @Enumerated(EnumType.STRING)
+  var cohort: Cas2v2Cohort? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationSummaryEntity.kt
@@ -94,5 +94,5 @@ data class Cas2ApplicationSummaryEntity(
   var serviceOrigin: String? = null,
   @Column(name = "cohort")
   @Enumerated(EnumType.STRING)
-  var cohort: Cas2v2Cohort? = null,
+  var cohort: Cas2Cohort? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
@@ -160,6 +161,7 @@ class Cas2ApplicationService(
         telephoneNumber = null,
         applicationOrigin = ApplicationOrigin.homeDetentionCurfew,
         serviceOrigin = Cas2ServiceOrigin.HDC,
+        cohort = Cas2v2Cohort.HDC,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -16,9 +16,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.SubmitCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
@@ -161,7 +161,7 @@ class Cas2ApplicationService(
         telephoneNumber = null,
         applicationOrigin = ApplicationOrigin.homeDetentionCurfew,
         serviceOrigin = Cas2ServiceOrigin.HDC,
-        cohort = Cas2v2Cohort.HDC,
+        cohort = Cas2Cohort.HDC,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2ApplicationController.kt
@@ -165,6 +165,7 @@ class Cas2v2ApplicationController(
         data = serializedData,
         user,
         body.bailHearingDate,
+        body.cohort,
       )
 
       else -> throw RuntimeException("Unsupported UpdateApplication type: ${body::class.qualifiedName}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ApplicationService.kt
@@ -12,16 +12,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummarySpecifications
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
@@ -188,7 +188,7 @@ class Cas2v2ApplicationService(
     data: String?,
     user: Cas2UserEntity,
     bailHearingDate: LocalDate?,
-    cohort: Cas2v2CohortDto?,
+    cohort: Cas2CohortDto?,
   ): CasResult<Cas2ApplicationEntity> {
     val application = cas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)
       ?: return CasResult.NotFound("Cas2ApplicationEntity", applicationId.toString())
@@ -206,7 +206,7 @@ class Cas2v2ApplicationService(
     }
 
     application.bailHearingDate = bailHearingDate
-    application.cohort = cohort?.let { Cas2v2Cohort.forValue(cohort.value) }
+    application.cohort = cohort?.let { Cas2Cohort.forValue(cohort.value) }
 
     application.apply {
       this.data = removeXssCharacters(data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ApplicationService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationRepository
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummarySpecifications
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
@@ -186,6 +188,7 @@ class Cas2v2ApplicationService(
     data: String?,
     user: Cas2UserEntity,
     bailHearingDate: LocalDate?,
+    cohort: Cas2v2CohortDto?,
   ): CasResult<Cas2ApplicationEntity> {
     val application = cas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)
       ?: return CasResult.NotFound("Cas2ApplicationEntity", applicationId.toString())
@@ -203,6 +206,7 @@ class Cas2v2ApplicationService(
     }
 
     application.bailHearingDate = bailHearingDate
+    application.cohort = cohort?.let { Cas2v2Cohort.forValue(cohort.value) }
 
     application.apply {
       this.data = removeXssCharacters(data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2ApplicationsTransformer.kt
@@ -45,6 +45,7 @@ class Cas2v2ApplicationsTransformer(
     assessment = if (jpa.assessment != null) cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
     timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
     applicationOrigin = jpa.applicationOrigin,
+    cohort = jpa.cohort?.apiType,
   )
 
   fun transformJpaAndFullPersonToApiSubmitted(jpa: Cas2ApplicationEntity, fullPerson: Person): Cas2v2SubmittedApplication = Cas2v2SubmittedApplication(
@@ -78,6 +79,7 @@ class Cas2v2ApplicationsTransformer(
     personName = personName,
     prisonCode = jpaSummary.prisonCode,
     applicationOrigin = jpaSummary.applicationOrigin?.let { ApplicationOrigin.forValue(it) } ?: ApplicationOrigin.homeDetentionCurfew,
+    cohort = jpaSummary.cohort?.apiType,
   )
 
   fun applicationOriginFromText(applicationOrigin: String): ApplicationOrigin = when (applicationOrigin) {

--- a/src/main/resources/db/migration/all/20260519162205__add_cas2_applications_cohort.sql
+++ b/src/main/resources/db/migration/all/20260519162205__add_cas2_applications_cohort.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cas_2_applications ADD cohort text NULL;

--- a/src/main/resources/db/migration/all/20261021113642__add_cohort_to_cas_2_application_summary_views.sql
+++ b/src/main/resources/db/migration/all/20261021113642__add_cohort_to_cas_2_application_summary_views.sql
@@ -1,0 +1,72 @@
+DROP VIEW IF EXISTS cas_2_application_live_summary;
+DROP VIEW IF EXISTS cas_2_application_summary;
+
+CREATE VIEW cas_2_application_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       a.created_by_cas2_user_id::text AS created_by_cas2_user_id,
+       cu.name AS created_by_cas2_user_name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       asu.label,
+       asu.status_id::text        AS status_id,
+       a.referring_prison_code,
+       a.conditional_release_date,
+       a.bail_hearing_date,
+       a.application_origin,
+       a.service_origin,
+       asu.created_at             AS status_created_at,
+       a.abandoned_at,
+       aa.allocated_pom_cas_2_user_id,
+       cu2.name as allocated_pom_cas_2_name,
+       aa.created_at  as assignment_date,
+       aa.prison_code as current_prison_code,
+       a.cohort
+FROM cas_2_applications a
+         LEFT JOIN (SELECT DISTINCT ON (aa.application_id) *
+                    FROM cas_2_application_assignments aa
+                    ORDER BY aa.application_id, created_at DESC) aa ON a.id = aa.application_id
+
+         LEFT JOIN (SELECT DISTINCT ON (su.application_id) su.application_id,
+                                                           su.label,
+                                                           su.status_id,
+                                                           su.created_at
+                    FROM cas_2_status_updates su
+                    ORDER BY su.application_id, su.created_at DESC) asu ON a.id = asu.application_id
+         LEFT JOIN cas_2_users cu ON cu.id = a.created_by_cas2_user_id
+         LEFT JOIN cas_2_users cu2 ON cu2.id = aa.allocated_pom_cas_2_user_id;
+
+CREATE VIEW cas_2_application_live_summary AS
+SELECT a.id,
+       a.crn,
+       a.noms_number,
+       a.created_by_cas2_user_id::text AS created_by_cas2_user_id,
+       a.created_by_cas2_user_name AS created_by_cas2_user_name,
+       a.created_at,
+       a.submitted_at,
+       a.hdc_eligibility_date,
+       a.label,
+       a.status_id,
+       a.referring_prison_code,
+       a.abandoned_at,
+       a.allocated_pom_cas_2_user_id,
+       a.allocated_pom_cas_2_name,
+       a.assignment_date,
+       a.current_prison_code,
+       a.bail_hearing_date,
+       a.application_origin,
+       a.service_origin,
+       a.cohort
+FROM cas_2_application_summary a
+WHERE (a.conditional_release_date IS NULL OR a.conditional_release_date >= CURRENT_DATE) AND a.abandoned_at IS NULL AND
+      a.status_id IS NULL
+   OR a.status_id = '004e2419-9614-4c1e-a207-a8418009f23d'::text AND
+      a.status_created_at > (CURRENT_DATE - '32 days'::interval)
+   OR a.status_id = 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9'::text AND
+      a.status_created_at > (CURRENT_DATE - '32 days'::interval)
+   OR a.status_id = '89458555-3219-44a2-9584-c4f715d6b565'::text AND
+      a.status_created_at > (CURRENT_DATE - '32 days'::interval)
+   OR (a.status_id <> ALL
+       (ARRAY ['004e2419-9614-4c1e-a207-a8418009f23d'::text, 'f13bbdd6-44f1-4362-b9d3-e6f1298b1bf9'::text, '89458555-3219-44a2-9584-c4f715d6b565'::text]));

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/factory/Cas2ApplicationEntityFactory.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
@@ -43,6 +44,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var applicationOrigin: Yielded<ApplicationOrigin> = { ApplicationOrigin.homeDetentionCurfew }
   private var serviceOrigin: Yielded<Cas2ServiceOrigin> = { Cas2ServiceOrigin.HDC }
   private var bailHearingDate: Yielded<LocalDate?> = { null }
+  private var cohort: Yielded<Cas2v2Cohort> = { Cas2v2Cohort.HDC }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -153,6 +155,10 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.bailHearingDate = { bailHearingDate }
   }
 
+  fun withCohort(cohort: Cas2v2Cohort) = apply {
+    this.cohort = { cohort }
+  }
+
   @SuppressWarnings("TooGenericExceptionThrown")
   override fun produce(): Cas2ApplicationEntity {
     val application = Cas2ApplicationEntity(
@@ -177,6 +183,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
       applicationOrigin = this.applicationOrigin(),
       bailHearingDate = this.bailHearingDate(),
       serviceOrigin = this.serviceOrigin(),
+      cohort = this.cohort(),
     )
     return application
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/factory/Cas2ApplicationEntityFactory.kt
@@ -8,9 +8,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
@@ -44,7 +44,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var applicationOrigin: Yielded<ApplicationOrigin> = { ApplicationOrigin.homeDetentionCurfew }
   private var serviceOrigin: Yielded<Cas2ServiceOrigin> = { Cas2ServiceOrigin.HDC }
   private var bailHearingDate: Yielded<LocalDate?> = { null }
-  private var cohort: Yielded<Cas2v2Cohort> = { Cas2v2Cohort.HDC }
+  private var cohort: Yielded<Cas2Cohort> = { Cas2Cohort.HDC }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -155,7 +155,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.bailHearingDate = { bailHearingDate }
   }
 
-  fun withCohort(cohort: Cas2v2Cohort) = apply {
+  fun withCohort(cohort: Cas2Cohort) = apply {
     this.cohort = { cohort }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
@@ -24,10 +24,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
@@ -1599,7 +1599,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             }
 
             val savedApplication = realApplicationRepository.findById(returnedApplication.id).get()
-            assertThat(savedApplication.cohort).isEqualTo(Cas2v2Cohort.HDC)
+            assertThat(savedApplication.cohort).isEqualTo(Cas2Cohort.HDC)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
@@ -1592,9 +1593,13 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               it.matches(Regex("/cas2/applications/.+"))
             }
 
-            assertThat(result.responseBody.blockFirst()!!).matches {
+            val returnedApplication = result.responseBody.blockFirst()!!
+            assertThat(returnedApplication).matches {
               it.person.crn == offenderDetails.otherIds.crn
             }
+
+            val savedApplication = realApplicationRepository.findById(returnedApplication.id).get()
+            assertThat(savedApplication.cohort).isEqualTo(Cas2v2Cohort.HDC)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
@@ -16,8 +16,10 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -27,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
@@ -713,6 +716,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                     withConditionalReleaseDate(LocalDate.now().randomDateAfter(14))
                     withApplicationOrigin(ApplicationOrigin.courtBail)
                     withServiceOrigin(Cas2ServiceOrigin.BAIL)
+                    withCohort(Cas2v2Cohort.HEFR)
                   }.id,
                 )
               }
@@ -730,6 +734,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                     withConditionalReleaseDate(LocalDate.now())
                     withApplicationOrigin(ApplicationOrigin.courtBail)
                     withServiceOrigin(Cas2ServiceOrigin.BAIL)
+                    withCohort(Cas2v2Cohort.HEFR)
                   }.id,
                 )
               }
@@ -757,6 +762,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                     withData("{}")
                     withApplicationOrigin(ApplicationOrigin.courtBail)
                     withServiceOrigin(Cas2ServiceOrigin.BAIL)
+                    withCohort(Cas2v2Cohort.ATCR)
                   }.id,
                 )
               }
@@ -806,6 +812,16 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
       Assertions.assertThat(responseBody).noneMatch {
         excludedApplicationId == it.id
       }
+
+      Assertions.assertThat(responseBody.filter { it.status == ApplicationStatus.submitted })
+        .allMatch {
+          it.cohort == Cas2v2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL
+        }
+
+      Assertions.assertThat(responseBody.filter { it.status == ApplicationStatus.inProgress })
+        .allMatch {
+          it.cohort == Cas2v2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL
+        }
 
       val uuids = responseBody.map { it.id }.toSet()
       Assertions.assertThat(uuids).isEqualTo(submittedIds.union(unSubmittedIds))
@@ -1127,6 +1143,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                 data,
               )
               withApplicationOrigin(ApplicationOrigin.courtBail)
+              withCohort(Cas2v2Cohort.ISC)
             }
 
             val rawResponseBody = webTestClient.get()
@@ -1149,6 +1166,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             assertThat(responseBody.createdAt).isEqualTo(applicationEntity.createdAt.toInstant())
             assertThat(responseBody.createdBy.id).isEqualTo(applicationEntity.createdByUser.id)
             assertThat(responseBody.submittedAt).isEqualTo(applicationEntity.submittedAt?.toInstant())
+            assertThat(responseBody.cohort).isEqualTo(Cas2v2CohortDto.INTENSIVE_SUPERVISION_COURTS)
             assertThat(serializableToJsonNode(responseBody.data)).isEqualTo(serializableToJsonNode(applicationEntity.data))
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
@@ -1576,6 +1576,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
           withCreatedByUser(submittingUser)
           withApplicationOrigin(ApplicationOrigin.courtBail)
           withServiceOrigin(Cas2ServiceOrigin.BAIL)
+          withCohort(Cas2v2Cohort.FROM_AP)
         }
 
         val resultBody = webTestClient.put()
@@ -1585,6 +1586,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             UpdateCas2v2Application(
               data = mapOf("thingId" to 123),
               type = UpdateApplicationType.CAS2V2,
+              cohort = Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW,
             ),
           )
           .exchange()
@@ -1597,6 +1599,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         val result = jsonMapper.readValue(resultBody, Cas2v2Application::class.java)
 
         Assertions.assertThat(result.person.crn).isEqualTo(offenderDetails.otherIds.crn)
+        Assertions.assertThat(result.cohort).isEqualTo(Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
@@ -17,19 +17,19 @@ import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApplicationType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2StatusUpdateEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
@@ -716,7 +716,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                     withConditionalReleaseDate(LocalDate.now().randomDateAfter(14))
                     withApplicationOrigin(ApplicationOrigin.courtBail)
                     withServiceOrigin(Cas2ServiceOrigin.BAIL)
-                    withCohort(Cas2v2Cohort.HEFR)
+                    withCohort(Cas2Cohort.HEFR)
                   }.id,
                 )
               }
@@ -734,7 +734,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                     withConditionalReleaseDate(LocalDate.now())
                     withApplicationOrigin(ApplicationOrigin.courtBail)
                     withServiceOrigin(Cas2ServiceOrigin.BAIL)
-                    withCohort(Cas2v2Cohort.HEFR)
+                    withCohort(Cas2Cohort.HEFR)
                   }.id,
                 )
               }
@@ -762,7 +762,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                     withData("{}")
                     withApplicationOrigin(ApplicationOrigin.courtBail)
                     withServiceOrigin(Cas2ServiceOrigin.BAIL)
-                    withCohort(Cas2v2Cohort.ATCR)
+                    withCohort(Cas2Cohort.ATCR)
                   }.id,
                 )
               }
@@ -815,12 +815,12 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
 
       Assertions.assertThat(responseBody.filter { it.status == ApplicationStatus.submitted })
         .allMatch {
-          it.cohort == Cas2v2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL
+          it.cohort == Cas2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL
         }
 
       Assertions.assertThat(responseBody.filter { it.status == ApplicationStatus.inProgress })
         .allMatch {
-          it.cohort == Cas2v2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL
+          it.cohort == Cas2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL
         }
 
       val uuids = responseBody.map { it.id }.toSet()
@@ -1143,7 +1143,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
                 data,
               )
               withApplicationOrigin(ApplicationOrigin.courtBail)
-              withCohort(Cas2v2Cohort.ISC)
+              withCohort(Cas2Cohort.ISC)
             }
 
             val rawResponseBody = webTestClient.get()
@@ -1166,7 +1166,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             assertThat(responseBody.createdAt).isEqualTo(applicationEntity.createdAt.toInstant())
             assertThat(responseBody.createdBy.id).isEqualTo(applicationEntity.createdByUser.id)
             assertThat(responseBody.submittedAt).isEqualTo(applicationEntity.submittedAt?.toInstant())
-            assertThat(responseBody.cohort).isEqualTo(Cas2v2CohortDto.INTENSIVE_SUPERVISION_COURTS)
+            assertThat(responseBody.cohort).isEqualTo(Cas2CohortDto.INTENSIVE_SUPERVISION_COURTS)
             assertThat(serializableToJsonNode(responseBody.data)).isEqualTo(serializableToJsonNode(applicationEntity.data))
           }
         }
@@ -1576,7 +1576,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
           withCreatedByUser(submittingUser)
           withApplicationOrigin(ApplicationOrigin.courtBail)
           withServiceOrigin(Cas2ServiceOrigin.BAIL)
-          withCohort(Cas2v2Cohort.FROM_AP)
+          withCohort(Cas2Cohort.FROM_AP)
         }
 
         val resultBody = webTestClient.put()
@@ -1586,7 +1586,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             UpdateCas2v2Application(
               data = mapOf("thingId" to 123),
               type = UpdateApplicationType.CAS2V2,
-              cohort = Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW,
+              cohort = Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW,
             ),
           )
           .exchange()
@@ -1599,7 +1599,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         val result = jsonMapper.readValue(resultBody, Cas2v2Application::class.java)
 
         Assertions.assertThat(result.person.crn).isEqualTo(offenderDetails.otherIds.crn)
-        Assertions.assertThat(result.cohort).isEqualTo(Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW)
+        Assertions.assertThat(result.cohort).isEqualTo(Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/service/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/service/Cas2v2ApplicationServiceTest.kt
@@ -22,7 +22,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
@@ -35,10 +35,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummarySpecifications
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.service.Cas2v2ApplicationService
@@ -549,7 +549,7 @@ class Cas2v2ApplicationServiceTest {
 
       val bailHearingDate = LocalDate.of(2030, 12, 18)
       val formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
-      val cohort = Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW
+      val cohort = Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW
 
       val updatedData = """
       {
@@ -563,7 +563,7 @@ class Cas2v2ApplicationServiceTest {
         .withId(applicationId)
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
         .withCreatedByUser(user)
-        .withCohort(Cas2v2Cohort.HEFR)
+        .withCohort(Cas2Cohort.HEFR)
         .produce()
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns
@@ -579,7 +579,7 @@ class Cas2v2ApplicationServiceTest {
         data = updatedData,
         user = user,
         bailHearingDate,
-        Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW,
+        Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW,
       )
 
       result as CasResult.Success
@@ -590,7 +590,7 @@ class Cas2v2ApplicationServiceTest {
 
       assertThat(cas2v2Application.data).isEqualTo(updatedData)
       assertThat(cas2v2Application.bailHearingDate).isEqualTo(bailHearingDate)
-      assertThat(cas2v2Application.cohort).isEqualTo(Cas2v2Cohort.RARR)
+      assertThat(cas2v2Application.cohort).isEqualTo(Cas2Cohort.RARR)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/service/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/service/Cas2v2ApplicationServiceTest.kt
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
@@ -37,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2LockableApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.service.Cas2v2ApplicationService
@@ -409,6 +411,7 @@ class Cas2v2ApplicationServiceTest {
           data = "{}",
           user = user,
           null,
+          null,
         ) is CasResult.NotFound,
       ).isTrue
     }
@@ -436,6 +439,7 @@ class Cas2v2ApplicationServiceTest {
           data = "{}",
           user = user,
           null,
+          null,
         ) is CasResult.Unauthorised,
       ).isTrue
     }
@@ -458,6 +462,7 @@ class Cas2v2ApplicationServiceTest {
         applicationId = applicationId,
         data = "{}",
         user = user,
+        null,
         null,
       )
 
@@ -483,6 +488,7 @@ class Cas2v2ApplicationServiceTest {
         applicationId = applicationId,
         data = "{}",
         user = user,
+        null,
         null,
       )
 
@@ -521,6 +527,7 @@ class Cas2v2ApplicationServiceTest {
         data = updatedData,
         user = user,
         null,
+        null,
       )
 
       result as CasResult.Success
@@ -542,11 +549,13 @@ class Cas2v2ApplicationServiceTest {
 
       val bailHearingDate = LocalDate.of(2030, 12, 18)
       val formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+      val cohort = Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW
 
       val updatedData = """
       {
-        "aProperty": "value"
-        "bailHearingDate": "${bailHearingDate.format(formatter)}"
+        "aProperty": "value",
+        "bailHearingDate": "${bailHearingDate.format(formatter)}",
+        "cohort": "${cohort.value}",
       }
     """
 
@@ -554,6 +563,7 @@ class Cas2v2ApplicationServiceTest {
         .withId(applicationId)
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
         .withCreatedByUser(user)
+        .withCohort(Cas2v2Cohort.HEFR)
         .produce()
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns
@@ -569,6 +579,7 @@ class Cas2v2ApplicationServiceTest {
         data = updatedData,
         user = user,
         bailHearingDate,
+        Cas2v2CohortDto.RISK_ASSESSED_RECALL_REVIEW,
       )
 
       result as CasResult.Success
@@ -579,6 +590,7 @@ class Cas2v2ApplicationServiceTest {
 
       assertThat(cas2v2Application.data).isEqualTo(updatedData)
       assertThat(cas2v2Application.bailHearingDate).isEqualTo(bailHearingDate)
+      assertThat(cas2v2Application.cohort).isEqualTo(Cas2v2Cohort.RARR)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessment
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2v2StatusUpdate
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2ApplicationsTransformer
@@ -87,7 +87,7 @@ class Cas2v2ApplicationTransformerTest {
         .withSubmittedAt(null)
         .withApplicationOrigin(ApplicationOrigin.prisonBail)
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
-        .withCohort(Cas2v2Cohort.BAIL)
+        .withCohort(Cas2Cohort.BAIL)
         .produce()
 
       val result = cas2v2ApplicationsTransformer.transformJpaToApi(application, mockk())
@@ -115,7 +115,7 @@ class Cas2v2ApplicationTransformerTest {
       assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
       assertThat(result.timelineEvents).isEqualTo(listOf<Cas2TimelineEvent>())
       assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.prisonBail)
-      assertThat(result.cohort).isEqualTo(Cas2v2CohortDto.BAIL)
+      assertThat(result.cohort).isEqualTo(Cas2CohortDto.BAIL)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -87,7 +87,7 @@ class Cas2v2ApplicationTransformerTest {
         .withSubmittedAt(null)
         .withApplicationOrigin(ApplicationOrigin.prisonBail)
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
-        .withCohort(Cas2Cohort.BAIL)
+        .withCohort(Cas2Cohort.PRISON_BAIL)
         .produce()
 
       val result = cas2v2ApplicationsTransformer.transformJpaToApi(application, mockk())
@@ -115,7 +115,7 @@ class Cas2v2ApplicationTransformerTest {
       assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
       assertThat(result.timelineEvents).isEqualTo(listOf<Cas2TimelineEvent>())
       assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.prisonBail)
-      assertThat(result.cohort).isEqualTo(Cas2CohortDto.BAIL)
+      assertThat(result.cohort).isEqualTo(Cas2CohortDto.PRISON_BAIL)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessment
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2CohortDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2v2StatusUpdate
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationSummaryEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2ApplicationsTransformer
@@ -85,6 +87,7 @@ class Cas2v2ApplicationTransformerTest {
         .withSubmittedAt(null)
         .withApplicationOrigin(ApplicationOrigin.prisonBail)
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
+        .withCohort(Cas2v2Cohort.BAIL)
         .produce()
 
       val result = cas2v2ApplicationsTransformer.transformJpaToApi(application, mockk())
@@ -104,6 +107,7 @@ class Cas2v2ApplicationTransformerTest {
         "timelineEvents",
         "applicationOrigin",
         "bailHearingDate",
+        "cohort",
       )
 
       assertThat(result.id).isEqualTo(application.id)
@@ -111,6 +115,7 @@ class Cas2v2ApplicationTransformerTest {
       assertThat(result.status).isEqualTo(ApplicationStatus.inProgress)
       assertThat(result.timelineEvents).isEqualTo(listOf<Cas2TimelineEvent>())
       assertThat(result.applicationOrigin).isEqualTo(ApplicationOrigin.prisonBail)
+      assertThat(result.cohort).isEqualTo(Cas2v2CohortDto.BAIL)
     }
 
     @Test


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-601

Adds a new “cohort” attribute to CAS2/CAS2v2 applications, persisting it in the `cas_2_applications` table, surfacing it through CAS2v2 API representations, and including it in CAS2 summary views used for list/reporting queries.

Changes:

- Introduces `Cas2v2CohortDto` and wires cohort through CAS2v2 API models, transformer(s), controller, and update service.
- Adds cohort to `cas_2_applications` (DB + JPA), and updates the CAS2 application summary/live summary views to select it.
- Updates unit/integration tests and test factories to set and assert cohort behaviour.