### PR TITLE
Optimise Space Search SQL

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
@@ -43,17 +43,24 @@ FROM
     aa.name AS ap_area_name,
     aa.identifier AS ap_area_identifier,
     ARRAY_REMOVE(ARRAY_AGG (DISTINCT premises_chars_resolved.property_name), null) as premises_characteristics,
-    ARRAY_REMOVE(ARRAY_AGG (DISTINCT room_chars_resolved.property_name), null) as room_characteristics,
+    room_chars.property_name_array as room_characteristics,
     ARRAY_REMOVE(ARRAY_AGG (DISTINCT restrictions.description), null) as local_restrictions
   FROM approved_premises ap
   INNER JOIN premises p ON ap.premises_id = p.id
   INNER JOIN probation_regions pr ON p.probation_region_id = pr.id
   INNER JOIN ap_areas aa ON pr.ap_area_id = aa.id
-  LEFT OUTER JOIN rooms ON rooms.premises_id = p.id
   LEFT OUTER JOIN premises_characteristics premises_chars ON premises_chars.premises_id = p.id
   LEFT OUTER JOIN characteristics premises_chars_resolved ON premises_chars_resolved.id = premises_chars.characteristic_id
-  LEFT OUTER JOIN room_characteristics room_chars ON room_chars.room_id = rooms.id
-  LEFT OUTER JOIN characteristics room_chars_resolved ON room_chars_resolved.id = room_chars.characteristic_id
+  
+  LEFT JOIN (
+    SELECT rooms.premises_id,
+           ARRAY_REMOVE(ARRAY_AGG(DISTINCT c.property_name), null) AS property_name_array
+    FROM room_characteristics rc
+    inner join rooms on rooms.id = rc.room_id
+    inner JOIN characteristics c ON c.id = rc.characteristic_id
+    GROUP BY rooms.premises_id
+  ) room_chars ON room_chars.premises_id = p.id
+  
   LEFT OUTER JOIN cas1_premises_local_restrictions restrictions ON restrictions.archived = false AND restrictions.approved_premises_id = p.id
   WHERE 
     p.status != 'archived' AND
@@ -61,7 +68,7 @@ FROM
     ap.allow_new_space_bookings = true AND
     (:gender = 'ANY' OR (ap.gender = :gender)) AND
     (:cruManagementAreaIdsCount = 0 OR (ap.cas1_cru_management_area_id IN (:cruManagementAreaIds)))
-  GROUP BY p.id, ap.point, p.name, ap.full_address, p.address_line1, p.address_line2, p.town, p.postcode, aa.id, aa.name  
+  GROUP BY p.id, ap.point, p.name, ap.full_address, p.address_line1, p.address_line2, p.town, p.postcode, aa.id, aa.name, room_chars.property_name_array   
 ) AS result
 WHERE
 (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1PremisesSearchRepository.kt
@@ -27,10 +27,10 @@ FROM
             ) * 0.000621371
     END AS distance_in_miles,
     CASE
-      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_PIPE'=ANY(ARRAY_AGG (premises_chars_resolved.property_name))) THEN 'PIPE'
-      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_ESAP'=ANY(ARRAY_AGG (premises_chars_resolved.property_name))) THEN 'ESAP'
-      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED'=ANY(ARRAY_AGG (premises_chars_resolved.property_name))) THEN 'RFAP'
-      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_SEMI_SPECIALIST_MENTAL_HEALTH'=ANY(ARRAY_AGG (premises_chars_resolved.property_name))) THEN 'MHAP'
+      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_PIPE'=ANY(premises_chars.property_name_array)) THEN 'PIPE'
+      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_ESAP'=ANY(premises_chars.property_name_array)) THEN 'ESAP'
+      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_RECOVERY_FOCUSSED'=ANY(premises_chars.property_name_array)) THEN 'RFAP'
+      WHEN ('$CAS1_PROPERTY_NAME_PREMISES_SEMI_SPECIALIST_MENTAL_HEALTH'=ANY(premises_chars.property_name_array)) THEN 'MHAP'
       ELSE 'NORMAL'
     END AS ap_type,
     p.name AS name,
@@ -42,15 +42,21 @@ FROM
     aa.id AS ap_area_id,
     aa.name AS ap_area_name,
     aa.identifier AS ap_area_identifier,
-    ARRAY_REMOVE(ARRAY_AGG (DISTINCT premises_chars_resolved.property_name), null) as premises_characteristics,
+    premises_chars.property_name_array as premises_characteristics,
     room_chars.property_name_array as room_characteristics,
     ARRAY_REMOVE(ARRAY_AGG (DISTINCT restrictions.description), null) as local_restrictions
   FROM approved_premises ap
   INNER JOIN premises p ON ap.premises_id = p.id
   INNER JOIN probation_regions pr ON p.probation_region_id = pr.id
   INNER JOIN ap_areas aa ON pr.ap_area_id = aa.id
-  LEFT OUTER JOIN premises_characteristics premises_chars ON premises_chars.premises_id = p.id
-  LEFT OUTER JOIN characteristics premises_chars_resolved ON premises_chars_resolved.id = premises_chars.characteristic_id
+
+  LEFT JOIN (
+    SELECT pc.premises_id,
+           ARRAY_REMOVE(ARRAY_AGG(DISTINCT c.property_name), null) AS property_name_array
+    FROM premises_characteristics pc
+    JOIN characteristics c ON c.id = pc.characteristic_id
+    GROUP BY pc.premises_id
+  ) premises_chars ON premises_chars.premises_id = p.id
   
   LEFT JOIN (
     SELECT rooms.premises_id,
@@ -68,7 +74,7 @@ FROM
     ap.allow_new_space_bookings = true AND
     (:gender = 'ANY' OR (ap.gender = :gender)) AND
     (:cruManagementAreaIdsCount = 0 OR (ap.cas1_cru_management_area_id IN (:cruManagementAreaIds)))
-  GROUP BY p.id, ap.point, p.name, ap.full_address, p.address_line1, p.address_line2, p.town, p.postcode, aa.id, aa.name, room_chars.property_name_array   
+  GROUP BY p.id, ap.point, p.name, ap.full_address, p.address_line1, p.address_line2, p.town, p.postcode, aa.id, aa.name, premises_chars.property_name_array, room_chars.property_name_array   
 ) AS result
 WHERE
 (


### PR DESCRIPTION
The space search query currently has a combinatorial exploision issue due to the amount of joins being applied.

This commit changes how we collate room and premises characteristics for each premises by using a subquery to collate the information int an array, and returning that to the ‘main’ query. This reduces the number of top level joins being applied, significantly increasing the SQL execution time (from around 1 second to 0.1 seconds)