### PR TITLE
FM-619 - Rename OASys Client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
@@ -6,8 +6,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
@@ -44,7 +44,7 @@ import java.util.stream.Collectors
 class Cas2OffenderService(
   private val prisonsApiClient: PrisonsApiClient,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
-  private val apOASysContextApiClient: ApOASysContextApiClient,
+  private val apAndOASysClient: ApAndOASysClient,
   private val offenderDetailsDataSource: OffenderDetailsDataSource,
   @Value("\${cas2.crn-search-limit:400}") private val numberOfCrn: Int,
 ) {
@@ -279,7 +279,7 @@ class Cas2OffenderService(
   }
 
   private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> {
-    when (val roshRisksResponse = apOASysContextApiClient.getRoshRatings(crn)) {
+    when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
       is ClientResult.Success -> {
         val summary = roshRisksResponse.body.rosh
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OAsysSectionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OAsysSectionsTransformer.kt
@@ -5,11 +5,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysAssessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysRiskOfSeriousHarm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysRiskToSelf
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskToTheIndividualInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummaryInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummaryInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 
 @Service

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3OASysOffenceDetailsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3OASysOffenceDetailsTransformer.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysAssessmentMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
 
 @Service
 class Cas3OASysOffenceDetailsTransformer {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApAndOASysClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApAndOASysClient.kt
@@ -3,17 +3,17 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.client
 import com.fasterxml.jackson.databind.json.JsonMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlan
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatings
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 
 @Component
-class ApOASysContextApiClient(
+class ApAndOASysClient(
   @Qualifier("apOASysContextApiWebClient") webClientConfig: WebClientConfig,
   jsonMapper: JsonMapper,
   webClientCache: WebClientCache,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/AssessmentInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/AssessmentInfo.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.OffsetDateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/HealthDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/HealthDetails.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.OffsetDateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/NeedsDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/NeedsDetails.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/OffenceDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/OffenceDetails.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskManagementPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskManagementPlan.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskToTheIndividual.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskToTheIndividual.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RoshRatings.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RoshRatings.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RoshSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RoshSummary.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -16,8 +16,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Problem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetailsInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskToTheIndividualInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
@@ -3,25 +3,25 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlan
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 
 @Service
 class OASysService(
-  private val apOASysContextApiClient: ApOASysContextApiClient,
+  private val apAndOASysClient: ApAndOASysClient,
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getOASysNeeds(crn: String): CasResult<NeedsDetails> = when (val needsResult = apOASysContextApiClient.getNeedsDetails(crn)) {
+  fun getOASysNeeds(crn: String): CasResult<NeedsDetails> = when (val needsResult = apAndOASysClient.getNeedsDetails(crn)) {
     is ClientResult.Success -> CasResult.Success(needsResult.body)
     is ClientResult.Failure.StatusCode -> when (needsResult.status) {
       HttpStatus.NOT_FOUND -> CasResult.NotFound("Person", crn)
@@ -38,7 +38,7 @@ class OASysService(
     is ClientResult.Failure -> needsResult.throwException()
   }
 
-  fun getOASysOffenceDetails(crn: String): CasResult<OffenceDetails> = when (val offenceDetailsResult = apOASysContextApiClient.getOffenceDetails(crn)) {
+  fun getOASysOffenceDetails(crn: String): CasResult<OffenceDetails> = when (val offenceDetailsResult = apAndOASysClient.getOffenceDetails(crn)) {
     is ClientResult.Success -> CasResult.Success(offenceDetailsResult.body)
     is ClientResult.Failure.StatusCode -> when (offenceDetailsResult.status) {
       HttpStatus.NOT_FOUND -> CasResult.NotFound("Person", crn)
@@ -48,7 +48,7 @@ class OASysService(
     is ClientResult.Failure -> offenceDetailsResult.throwException()
   }
 
-  fun getOASysRiskManagementPlan(crn: String): CasResult<RiskManagementPlan> = when (val riskManagementPlanResult = apOASysContextApiClient.getRiskManagementPlan(crn)) {
+  fun getOASysRiskManagementPlan(crn: String): CasResult<RiskManagementPlan> = when (val riskManagementPlanResult = apAndOASysClient.getRiskManagementPlan(crn)) {
     is ClientResult.Success -> CasResult.Success(riskManagementPlanResult.body)
     is ClientResult.Failure.StatusCode -> when (riskManagementPlanResult.status) {
       HttpStatus.NOT_FOUND -> CasResult.NotFound("Person", crn)
@@ -58,7 +58,7 @@ class OASysService(
     is ClientResult.Failure -> riskManagementPlanResult.throwException()
   }
 
-  fun getOASysRoshSummary(crn: String): CasResult<RoshSummary> = when (val roshSummaryResult = apOASysContextApiClient.getRoshSummary(crn)) {
+  fun getOASysRoshSummary(crn: String): CasResult<RoshSummary> = when (val roshSummaryResult = apAndOASysClient.getRoshSummary(crn)) {
     is ClientResult.Success -> CasResult.Success(roshSummaryResult.body)
     is ClientResult.Failure.StatusCode -> when (roshSummaryResult.status) {
       HttpStatus.NOT_FOUND -> CasResult.NotFound("Person", crn)
@@ -68,7 +68,7 @@ class OASysService(
     is ClientResult.Failure -> roshSummaryResult.throwException()
   }
 
-  fun getOASysRiskToTheIndividual(crn: String): CasResult<RisksToTheIndividual> = when (val risksToTheIndividualResult = apOASysContextApiClient.getRiskToTheIndividual(crn)) {
+  fun getOASysRiskToTheIndividual(crn: String): CasResult<RisksToTheIndividual> = when (val risksToTheIndividualResult = apAndOASysClient.getRiskToTheIndividual(crn)) {
     is ClientResult.Success -> CasResult.Success(risksToTheIndividualResult.body)
     is ClientResult.Failure.StatusCode -> when (risksToTheIndividualResult.status) {
       HttpStatus.NOT_FOUND -> CasResult.NotFound("Person", crn)
@@ -78,7 +78,7 @@ class OASysService(
     is ClientResult.Failure -> risksToTheIndividualResult.throwException()
   }
 
-  fun getOASysHealthDetails(crn: String): CasResult<HealthDetails> = when (val healthDetailsResult = apOASysContextApiClient.getHealth(crn)) {
+  fun getOASysHealthDetails(crn: String): CasResult<HealthDetails> = when (val healthDetailsResult = apAndOASysClient.getHealth(crn)) {
     is ClientResult.Success -> CasResult.Success(healthDetailsResult.body)
     is ClientResult.Failure.StatusCode -> when (healthDetailsResult.status) {
       HttpStatus.NOT_FOUND -> CasResult.NotFound("Person", crn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseDetail
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 @Component
 class OffenderRisksService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
-  private val apOASysContextApiClient: ApOASysContextApiClient,
+  private val apAndOASysClient: ApAndOASysClient,
   private val hmppsTierApiClient: HMPPSTierApiClient,
   private val sentryService: SentryService,
 ) {
@@ -36,7 +36,7 @@ class OffenderRisksService(
     )
   }
 
-  private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> = when (val roshRisksResponse = apOASysContextApiClient.getRoshRatings(crn)) {
+  private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> = when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
     is ClientResult.Success -> {
       val summary = roshRisksResponse.body.rosh
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/OASysSectionsTransformer.kt
@@ -5,15 +5,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysAssessmen
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSections
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSupportingInformationQuestion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetailsInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlan
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlanInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskToTheIndividualInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummaryInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlanInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummaryInner
 
 @Component
 class OASysSectionsTransformer {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysNeedsQuestionTransformer.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysSupportingInformationQuestionMetaData
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysLabels
 
 @Service

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysOffenceDetailsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysOffenceDetailsTransformer.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysAssessmentMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
 
 @Service
 class Cas1OASysOffenceDetailsTransformer {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1CreateTestApplicationSeedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1CreateTestApplicationSeedTest.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
@@ -27,7 +27,7 @@ class SeedCas1CreateTestApplicationSeedTest : SeedTestBase() {
     val crn = offender.otherIds.crn
 
     apDeliusContextMockSuccessfulTeamsManagingCaseCall(crn, ManagingTeamsResponse(teamCodes = listOf("TEAM1")))
-    apOASysContextMockSuccessfulNeedsDetailsCall(crn, NeedsDetailsFactory().produce())
+    apAndOASysMockSuccessfulNeedsDetailsCall(crn, NeedsDetailsFactory().produce())
     govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse()
 
     val premises = givenAnApprovedPremises(supportsSpaceBookings = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1DuplicateApplicationTest.kt
@@ -11,8 +11,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
@@ -44,7 +44,7 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
           ),
         )
 
-        apOASysContextMockSuccessfulNeedsDetailsCall(
+        apAndOASysMockSuccessfulNeedsDetailsCall(
           offenderDetails.otherIds.crn,
           NeedsDetailsFactory().produce(),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
@@ -8,10 +8,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndivid
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockUnsuccessfulRisksToTheIndividualCallWithDelay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskToTheIndividualCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay
 
 class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
   @Autowired
@@ -78,10 +78,10 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val offenceDetails = OffenceDetailsFactory().produce()
-        apOASysContextMockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
+        apAndOASysMockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
 
         val risksToTheIndividual = RiskToTheIndividualFactory().produce()
-        apOASysContextMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
+        apAndOASysMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
 
         webTestClient.get()
           .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
@@ -107,7 +107,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val risksToTheIndividual = RiskToTheIndividualFactory().produce()
-        apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, 2500)
+        apAndOASysMockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
           .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
@@ -107,7 +107,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val risksToTheIndividual = RiskToTheIndividualFactory().produce()
-        apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, risksToTheIndividual, 2500)
+        apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
           .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRoshTest.kt
@@ -8,10 +8,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockUnsuccessfulRoshCallWithDelay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRoSHSummaryCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockUnsuccessfulRoshCallWithDelay
 
 class Cas2PersonOASysRoshTest : IntegrationTestBase() {
   @Autowired
@@ -78,10 +78,10 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val offenceDetails = OffenceDetailsFactory().produce()
-        apOASysContextMockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
+        apAndOASysMockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
 
         val rosh = RoshSummaryFactory().produce()
-        apOASysContextMockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, rosh)
+        apAndOASysMockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, rosh)
 
         webTestClient.get()
           .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/rosh")
@@ -107,7 +107,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val rosh = RoshSummaryFactory().produce()
-        apOASysContextMockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, 2500)
+        apAndOASysMockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
           .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/rosh")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRoshTest.kt
@@ -107,7 +107,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val rosh = RoshSummaryFactory().produce()
-        apOASysContextMockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, rosh, 2500)
+        apOASysContextMockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
           .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/rosh")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonRisksTest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskEnvelopeSt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RiskTierEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonRisksTest.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRoshRatingsCall
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -79,7 +79,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
   fun `Getting risks for a CRN returns OK with correct body`() {
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
-        apOASysContextMockSuccessfulRoshRatingsCall(
+        apAndOASysMockSuccessfulRoshRatingsCall(
           offenderDetails.otherIds.crn,
           RoshRatingsFactory().apply {
             withDateCompleted(OffsetDateTime.parse("2022-09-06T15:15:15Z"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2OffenderServiceTest.kt
@@ -12,14 +12,14 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.ProbationOffenderSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult.Failure.StatusCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummaries
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskLevel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateStatus
@@ -40,7 +40,7 @@ import java.time.OffsetDateTime
 class Cas2OffenderServiceTest {
   private val mockPrisonsApiClient = mockk<PrisonsApiClient>()
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
-  private val mockApOASysContextApiClient = mockk<ApOASysContextApiClient>()
+  private val mockApOASysContextApiClient = mockk<ApAndOASysClient>()
   private val mockOffenderDetailsDataSource = mockk<OffenderDetailsDataSource>()
 
   private val offenderService = Cas2OffenderService(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PeopleTest.kt
@@ -11,11 +11,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1OAsysTest.Companion.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockNeedsDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockOffenceDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskManagementPlanCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockNeedsDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockOffenceDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskManagementPlanCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 
 class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
@@ -37,7 +37,7 @@ class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apOASysContextMockOffenceDetails404Call(CRN)
+      apAndOASysMockOffenceDetails404Call(CRN)
 
       webTestClient.get()
         .uri("/cas3/people/$CRN/oasys/riskManagement")
@@ -52,8 +52,8 @@ class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
-      apOASysContextMockNeedsDetails404Call(CRN)
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockNeedsDetails404Call(CRN)
 
       webTestClient.get()
         .uri("/cas3/people/$CRN/oasys/riskManagement")
@@ -69,12 +69,12 @@ class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val riskManagementPlan = RiskManagementPlanFactory()
         .withSupervision("The supervision answer")
         .produce()
-      apOASysContextMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
 
       val result = webTestClient.get()
         .uri("/cas3/people/$CRN/oasys/riskManagement")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentInfoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/AssessmentInfoFactory.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.AssessmentInfo
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import java.time.OffsetDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/HealthDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/HealthDetailsFactory.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetailsInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthIssue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthIssue
 
 class HealthDetailsFactory : AssessmentInfoFactory<HealthDetails>() {
   private var generalHealth: Yielded<Boolean?> = { false }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NeedsDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/NeedsDetailsFactory.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.LinksToHarm
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.LinksToReOffending
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.LinksToHarm
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.LinksToReOffending
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetailsInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
 class NeedsDetailsFactory : AssessmentInfoFactory<NeedsDetails>() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenceDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/OffenceDetailsFactory.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetailsInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
 class OffenceDetailsFactory : AssessmentInfoFactory<OffenceDetails>() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskManagementPlanFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskManagementPlanFactory.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlan
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlanInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlanInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
 class RiskManagementPlanFactory : AssessmentInfoFactory<RiskManagementPlan>() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskToTheIndividualFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RiskToTheIndividualFactory.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskToTheIndividualInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
 class RiskToTheIndividualFactory : AssessmentInfoFactory<RisksToTheIndividual>() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshRatingsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshRatingsFactory.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskLevel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatings
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatingsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatingsInner
 
 class RoshRatingsFactory : AssessmentInfoFactory<RoshRatings>() {
   private var riskChildrenCommunity: Yielded<RiskLevel> = { RiskLevel.LOW }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RoshSummaryFactory.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummaryInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummaryInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
 class RoshSummaryFactory : AssessmentInfoFactory<RoshSummary>() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -142,7 +142,7 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
           withFinanceIssuesDetails(null, null, null)
         }.produce()
 
-        apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay(offenderDetails.otherIds.crn, needsDetails, 2500)
+        apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
           .uri("/people/${offenderDetails.otherIds.crn}/oasys/sections?selected-sections=11&selected-sections=12")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -10,13 +10,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndivid
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskManagementPlanCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockUnsuccessfulNeedsDetailsCallWithDelay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleResponseToUserAccessCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskManagementPlanCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskToTheIndividualCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRoSHSummaryCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 
 class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
@@ -88,16 +88,16 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
     givenAUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         val offenceDetails = OffenceDetailsFactory().produce()
-        apOASysContextMockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
+        apAndOASysMockSuccessfulOffenceDetailsCall(offenderDetails.otherIds.crn, offenceDetails)
 
         val roshSummary = RoshSummaryFactory().produce()
-        apOASysContextMockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, roshSummary)
+        apAndOASysMockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, roshSummary)
 
         val risksToTheIndividual = RiskToTheIndividualFactory().produce()
-        apOASysContextMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
+        apAndOASysMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
 
         val riskManagementPlan = RiskManagementPlanFactory().produce()
-        apOASysContextMockSuccessfulRiskManagementPlanCall(offenderDetails.otherIds.crn, riskManagementPlan)
+        apAndOASysMockSuccessfulRiskManagementPlanCall(offenderDetails.otherIds.crn, riskManagementPlan)
 
         val needsDetails = NeedsDetailsFactory().apply {
           withAssessmentId(34853487)
@@ -106,7 +106,7 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
           withFinanceIssuesDetails(null, null, null)
         }.produce()
 
-        apOASysContextMockSuccessfulNeedsDetailsCall(offenderDetails.otherIds.crn, needsDetails)
+        apAndOASysMockSuccessfulNeedsDetailsCall(offenderDetails.otherIds.crn, needsDetails)
 
         webTestClient.get()
           .uri("/people/${offenderDetails.otherIds.crn}/oasys/sections?selected-sections=11&selected-sections=12")
@@ -142,7 +142,7 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
           withFinanceIssuesDetails(null, null, null)
         }.produce()
 
-        apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay(offenderDetails.otherIds.crn, 2500)
+        apAndOASysMockUnsuccessfulNeedsDetailsCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
           .uri("/people/${offenderDetails.otherIds.crn}/oasys/sections?selected-sections=11&selected-sections=12")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationStateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationStateTest.kt
@@ -37,8 +37,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -92,7 +92,7 @@ class Cas1ApplicationStateTest : InitialiseDatabasePerClassTestBase() {
       ),
     )
 
-    apOASysContextMockSuccessfulNeedsDetailsCall(
+    apAndOASysMockSuccessfulNeedsDetailsCall(
       offenderDetails.otherIds.crn,
       NeedsDetailsFactory().produce(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -56,7 +56,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TeamFactoryDeliusContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1WithdrawalTest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1CruManagementArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
@@ -65,12 +64,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
@@ -1605,7 +1604,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             ),
           )
 
-          apOASysContextMockSuccessfulNeedsDetailsCall(
+          apAndOASysMockSuccessfulNeedsDetailsCall(
             offenderDetails.otherIds.crn,
             NeedsDetailsFactory().produce(),
           )
@@ -1734,7 +1733,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             ),
           )
 
-          apOASysContextMockSuccessfulNeedsDetailsCall(
+          apAndOASysMockSuccessfulNeedsDetailsCall(
             offenderDetails.otherIds.crn,
             NeedsDetailsFactory().produce(),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -17,17 +17,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndivid
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockNeedsDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockOffenceDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskManagementPlan404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskToTheIndividual404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulHealthDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskManagementPlanCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockNeedsDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockOffenceDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockRiskManagementPlan404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockRiskToTheIndividual404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulHealthDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulNeedsDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulOffenceDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskManagementPlanCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskToTheIndividualCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
@@ -61,8 +61,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apOASysContextMockOffenceDetails404Call(CRN)
-      apOASysContextMockNeedsDetails404Call(CRN)
+      apAndOASysMockOffenceDetails404Call(CRN)
+      apAndOASysMockNeedsDetails404Call(CRN)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/metadata")
@@ -102,7 +102,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
       val offenceDetails = OffenceDetailsFactory().produce()
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
 
       val needsDetails = NeedsDetailsFactory().apply {
         withAssessmentId(34853487)
@@ -110,7 +110,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         withAttitudeIssuesDetails("Attitude", false, true)
         withFinanceIssuesDetails(null, null, null)
       }.produce()
-      apOASysContextMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
+      apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
 
       webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/metadata")
@@ -166,8 +166,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apOASysContextMockOffenceDetails404Call(CRN)
-      apOASysContextMockRiskManagementPlan404Call(CRN)
+      apAndOASysMockOffenceDetails404Call(CRN)
+      apAndOASysMockRiskManagementPlan404Call(CRN)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=riskManagementPlan")
@@ -194,12 +194,12 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val riskManagementPlan = RiskManagementPlanFactory()
         .withSupervision("The supervision answer")
         .produce()
-      apOASysContextMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=riskManagementPlan")
@@ -225,7 +225,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apOASysContextMockOffenceDetails404Call(CRN)
+      apAndOASysMockOffenceDetails404Call(CRN)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=offenceDetails")
@@ -255,7 +255,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val offenceDetails = OffenceDetailsFactory()
         .withVictimImpact("Victim impact answer")
         .produce()
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=offenceDetails")
@@ -282,12 +282,12 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val roshSummary = RoshSummaryFactory()
         .withWhoAtRisk("Who at risk answer")
         .produce()
-      apOASysContextMockSuccessfulRoSHSummaryCall(CRN, roshSummary)
+      apAndOASysMockSuccessfulRoSHSummaryCall(CRN, roshSummary)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=roshSummary")
@@ -313,8 +313,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
-      apOASysContextMockRiskToTheIndividual404Call(CRN)
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockRiskToTheIndividual404Call(CRN)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=riskToSelf")
@@ -340,12 +340,12 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val riskToIndividual = RiskToTheIndividualFactory()
         .withCurrentVulnerability("Current vuln answer")
         .produce()
-      apOASysContextMockSuccessfulRiskToTheIndividualCall(CRN, riskToIndividual)
+      apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, riskToIndividual)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=riskToSelf")
@@ -371,8 +371,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apOASysContextMockOffenceDetails404Call(CRN)
-      apOASysContextMockNeedsDetails404Call(CRN)
+      apAndOASysMockOffenceDetails404Call(CRN)
+      apAndOASysMockNeedsDetails404Call(CRN)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=supportingInformation&includeOptionalSections=")
@@ -409,7 +409,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apOASysContextMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val needsDetails = NeedsDetailsFactory().apply {
         withRelationshipIssuesDetails(linkedToHarm = true, relationshipIssuesDetails = "relationship answer")
@@ -421,8 +421,8 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         withGeneralHealth(generalHealth = false, generalHealthSpecify = "health answer")
       }.produce()
 
-      apOASysContextMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
-      apOASysContextMockSuccessfulHealthDetailsCall(CRN, healthDetails)
+      apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
+      apAndOASysMockSuccessfulHealthDetailsCall(CRN, healthDetails)
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=supportingInformation&includeOptionalSections=10")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
@@ -52,16 +52,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockHealthDetails404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskToTheIndividual404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulHealthDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUnsuccesfullCaseDetailCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockHealthDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockRiskToTheIndividual404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulHealthDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRiskToTheIndividualCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apOASysContextMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.healthAndMedicationMockForbiddenDietAndAllergyCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.healthAndMedicationMockNotFoundDietAndAllergyCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.healthAndMedicationMockSuccessfulDietAndAllergyCall
@@ -126,7 +126,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
           ),
         )
 
-        apOASysContextMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
+        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
 
         webTestClient.get()
           .uri("/cas1/people/$crn/oasys/risks-to-individual")
@@ -146,7 +146,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         val crn = "CRN"
 
-        apOASysContextMockRiskToTheIndividual404Call(crn)
+        apAndOASysMockRiskToTheIndividual404Call(crn)
 
         webTestClient.get()
           .uri("/cas1/people/$crn/oasys/risks-to-individual")
@@ -173,7 +173,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
           riskToTheIndividual = null,
         )
 
-        apOASysContextMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
+        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
 
         webTestClient.get()
           .uri("/cas1/people/$crn/oasys/risks-to-individual")
@@ -675,7 +675,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
       givenAnOffender { offenderDetails, _ ->
         apDeliusContextMockSuccessfulCaseDetailCall(offenderDetails.otherIds.crn, caseDetail)
-        apOASysContextMockSuccessfulRoshRatingsCall(offenderDetails.otherIds.crn, roshRatings)
+        apAndOASysMockSuccessfulRoshRatingsCall(offenderDetails.otherIds.crn, roshRatings)
         hmppsTierMockSuccessfulTierCall(
           offenderDetails.otherIds.crn,
           tier,
@@ -1378,7 +1378,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
           .withAlcoholMisuse(alcoholMisuse)
           .produce()
 
-        apOASysContextMockSuccessfulHealthDetailsCall(crn, healthDetails)
+        apAndOASysMockSuccessfulHealthDetailsCall(crn, healthDetails)
 
         val response = webTestClient.get()
           .uri("/cas1/people/$crn/oasys/health-details")
@@ -1406,7 +1406,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
       givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
         val crn = "CRN"
 
-        apOASysContextMockHealthDetails404Call(crn)
+        apAndOASysMockHealthDetails404Call(crn)
 
         webTestClient.get()
           .uri("/cas1/people/$crn/oasys/health-details")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
@@ -14,6 +14,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEv
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventUrlType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthIssue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Address
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Name
@@ -22,10 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.health.CodeDescri
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.health.DietAndAllergyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.health.ValueWithMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetailsInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthIssue
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskToTheIndividualInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.CsraSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas1.Cas1PersonalTimeline
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingDetailsFactory

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
@@ -9,84 +9,84 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulOffenceDetailsCall(crn: String, response: OffenceDetails) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulOffenceDetailsCall(crn: String, response: OffenceDetails) = mockSuccessfulGetCallWithJsonResponse(
   url = "/offence-details/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockOffenceDetails404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockOffenceDetails404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/offence-details/$crn",
   responseStatus = 404,
   delayMs = 0,
 )
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulRoSHSummaryCall(crn: String, response: RoshSummary) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulRoSHSummaryCall(crn: String, response: RoshSummary) = mockSuccessfulGetCallWithJsonResponse(
   url = "/rosh-summary/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulRiskToTheIndividualCall(crn: String, response: RisksToTheIndividual) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulRiskToTheIndividualCall(crn: String, response: RisksToTheIndividual) = mockSuccessfulGetCallWithJsonResponse(
   url = "/risk-to-the-individual/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockRiskToTheIndividual404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockRiskToTheIndividual404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/risk-to-the-individual/$crn",
   responseStatus = 404,
   delayMs = 0,
 )
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulRiskManagementPlanCall(crn: String, response: RiskManagementPlan) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulRiskManagementPlanCall(crn: String, response: RiskManagementPlan) = mockSuccessfulGetCallWithJsonResponse(
   url = "/risk-management-plan/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockRiskManagementPlan404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockRiskManagementPlan404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/risk-management-plan/$crn",
   responseStatus = 404,
   delayMs = 0,
 )
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulNeedsDetailsCall(crn: String, response: NeedsDetails) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulNeedsDetailsCall(crn: String, response: NeedsDetails) = mockSuccessfulGetCallWithJsonResponse(
   url = "/needs-details/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulHealthDetailsCall(crn: String, response: HealthDetails) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulHealthDetailsCall(crn: String, response: HealthDetails) = mockSuccessfulGetCallWithJsonResponse(
   url = "/health-details/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockHealthDetails404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockHealthDetails404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/health-details/$crn",
   responseStatus = 404,
   delayMs = 0,
 )
 
-fun IntegrationTestBase.apOASysContextMockNeedsDetails404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockNeedsDetails404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/needs-details/$crn",
   responseStatus = 404,
   delayMs = 0,
 )
 
-fun IntegrationTestBase.apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockUnsuccessfulNeedsDetailsCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/needs-details/$crn",
   responseStatus = 404,
   delayMs = delayMs,
 )
 
-fun IntegrationTestBase.apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockUnsuccessfulRisksToTheIndividualCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/risk-to-the-individual/$crn",
   responseStatus = 404,
   delayMs = delayMs,
 )
 
-fun IntegrationTestBase.apOASysContextMockSuccessfulRoshRatingsCall(crn: String, response: RoshRatings) = mockSuccessfulGetCallWithJsonResponse(
+fun IntegrationTestBase.apAndOASysMockSuccessfulRoshRatingsCall(crn: String, response: RoshRatings) = mockSuccessfulGetCallWithJsonResponse(
   url = "/rosh/$crn",
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockUnsuccessfulRoshCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apAndOASysMockUnsuccessfulRoshCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/rosh/$crn",
   responseStatus = 404,
   delayMs = delayMs,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.HealthDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.NeedsDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.OffenceDetails
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskManagementPlan
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RisksToTheIndividual
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatings
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 
 fun IntegrationTestBase.apOASysContextMockSuccessfulOffenceDetailsCall(crn: String, response: OffenceDetails) = mockSuccessfulGetCallWithJsonResponse(
@@ -23,12 +23,6 @@ fun IntegrationTestBase.apOASysContextMockOffenceDetails404Call(crn: String) = m
 fun IntegrationTestBase.apOASysContextMockSuccessfulRoSHSummaryCall(crn: String, response: RoshSummary) = mockSuccessfulGetCallWithJsonResponse(
   url = "/rosh-summary/$crn",
   responseBody = response,
-)
-
-fun IntegrationTestBase.apOASysContextMockRoSHSummary404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
-  url = "/rosh-summary/$crn",
-  responseStatus = 404,
-  delayMs = 0,
 )
 
 fun IntegrationTestBase.apOASysContextMockSuccessfulRiskToTheIndividualCall(crn: String, response: RisksToTheIndividual) = mockSuccessfulGetCallWithJsonResponse(
@@ -75,13 +69,13 @@ fun IntegrationTestBase.apOASysContextMockNeedsDetails404Call(crn: String) = moc
   delayMs = 0,
 )
 
-fun IntegrationTestBase.apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay(crn: String, response: NeedsDetails, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apOASysContextMockUnsuccessfulNeedsDetailsCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/needs-details/$crn",
   responseStatus = 404,
   delayMs = delayMs,
 )
 
-fun IntegrationTestBase.apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay(crn: String, response: RisksToTheIndividual, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apOASysContextMockUnsuccessfulRisksToTheIndividualCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/risk-to-the-individual/$crn",
   responseStatus = 404,
   delayMs = delayMs,
@@ -92,7 +86,7 @@ fun IntegrationTestBase.apOASysContextMockSuccessfulRoshRatingsCall(crn: String,
   responseBody = response,
 )
 
-fun IntegrationTestBase.apOASysContextMockUnsuccessfulRoshCallWithDelay(crn: String, response: RoshSummary, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
+fun IntegrationTestBase.apOASysContextMockUnsuccessfulRoshCallWithDelay(crn: String, delayMs: Int) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/rosh/$crn",
   responseStatus = 404,
   delayMs = delayMs,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/oasyscontext/RoshRatingsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/model/oasyscontext/RoshRatingsTest.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.model.oasyscontext
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskLevel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatingsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatingsInner
 
 class RoshRatingsTest {
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
@@ -8,16 +8,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApOASysContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.MappaDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Registration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RiskLevel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.oasyscontext.RoshRatings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
@@ -31,7 +31,7 @@ import java.util.UUID
 
 class OffenderRisksServiceTest {
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
-  private val mockApOASysContextApiClient = mockk<ApOASysContextApiClient>()
+  private val mockApOASysContextApiClient = mockk<ApAndOASysClient>()
   private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
   private val mockSentryService = mockk<SentryService>()
 


### PR DESCRIPTION
The name `ApOASysContextApiClient ` is confusing. This renames it to `ApAndOASysClient` to reflect the actual service name