### PR TITLE
Refresh dependency check supressions

### DIFF
--- a/.cas-api-dependency-check-ignore.xml
+++ b/.cas-api-dependency-check-ignore.xml
@@ -14,11 +14,52 @@
         <vulnerabilityName>CVE-2025-31672</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes><![CDATA[We don't derive file download names from user input, so this is not
-        of concern. This should be resolved in a newer version of
-        uk.gov.justice.hmpps.gradle-spring-boot when it includes a version
-         of spring newer than 6.2.7]]></notes>
-        <packageUrl regex="true">^.*org.springframework.*$</packageUrl>
-        <vulnerabilityName>CVE-2025-41234</vulnerabilityName>
+        <notes><![CDATA[
+        file name: applicationinsights-core-2.6.4.jar
+        Suppressed as this is an Azure SDK dependency, not application insights.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/applicationinsights-core@.*$</packageUrl>
+        <cve>CVE-2026-33117</cve>
+    </suppress>
+    <!-- DOM Purify -->
+    <suppress>
+        <notes><![CDATA[
+    Suppression for dompurify issue as only bundled with swagger-ui and swagger docs should only be available in dev.
+    file name: swagger-ui-5.32.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2026-0540</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    Suppression for dompurify issue as only bundled with swagger-ui and swagger docs should only be available in dev.
+    file name: swagger-ui-5.32.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-15599</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    Suppression for dompurify issue as only bundled with swagger-ui and swagger docs should only be available in dev.
+    file name: swagger-ui-5.32.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>GHSA-cj63-jhhr-wcxv</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    Suppression for dompurify issue as only bundled with swagger-ui and swagger docs should only be available in dev.
+    file name: swagger-ui-5.32.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>GHSA-cjmm-f4jc-qw8r</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    Suppression for dompurify issue as only bundled with swagger-ui and swagger docs should only be available in dev.
+    file name: swagger-ui-5.32.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>GHSA-h8r8-wccr-v5f2</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,8 @@ configurations.matching { it.name == "detekt" }.all {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.2.0")
+  val hmppsSpringBootStarterVersion = "2.2.0"
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:$hmppsSpringBootStarterVersion")
   implementation("org.springframework.boot:spring-boot-starter-flyway")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
@@ -36,14 +37,15 @@ dependencies {
   implementation("org.postgresql:postgresql:42.7.11")
   implementation("org.javers:javers-core:7.11.0")
 
+  val springDocOpenApiStarterVersion = "3.0.2"
   // https://github.com/springdoc/springdoc-openapi/pull/3256 significantly changed our
   // generated schema, making it incompatible with the typescript generators and in some
   // places it was incorrect. We're pinning version 3.0.2 until a new version is available
   // reverting this change, as proposed by https://github.com/springdoc/springdoc-openapi/pull/3276
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springDocOpenApiStarterVersion")
   // this is a transitive dependency of uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-autoconfigure
   // so we need to force a different version
-  implementation("org.springdoc:springdoc-openapi-starter-common:3.0.2")
+  implementation("org.springdoc:springdoc-openapi-starter-common:$springDocOpenApiStarterVersion")
 
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
@@ -68,8 +70,10 @@ dependencies {
 
   implementation("com.opencsv:opencsv:5.12.0")
 
-  implementation("net.javacrumbs.shedlock:shedlock-spring:7.7.0")
-  implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:7.7.0")
+  val shedLockVersion = "7.7.0"
+  implementation("net.javacrumbs.shedlock:shedlock-spring:$shedLockVersion")
+  implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:$shedLockVersion")
+
   implementation("org.jetbrains.kotlinx:dataframe-excel:0.15.0")
 
   val appinsightsCore = "core:2.6.4"
@@ -80,7 +84,7 @@ dependencies {
   testImplementation("io.mockk:mockk:1.14.9")
   testImplementation("org.wiremock.integrations:wiremock-spring-boot:4.2.1")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:$hmppsSpringBootStarterVersion")
 
   testImplementation("com.ninja-squad:springmockk:5.0.1")
   testImplementation("org.springframework.boot:spring-boot-webtestclient")


### PR DESCRIPTION
Remove stale entries

Add DOMPurify entries, aligned with hmpps gradle plugin rationale (https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/src/main/resources/dps-gradle-spring-boot-suppressions.xml). We use a different version so have different CVEs

Use variables to remove version duplication in build file