### PR TITLE
Add renovate ignore list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ministryofjustice/hmpps-renovate-config:jvm"]
+  "extends": ["github>ministryofjustice/hmpps-renovate-config:jvm"],
+  "ignoreDeps": ["postgres", "postgis", "redis"]
 }


### PR DESCRIPTION
We don’t want renovate to update docker image versions where we’re aligned with production