### PR TITLE
FM-619 Add GET Cas2v2 OASys Meta Data Endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/Cas2v2Constants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/Cas2v2Constants.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2
+
+object Cas2v2Constants {
+  object Cas2v2Role {
+    const val ADMIN = "ROLE_CAS2_ADMIN"
+    const val ASSESSOR = "ROLE_CAS2_ASSESSOR"
+    const val PRISON_BAIL_REFERRER = "ROLE_CAS2_PRISON_BAIL_REFERRER"
+    const val MI = "ROLE_CAS2_MI"
+    const val COURT_BAIL_REFERRER = "ROLE_CAS2_COURT_BAIL_REFERRER"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2V2OASysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2V2OASysController.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2OASysTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@Cas2v2Controller
+class Cas2V2OASysController(
+  val oasysService: OASysService,
+  val cas2v2OASysTransformer: Cas2v2OASysTransformer,
+) {
+
+  @GetMapping("/people/{crn}/oasys/metadata")
+  fun searchByCrnGet(
+    @PathVariable crn: String,
+  ): ResponseEntity<Cas2v2OASysAssessmentMetadataDto> {
+    val assessment = when (val result = oasysService.getAssessmentSummary(crn)) {
+      is CasResult.NotFound -> null
+      else -> extractEntityFromCasResult(result)
+    }
+
+    return ResponseEntity.ok(cas2v2OASysTransformer.toOASysAssessmentMetadataDto(assessment))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/model/Cas2v2OASysAssessmentMetadataDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/model/Cas2v2OASysAssessmentMetadataDto.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model
+
+import java.time.Instant
+
+data class Cas2v2OASysAssessmentMetadataDto(
+  val hasApplicableAssessment: Boolean,
+  val dateStarted: Instant?,
+  val dateCompleted: Instant?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2OASysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2OASysTransformer.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
+
+@Service
+class Cas2v2OASysTransformer {
+
+  fun toOASysAssessmentMetadataDto(summary: OASysAssessmentSummary?) = Cas2v2OASysAssessmentMetadataDto(
+    hasApplicableAssessment = summary != null,
+    dateStarted = summary?.initiationDate?.toInstant(),
+    dateCompleted = summary?.completedDate?.toInstant(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApAndOASysClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/ApAndOASysClient.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
@@ -18,6 +19,10 @@ class ApAndOASysClient(
   jsonMapper: JsonMapper,
   webClientCache: WebClientCache,
 ) : BaseHMPPSClient(webClientConfig, jsonMapper, webClientCache) {
+  fun getLatestAssessmentSummary(crn: String) = getRequest<OASysAssessmentSummary> {
+    path = "/latest-assessment/$crn"
+  }
+
   fun getOffenceDetails(crn: String) = getRequest<OffenceDetails> {
     path = "/offence-details/$crn"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/OASysAssessmentSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/OASysAssessmentSummary.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys
+
+import java.time.OffsetDateTime
+
+data class OASysAssessmentSummary(
+  val assessmentPk: Long,
+  val assessmentType: String,
+  val initiationDate: OffsetDateTime,
+  val status: String,
+  val completedDate: OffsetDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -31,6 +31,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.Cas2v2Constants.Cas2v2Role
 import java.time.Duration
 import java.util.Base64
 
@@ -65,6 +66,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.POST, "/migration-job", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
+
         authorize(HttpMethod.GET, "/cas2/external/**", hasRole("APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE"))
         authorize(HttpMethod.PUT, "/cas2/assessments/**", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/assessments/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN", "CAS2_COURT_BAIL_REFERRER", "CAS2_PRISON_BAIL_REFERRER"))
@@ -84,6 +86,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.POST, "/cas2v2/submissions/*/status-updates", hasAnyAuthority("ROLE_CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2v2/reference-data/**", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2v2/reports/**", hasAuthority("ROLE_CAS2_MI"))
+        authorize(HttpMethod.GET, "/cas2v2/people/*/oasys/**", hasAnyAuthority(Cas2v2Role.COURT_BAIL_REFERRER, Cas2v2Role.PRISON_BAIL_REFERRER))
         authorize(HttpMethod.GET, "/cas2v2/people/search-by-crn/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2v2/people/search-by-noms/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2v2/external/**", hasRole("APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
@@ -20,6 +21,15 @@ class OASysService(
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getAssessmentSummary(crn: String): CasResult<OASysAssessmentSummary> = when (val result = apAndOASysClient.getLatestAssessmentSummary(crn)) {
+    is ClientResult.Success -> CasResult.Success(result.body)
+    is ClientResult.Failure.StatusCode -> when (result.status) {
+      HttpStatus.NOT_FOUND -> CasResult.NotFound("OASysAssessment", crn)
+      else -> result.throwException()
+    }
+    is ClientResult.Failure -> result.throwException()
+  }
 
   fun getOASysNeeds(crn: String): CasResult<NeedsDetails> = when (val needsResult = apAndOASysClient.getNeedsDetails(crn)) {
     is ClientResult.Success -> CasResult.Success(needsResult.body)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2IntegrationTestBase.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.integration
+
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.Cas2v2Constants.Cas2v2Role
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.hmpps.kotlin.auth.AuthSource
+
+class Cas2v2IntegrationTestBase : IntegrationTestBase() {
+
+  fun <S : WebTestClient.RequestHeadersSpec<S>> WebTestClient.RequestHeadersSpec<S>.addJwtForRoleAndAuthSource(
+    role: RoleAndAuthSource,
+  ): S {
+    val jwt = jwtAuthHelper.createClientCredentialsJwt(
+      username = "username",
+      authSource = role.authSource.source,
+      roles = listOf(role.name),
+    )
+
+    return this.header("Authorization", "Bearer $jwt")
+  }
+
+  companion object {
+
+    @JvmStatic
+    fun cas2v2NonReferrerRoles(): List<Arguments> = listOf(Cas2v2Role.ADMIN, Cas2v2Role.ASSESSOR, Cas2v2Role.MI)
+      .flatMap {
+        listOf(
+          Arguments.of(RoleAndAuthSource(it, AuthSource.DELIUS)),
+          Arguments.of(RoleAndAuthSource(it, AuthSource.NOMIS)),
+        )
+      }
+
+    @JvmStatic
+    fun cas2v2ReferrerRoles(): List<Arguments> = listOf(Cas2v2Role.COURT_BAIL_REFERRER, Cas2v2Role.PRISON_BAIL_REFERRER)
+      .flatMap {
+        listOf(
+          Arguments.of(RoleAndAuthSource(it, AuthSource.DELIUS)),
+          Arguments.of(RoleAndAuthSource(it, AuthSource.NOMIS)),
+        )
+      }
+  }
+}
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.integration.Cas2v2IntegrationTestBase#cas2v2NonReferrerRoles")
+annotation class Cas2v2NonReferrerRoles
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MethodSource("uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.integration.Cas2v2IntegrationTestBase#cas2v2ReferrerRoles")
+annotation class Cas2v2ReferrerRoles
+
+data class RoleAndAuthSource(
+  val name: String,
+  val authSource: AuthSource,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockAssessmentSummaryNotFound
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOAsysMockAssessmentSummaryResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+
+class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
+
+  @Nested
+  @DisplayName("GET /cas2v2/people/{crn}/oasys/metadata")
+  inner class GetAssessmentMetadata {
+
+    @Test
+    fun `Get without JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Cas2v2NonReferrerRoles
+    @ParameterizedTest
+    fun `Get without referrer role returns 403`(role: RoleAndAuthSource) {
+      webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .addJwtForRoleAndAuthSource(role)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Cas2v2ReferrerRoles
+    @ParameterizedTest
+    fun `Assessment not available`(role: RoleAndAuthSource) {
+      apAndOASysMockAssessmentSummaryNotFound("CRN123")
+
+      val result = webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .addJwtForRoleAndAuthSource(role)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas2v2OASysAssessmentMetadataDto>()
+
+      assertThat(result.hasApplicableAssessment).isFalse
+    }
+
+    @Cas2v2ReferrerRoles
+    @ParameterizedTest
+    fun `Assessment available`(role: RoleAndAuthSource) {
+      apAndOAsysMockAssessmentSummaryResponse(
+        crn = "CRN123",
+        response = OASysAssessmentSummaryFactory().produce(),
+      )
+
+      val result = webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .addJwtForRoleAndAuthSource(role)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas2v2OASysAssessmentMetadataDto>()
+
+      assertThat(result.hasApplicableAssessment).isTrue
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2OASysTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2OASysTransformerTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2OASysTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
+import java.time.Instant
+import java.time.OffsetDateTime
+
+class Cas2v2OASysTransformerTest {
+
+  private val transformer = Cas2v2OASysTransformer()
+
+  @Nested
+  inner class ToOASysMetadataDto {
+
+    @Test
+    fun found() {
+      val result = transformer.toOASysAssessmentMetadataDto(
+        OASysAssessmentSummaryFactory()
+          .withInitiationDate(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"))
+          .withCompletedDate(OffsetDateTime.parse("2008-12-03T10:15:30+01:00"))
+          .produce(),
+      )
+
+      assertThat(result.hasApplicableAssessment).isTrue()
+      assertThat(result.dateStarted).isEqualTo(Instant.parse("2007-12-03T10:15:30+01:00"))
+      assertThat(result.dateCompleted).isEqualTo(Instant.parse("2008-12-03T10:15:30+01:00"))
+    }
+
+    fun not_found() {
+      val result = transformer.toOASysAssessmentMetadataDto(null)
+
+      assertThat(result.hasApplicableAssessment).isFalse()
+      assertThat(result.dateStarted).isNull()
+      assertThat(result.dateCompleted).isNull()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/client/apandoasys/OASysAssessmentSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/client/apandoasys/OASysAssessmentSummaryFactory.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys
+
+import io.github.bluegroundltd.kfactory.Factory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomLong
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.OffsetDateTime
+
+class OASysAssessmentSummaryFactory : Factory<OASysAssessmentSummary> {
+
+  private var assessmentPk = { randomLong() }
+  private var assessmentType = { randomStringUpperCase(6) }
+  private var initiationDate = { OffsetDateTime.now() }
+  private var status = { randomStringUpperCase(6) }
+  private var completedDate = { OffsetDateTime.now() }
+
+  fun withInitiationDate(initiationDate: OffsetDateTime) = apply {
+    this.initiationDate = { initiationDate }
+  }
+
+  fun withCompletedDate(completedDate: OffsetDateTime) = apply {
+    this.completedDate = { completedDate }
+  }
+
+  override fun produce() = OASysAssessmentSummary(
+    assessmentPk = this.assessmentPk(),
+    assessmentType = this.assessmentType(),
+    initiationDate = this.initiationDate(),
+    status = this.status(),
+    completedDate = this.completedDate(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -163,7 +163,7 @@ fun IntegrationTestBase.givenACas2v2DeliusUser(
     withServiceOrigin(Cas2ServiceOrigin.BAIL)
   }
 
-  val jwt = jwtAuthHelper.createValidDeliusAuthorisationCodeJwt(deliusUser.deliusUsername)
+  val jwt = jwtAuthHelper.createValidCas2v2DeliusAuthorisationCodeJwt(deliusUser.deliusUsername)
 
   block(user, jwt)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskManagementPlan
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
@@ -90,4 +91,15 @@ fun IntegrationTestBase.apAndOASysMockUnsuccessfulRoshCallWithDelay(crn: String,
   url = "/rosh/$crn",
   responseStatus = 404,
   delayMs = delayMs,
+)
+
+fun IntegrationTestBase.apAndOAsysMockAssessmentSummaryResponse(crn: String, response: OASysAssessmentSummary) = mockSuccessfulGetCallWithJsonResponse(
+  "/latest-assessment/$crn",
+  responseStatus = 200,
+  responseBody = response,
+)
+
+fun IntegrationTestBase.apAndOASysMockAssessmentSummaryNotFound(crn: String) = mockUnsuccessfulGetCall(
+  url = "/latest-assessment/$crn",
+  responseStatus = 404,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/JwtAuthHelper.kt
@@ -63,7 +63,7 @@ class JwtAuthHelper {
     roles = roles,
   )
 
-  internal fun createValidDeliusAuthorisationCodeJwt(username: String = "username", roles: List<String>? = listOf("ROLE_CAS2_COURT_BAIL_REFERRER")) = createAuthorizationCodeJwt(
+  internal fun createValidCas2v2DeliusAuthorisationCodeJwt(username: String = "username", roles: List<String>? = listOf("ROLE_CAS2_COURT_BAIL_REFERRER")) = createAuthorizationCodeJwt(
     subject = username,
     authSource = "delius",
     roles = roles,


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/FM-619

As part of the ISR enhancements we now need to retrieve OASys data depending upon the CAS2v2 application type. This commit adds a metadata endpoint to determine if an assessment is available, and if it is, when it was created/submitted.