### PR TITLE
FM-603 - Add CAS2 backfill application cohorts migration job and tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/MigrationJobType.kt
@@ -30,4 +30,5 @@ enum class MigrationJobType(@get:JsonValue val value: String) {
   updateCas3ArchiveUnarchiveDomainEventDetails("update_cas3_archive_unarchive_domain_event_details"),
   updateCas3BedspaceStartDate("update_cas3_bedspace_start_date"),
   updateCas3PremisesDomainEventDates("update_cas3_premises_domain_event_dates"),
+  cas2BackfillApplicationCohorts("cas2_backfill_application_cohorts"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/jpa/entity/Cas2ApplicationEntity.kt
@@ -20,6 +20,7 @@ import org.hibernate.annotations.Type
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
@@ -38,6 +39,16 @@ interface Cas2ApplicationRepository : JpaRepository<Cas2ApplicationEntity, UUID>
   fun findByIdAndServiceOriginAndSubmittedAtIsNotNull(id: UUID, serviceOrigin: Cas2ServiceOrigin): Cas2ApplicationEntity?
   fun findByIdAndServiceOrigin(id: UUID, serviceOrigin: Cas2ServiceOrigin): Cas2ApplicationEntity?
   fun findAllByCrnAndSubmittedAtIsNotNullAndAssessmentIdIsNotNull(crn: String): List<Cas2ApplicationEntity>
+
+  @Query(
+    "SELECT id, application_origin FROM cas_2_applications WHERE cohort IS NULL",
+    nativeQuery = true,
+  )
+  fun findIdAndApplicationOriginByCohortIsNull(): List<Cas2IdApplicationOriginEntity>
+
+  @Modifying
+  @Query("UPDATE cas_2_applications SET cohort = :cohort WHERE id = :id", nativeQuery = true)
+  fun updateCohort(id: UUID, cohort: String)
 
   @Query(
     "SELECT a FROM Cas2ApplicationEntity a WHERE a.submittedAt IS NOT NULL " +
@@ -97,6 +108,16 @@ enum class Cas2Cohort(val apiType: Cas2CohortDto) {
     fun forValue(value: String) = values().first { it.apiType.value == value }
   }
 }
+
+@Entity
+@Table(name = "cas_2_applications")
+data class Cas2IdApplicationOriginEntity(
+  @Id
+  val id: UUID,
+
+  @Enumerated(EnumType.STRING)
+  var applicationOrigin: ApplicationOrigin,
+)
 
 @Entity
 @Table(name = "cas_2_applications")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/migration/Cas2BackfillApplicationCohortJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/migration/Cas2BackfillApplicationCohortJob.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2IdApplicationOriginEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.migration.MigrationJob
+
+@Component
+class Cas2BackfillApplicationCohortJob(
+  private val cas2ApplicationRepository: Cas2ApplicationRepository,
+  private val transactionTemplate: TransactionTemplate,
+) : MigrationJob() {
+  override val shouldRunInTransaction = false
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @SuppressWarnings("MagicNumber")
+  override fun process(pageSize: Int) {
+    val applications = cas2ApplicationRepository.findIdAndApplicationOriginByCohortIsNull()
+
+    log.info("Found ${applications.size} applications without a cohort to backfill")
+
+    applications.forEach { application ->
+      transactionTemplate.executeWithoutResult {
+        updateCohort(application)
+      }
+      Thread.sleep(50)
+    }
+
+    log.info("Backfilled ${applications.size} applications")
+  }
+
+  private fun updateCohort(application: Cas2IdApplicationOriginEntity) {
+    cas2ApplicationRepository.updateCohort(
+      application.id,
+      when (application.applicationOrigin) {
+        ApplicationOrigin.courtBail -> Cas2Cohort.COURT_BAIL.name
+        ApplicationOrigin.prisonBail -> Cas2Cohort.PRISON_BAIL.name
+        ApplicationOrigin.homeDetentionCurfew -> Cas2Cohort.HDC.name
+        ApplicationOrigin.other -> throw IllegalStateException("Unexpected application origin: ${application.applicationOrigin}")
+      },
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/migration/MigrationJobService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1Updat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.Cas1UpdateRoomCodesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration.UpdateSentenceTypeAndSituationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2AssessmentMigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2BackfillApplicationCohortJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2NoteMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.migration.Cas2StatusUpdateMigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.migration.BookingStatusMigrationJob
@@ -73,6 +74,7 @@ class MigrationJobService(
         MigrationJobType.updateCas3ArchiveUnarchiveDomainEventDetails -> getBean(Cas3UpdateArchiveUnarchiveDomainEventDetailsJob::class)
         MigrationJobType.updateCas3BedspaceStartDate -> getBean(Cas3UpdateBedspaceStartDateJob::class)
         MigrationJobType.updateCas3PremisesDomainEventDates -> getBean(Cas3AdjustPremisesDomainEventDatesJob::class)
+        MigrationJobType.cas2BackfillApplicationCohorts -> getBean(Cas2BackfillApplicationCohortJob::class)
       }
 
       if (job.shouldRunInTransaction) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/factory/Cas2ApplicationEntityFactory.kt
@@ -44,7 +44,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var applicationOrigin: Yielded<ApplicationOrigin> = { ApplicationOrigin.homeDetentionCurfew }
   private var serviceOrigin: Yielded<Cas2ServiceOrigin> = { Cas2ServiceOrigin.HDC }
   private var bailHearingDate: Yielded<LocalDate?> = { null }
-  private var cohort: Yielded<Cas2Cohort> = { Cas2Cohort.HDC }
+  private var cohort: Yielded<Cas2Cohort?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2BackfillApplicationCohortIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/migration/Cas2BackfillApplicationCohortIntegrationTest.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration.migration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2Cohort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
+
+class Cas2BackfillApplicationCohortIntegrationTest : MigrationJobTestBase() {
+
+  @Test
+  fun `Successfully backfills application cohorts`() {
+    givenACas2PomUser { userEntity, _ ->
+
+      val courtBailApplications = cas2ApplicationEntityFactory.produceAndPersistMultiple(4) {
+        withApplicationOrigin(ApplicationOrigin.courtBail)
+        withCreatedByUser(userEntity)
+      }
+
+      val prisonBailApplications = cas2ApplicationEntityFactory.produceAndPersistMultiple(4) {
+        withApplicationOrigin(ApplicationOrigin.prisonBail)
+        withCreatedByUser(userEntity)
+      }
+
+      val hdcApplications = cas2ApplicationEntityFactory.produceAndPersistMultiple(4) {
+        withApplicationOrigin(ApplicationOrigin.homeDetentionCurfew)
+        withCreatedByUser(userEntity)
+      }
+
+      val courtBailApplicationWithCohort = cas2ApplicationEntityFactory.produceAndPersist {
+        withApplicationOrigin(ApplicationOrigin.courtBail)
+        withCreatedByUser(userEntity)
+        withCohort(Cas2Cohort.COURT_BAIL)
+      }
+
+      val prisonBailApplicationWithCohort = cas2ApplicationEntityFactory.produceAndPersist {
+        withApplicationOrigin(ApplicationOrigin.prisonBail)
+        withCreatedByUser(userEntity)
+        withCohort(Cas2Cohort.PRISON_BAIL)
+      }
+
+      val hdcApplicationWithCohort = cas2ApplicationEntityFactory.produceAndPersist {
+        withApplicationOrigin(ApplicationOrigin.homeDetentionCurfew)
+        withCreatedByUser(userEntity)
+        withCohort(Cas2Cohort.HDC)
+      }
+
+      assertThat(courtBailApplications.map { it.cohort }).allMatch { it == null }
+      assertThat(prisonBailApplications.map { it.cohort }).allMatch { it == null }
+      assertThat(hdcApplications.map { it.cohort }).allMatch { it == null }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas2BackfillApplicationCohorts)
+
+      val updatedCourtBailApplications = cas2ApplicationRepository.findAllById(courtBailApplications.map { it.id })
+      val updatedPrisonBailApplications = cas2ApplicationRepository.findAllById(prisonBailApplications.map { it.id })
+      val updatedHdcApplications = cas2ApplicationRepository.findAllById(hdcApplications.map { it.id })
+
+      val savedCourtBailApplicationWithCohort = cas2ApplicationRepository.findById(courtBailApplicationWithCohort.id).get()
+      val savedPrisonBailApplicationWithCohort = cas2ApplicationRepository.findById(prisonBailApplicationWithCohort.id).get()
+      val savedHdcApplicationWithCohort = cas2ApplicationRepository.findById(hdcApplicationWithCohort.id).get()
+
+      assertThat(updatedCourtBailApplications.map { it.cohort }).allMatch { it == Cas2Cohort.COURT_BAIL }
+      assertThat(updatedPrisonBailApplications.map { it.cohort }).allMatch { it == Cas2Cohort.PRISON_BAIL }
+      assertThat(updatedHdcApplications.map { it.cohort }).allMatch { it == Cas2Cohort.HDC }
+      assertThat(savedCourtBailApplicationWithCohort.cohort).isEqualTo(Cas2Cohort.COURT_BAIL)
+      assertThat(savedPrisonBailApplicationWithCohort.cohort).isEqualTo(Cas2Cohort.PRISON_BAIL)
+      assertThat(savedHdcApplicationWithCohort.cohort).isEqualTo(Cas2Cohort.HDC)
+    }
+  }
+
+  @Test
+  fun `Raises exception if application origin is other`() {
+    givenACas2PomUser { userEntity, _ ->
+      cas2ApplicationEntityFactory.produceAndPersist {
+        withApplicationOrigin(ApplicationOrigin.other)
+        withCreatedByUser(userEntity)
+      }
+
+      migrationJobService.runMigrationJob(MigrationJobType.cas2BackfillApplicationCohorts)
+
+      assertThat(logEntries.mapNotNull { it.throwable?.message }).anyMatch { it.contains("Unexpected application origin: other") }
+    }
+  }
+}


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-603

Adds a migration job to populate `cohort` based on `applicationOrigin`.