### PR TITLE
FM-586 - Use Enumeration for CAS1 Application and PlacementApplication Release Type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
@@ -209,7 +209,7 @@ class Cas1ApplicationSeedService(
           isWomensApplication = false,
           isEmergencyApplication = false,
           apType = ApType.normal,
-          releaseType = "licence",
+          releaseType = ReleaseTypeOption.licence,
           arrivalDate = LocalDate.of(2025, 12, 12),
           data = APPLICATION_DATA_JSON,
           isInapplicable = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1DuplicateApplicationSeedJob.kt
@@ -96,7 +96,7 @@ class Cas1DuplicateApplicationSeedJob(
         isWomensApplication = sourceApplication.isWomensApplication,
         isEmergencyApplication = sourceApplication.isEmergencyApplication,
         apType = sourceApplication.apType.asApiType(),
-        releaseType = sourceApplication.releaseType,
+        releaseType = sourceApplication.releaseType?.apiType,
         arrivalDate = sourceApplication.arrivalDate?.toLocalDate(),
         data = sourceApplication.data!!,
         isInapplicable = sourceApplication.isInapplicable,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1ApplicationsController.kt
@@ -250,7 +250,7 @@ class Cas1ApplicationsController(
         isWomensApplication = body.isWomensApplication,
         isEmergencyApplication = body.isEmergencyApplication,
         apType = body.apType,
-        releaseType = body.releaseType?.name,
+        releaseType = body.releaseType,
         arrivalDate = body.arrivalDate,
         isInapplicable = body.isInapplicable,
         noticeType = body.noticeType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -365,7 +366,8 @@ class ApprovedPremisesApplicationEntity(
   val teamCodes: MutableList<ApplicationTeamCodeEntity>,
   @OneToMany(mappedBy = "application")
   var placementRequests: MutableList<PlacementRequestEntity>,
-  var releaseType: String?,
+  @Enumerated(value = EnumType.STRING)
+  var releaseType: Cas1ReleaseType?,
   var sentenceType: String?,
   var situation: String?,
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/PlacementApplicationEntity.kt
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1PlacementDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -155,7 +156,8 @@ data class PlacementApplicationEntity(
 
   var expectedArrivalFlexible: Boolean? = null,
 
-  var releaseType: String? = null,
+  @Enumerated(value = EnumType.STRING)
+  var releaseType: Cas1ReleaseType? = null,
   var sentenceType: String? = null,
   var situation: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ReleaseType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ReleaseType.kt
@@ -22,6 +22,6 @@ enum class Cas1ReleaseType(
   ;
 
   companion object {
-    fun fromApiType(apiType: ReleaseTypeOption) = Cas1ReleaseType.entries.first { it.apiType == apiType }
+    fun fromApiType(apiType: ReleaseTypeOption) = Cas1ReleaseType.entries.firstOrNull { it.apiType == apiType } ?: error("Can't find entry for API Type $apiType")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ReleaseType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/cas1/Cas1ReleaseType.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
+
+// This enum has been created to replace usage of [String] on the entity model
+// as these values were previously populated by the API Enumeration [ReleaseTypeOption]
+// we have maintained the (incorrect) naming style
+@Suppress("ktlint:standard:enum-entry-name-case", "EnumNaming")
+enum class Cas1ReleaseType(
+  val apiType: ReleaseTypeOption,
+) {
+  licence(ReleaseTypeOption.licence),
+  rotl(ReleaseTypeOption.rotl),
+  hdc(ReleaseTypeOption.hdc),
+  pss(ReleaseTypeOption.pss),
+  inCommunity(ReleaseTypeOption.inCommunity),
+  notApplicable(ReleaseTypeOption.notApplicable),
+  extendedDeterminateLicence(ReleaseTypeOption.extendedDeterminateLicence),
+  paroleDirectedLicence(ReleaseTypeOption.paroleDirectedLicence),
+  reReleasedPostRecall(ReleaseTypeOption.reReleasedPostRecall),
+  reReleasedFollowingFixedTermRecall(ReleaseTypeOption.reReleasedFollowingFixedTermRecall),
+  ;
+
+  companion object {
+    fun fromApiType(apiType: ReleaseTypeOption) = Cas1ReleaseType.entries.first { it.apiType == apiType }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
@@ -7,6 +7,7 @@ import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -217,7 +219,7 @@ class Cas1ApplicationCreationService(
       this.apType = submitApplication.apType.asApprovedPremisesType()
       submittedAt = now
       document = serializedTranslatedDocument
-      releaseType = submitApplication.releaseType.toString()
+      releaseType = Cas1ReleaseType.fromApiType(submitApplication.releaseType)
       targetLocation = submitApplication.targetLocation
       arrivalDate = getArrivalDate(submitApplication.arrivalDate)
       duration = submitApplication.duration
@@ -328,7 +330,7 @@ class Cas1ApplicationCreationService(
       this.isWomensApplication = updateFields.isWomensApplication
       this.isEmergencyApplication = updateFields.isEmergencyApplication
       this.apType = updateFields.apType?.asApprovedPremisesType() ?: ApprovedPremisesType.NORMAL
-      this.releaseType = updateFields.releaseType
+      this.releaseType = updateFields.releaseType?.let { Cas1ReleaseType.fromApiType(it) }
       this.arrivalDate = if (updateFields.arrivalDate !== null) {
         OffsetDateTime.of(updateFields.arrivalDate, LocalTime.MIDNIGHT, ZoneOffset.UTC)
       } else {
@@ -387,7 +389,7 @@ class Cas1ApplicationCreationService(
     @Deprecated("use noticeType")
     val isEmergencyApplication: Boolean?,
     val apType: ApType?,
-    val releaseType: String?,
+    val releaseType: ReleaseTypeOption?,
     val arrivalDate: LocalDate?,
     val data: String,
     val isInapplicable: Boolean?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1BookingDomainEventService.kt
@@ -65,7 +65,7 @@ class Cas1BookingDomainEventService(
       bookingInfo = booking.toBookingInfo(),
       user = user,
       applicationSubmittedOn = application.submittedAt,
-      releaseType = application.releaseType,
+      releaseType = application.releaseType?.name,
       sentenceType = application.sentenceType,
       situation = application.situation,
       placementRequestId = placementRequest.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ValidationErrors
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.validatedCasResult
@@ -163,7 +164,7 @@ class Cas1PlacementApplicationService(
           allocatedAt = assessment.allocatedAt,
           reallocatedAt = null,
           dueAt = null,
-          releaseType = application.releaseType?.toString(),
+          releaseType = application.releaseType,
           sentenceType = application.sentenceType?.toString(),
           situation = application.situation?.toString(),
         ),
@@ -371,7 +372,7 @@ class Cas1PlacementApplicationService(
       allocatedAt = now
       placementType = placementTypeValue
       submissionGroupId = UUID.randomUUID()
-      releaseType = submitPlacementApplication.releaseType?.toString()
+      releaseType = submitPlacementApplication.releaseType?.let { Cas1ReleaseType.fromApiType(it) }
       sentenceType = submitPlacementApplication.sentenceType?.toString()
       situation = submitPlacementApplication.situationType?.toString()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -133,7 +133,7 @@ class ApplicationsTransformer(
       apType = applicationEntity.apType.asApiType(),
       licenceExpiryDate = applicationEntity.licenceExpiryDate,
 
-      releaseType = applicationEntity.releaseType?.let { ReleaseTypeOption.valueOf(it) },
+      releaseType = applicationEntity.releaseType?.apiType,
       sentenceType = applicationEntity.sentenceType?.let { SentenceTypeOption.valueOf(it) },
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCrite
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequestStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawable
@@ -42,7 +41,7 @@ class PlacementRequestTransformer(
     risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn),
     applicationId = jpa.application.id,
     assessmentId = jpa.assessment.id,
-    releaseType = getReleaseType(jpa.application.releaseType),
+    releaseType = jpa.application.releaseType!!.apiType,
     status = getStatus(jpa),
     assessmentDecision = assessmentTransformer.transformJpaDecisionToApi(jpa.assessment.decision)!!,
     assessmentDate = jpa.assessment.submittedAt?.toInstant()!!,
@@ -78,20 +77,6 @@ class PlacementRequestTransformer(
     PlacementCriteria.valueOf(characteristic.propertyName!!)
   } catch (exception: Exception) {
     null
-  }
-
-  fun getReleaseType(releaseType: String?): ReleaseTypeOption = when (releaseType) {
-    "licence" -> ReleaseTypeOption.licence
-    "rotl" -> ReleaseTypeOption.rotl
-    "hdc" -> ReleaseTypeOption.hdc
-    "pss" -> ReleaseTypeOption.pss
-    "inCommunity" -> ReleaseTypeOption.inCommunity
-    "notApplicable" -> ReleaseTypeOption.notApplicable
-    "extendedDeterminateLicence" -> ReleaseTypeOption.extendedDeterminateLicence
-    "paroleDirectedLicence" -> ReleaseTypeOption.paroleDirectedLicence
-    "reReleasedPostRecall" -> ReleaseTypeOption.reReleasedPostRecall
-    "reReleasedFollowingFixedTermRecall" -> ReleaseTypeOption.reReleasedFollowingFixedTermRecall
-    else -> throw RuntimeException("Unrecognised releaseType: $releaseType")
   }
 
   fun getWithdrawalReason(withdrawalReason: PlacementRequestWithdrawalReason?): WithdrawPlacementRequestReason? = when (withdrawalReason) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
@@ -56,7 +55,7 @@ class RequestForPlacementTransformer(
       status = statusAndWhen.status,
       statusSetDate = statusAndWhen.occurredAt,
       sentenceType = placementApplicationEntity.sentenceType?.let { SentenceTypeOption.valueOf(it) },
-      releaseType = placementApplicationEntity.releaseType?.let { ReleaseTypeOption.valueOf(it) },
+      releaseType = placementApplicationEntity.releaseType?.apiType,
       situation = placementApplicationEntity.situation?.let { SituationOption.valueOf(it) },
     )
   }
@@ -110,7 +109,7 @@ class RequestForPlacementTransformer(
       status = statusAndWhen.status,
       statusSetDate = statusAndWhen.occurredAt,
       sentenceType = application.sentenceType?.let { SentenceTypeOption.valueOf(it) },
-      releaseType = application.releaseType?.let { ReleaseTypeOption.valueOf(it) },
+      releaseType = application.releaseType?.apiType,
       situation = application.situation?.let { SituationOption.valueOf(it) },
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 class TaskTransformer(
   private val userTransformer: UserTransformer,
   private val risksTransformer: RisksTransformer,
-  private val placementRequestTransformer: PlacementRequestTransformer,
   private val apAreaTransformer: ApAreaTransformer,
   private val assessmentTransformer: AssessmentTransformer,
   private val probationDeliveryUnitTransformer: ProbationDeliveryUnitTransformer,
@@ -76,7 +75,7 @@ class TaskTransformer(
     tier = risksTransformer.transformTierDomainToApi(placementApplication.application.riskRatings!!.tier),
     dates = placementApplication.placementDates()!!.toApiType(),
     placementDates = listOf(placementApplication.placementDates()!!.toApiType()),
-    releaseType = placementRequestTransformer.getReleaseType(placementApplication.application.releaseType),
+    releaseType = placementApplication.application.releaseType!!.apiType,
     placementType = getPlacementType(placementApplication.placementType!!),
     apArea = getApArea(placementApplication.application),
     outcomeRecordedAt = placementApplication.decisionMadeAt?.toInstant(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1DuplicateApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1DuplicateApplicationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
@@ -34,7 +35,7 @@ class SeedCas1DuplicateApplicationTest : SeedTestBase() {
           withNomsNumber(offenderDetails.otherIds.nomsNumber)
           withApArea(givenAnApArea())
           withIsEmergencyApplication(true)
-          withReleaseType("licence")
+          withReleaseType(Cas1ReleaseType.licence)
         }
 
         apDeliusContextMockSuccessfulTeamsManagingCaseCall(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1WithdrawPlacementRequestsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1WithdrawPlacementRequestsTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -170,7 +171,7 @@ class SeedCas1WithdrawPlacementRequestsTest : SeedTestBase() {
       withCreatedByUser(applicant)
       withSubmittedAt(OffsetDateTime.now())
       withApArea(apArea)
-      withReleaseType("licence")
+      withReleaseType(Cas1ReleaseType.licence)
       withCaseManagerUserDetails(caseManager)
       withCaseManagerIsNotApplicant(caseManager != null)
       withCruManagementArea(givenACas1CruManagementArea())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCasUpdateEventNumberTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCasUpdateEventNumberTest.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.seed.SeedTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.seed.CsvBuilder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.SaveCas1DomainEvent
@@ -304,7 +305,7 @@ class SeedCasUpdateEventNumberTest : SeedTestBase() {
         withCreatedByUser(applicant)
         withSubmittedAt(OffsetDateTime.now())
         withApArea(givenAnApArea())
-        withReleaseType("licence")
+        withReleaseType(Cas1ReleaseType.licence)
         withEventNumber(OLD_EVENT_NUMBER)
         withOffenceId(OLD_OFFENCE_ID)
         withConvictionId(OLD_CONVICTION_ID)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
@@ -48,7 +49,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
   private var assessments: Yielded<MutableList<AssessmentEntity>> = { mutableListOf() }
   private var teamCodes: Yielded<MutableList<ApplicationTeamCodeEntity>> = { mutableListOf() }
   private var placementRequests: Yielded<MutableList<PlacementRequestEntity>> = { mutableListOf() }
-  private var releaseType: Yielded<String?> = { null }
+  private var releaseType: Yielded<Cas1ReleaseType?> = { null }
   private var sentenceType: Yielded<String?> = { null }
   private var situation: Yielded<String?> = { null }
   private var arrivalDate: Yielded<OffsetDateTime?> = { null }
@@ -140,7 +141,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.placementRequests = { placementRequests }
   }
 
-  fun withReleaseType(releaseType: String) = apply {
+  fun withReleaseType(releaseType: Cas1ReleaseType) = apply {
     this.releaseType = { releaseType }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/PlacementApplicationEntityFactory.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.LocalDate
@@ -39,7 +40,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
   private var authorisedDuration: Yielded<Int?> = { null }
   private var expectedArrivalFlexible: Yielded<Boolean> = { false }
   private var sentenceType: Yielded<String?> = { null }
-  private var releaseType: Yielded<String?> = { null }
+  private var releaseType: Yielded<Cas1ReleaseType?> = { null }
   private var situation: Yielded<String?> = { null }
 
   fun withDefaults() = apply {
@@ -135,7 +136,7 @@ class PlacementApplicationEntityFactory : Factory<PlacementApplicationEntity> {
     this.sentenceType = { sentenceType }
   }
 
-  fun withReleaseType(releaseType: String?) = apply {
+  fun withReleaseType(releaseType: Cas1ReleaseType?) = apply {
     this.releaseType = { releaseType }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ApplicationSummaryQueryTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import java.time.OffsetDateTime
@@ -26,7 +27,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCreatedByUser(differentUser)
             withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
-            withReleaseType("rotl")
+            withReleaseType(Cas1ReleaseType.rotl)
             withSubmittedAt(null)
           }
 
@@ -35,7 +36,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCreatedByUser(user)
             withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
-            withReleaseType("rotl")
+            withReleaseType(Cas1ReleaseType.rotl)
             withSubmittedAt(null)
             withIsInapplicable(false)
             withStatus(ApprovedPremisesApplicationStatus.STARTED)
@@ -46,7 +47,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCreatedByUser(user)
             withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
-            withReleaseType("rotl")
+            withReleaseType(Cas1ReleaseType.rotl)
             withIsWithdrawn(true)
             withStatus(ApprovedPremisesApplicationStatus.WITHDRAWN)
           }
@@ -63,7 +64,7 @@ class ApplicationSummaryQueryTest : IntegrationTestBase() {
             withCreatedByUser(user)
             withApType(ApprovedPremisesType.PIPE)
             withIsWomensApplication(false)
-            withReleaseType("rotl")
+            withReleaseType(Cas1ReleaseType.rotl)
             withSubmittedAt(OffsetDateTime.parse("2023-04-19T09:34:00+01:00"))
             withStatus(ApprovedPremisesApplicationStatus.AWAITING_ASSESSMENT)
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.isWithinTheLastMinute
 import java.time.LocalDate
@@ -876,7 +877,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             assertThat(updatedPlacementApplication.allocatedToUser).isNull()
             assertThat(updatedPlacementApplication.requestedDuration).isEqualTo(placementDates[0].duration)
             assertThat(updatedPlacementApplication.expectedArrival).isEqualTo(placementDates[0].expectedArrival)
-            assertThat(updatedPlacementApplication.releaseType).isEqualTo(ReleaseTypeOption.licence.toString())
+            assertThat(updatedPlacementApplication.releaseType).isEqualTo(Cas1ReleaseType.licence)
             assertThat(updatedPlacementApplication.sentenceType).isEqualTo(SentenceTypeOption.communityOrder.toString())
             assertThat(updatedPlacementApplication.situation).isEqualTo(SituationOption.bailSentence.toString())
 
@@ -959,7 +960,7 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             assertThat(updatedEntity1.requestedDuration).isEqualTo(duration1)
             assertThat(updatedEntity1.submittedAt).isNotNull()
             assertThat(updatedEntity1.allocatedToUser).isNull()
-            assertThat(updatedEntity1.releaseType).isEqualTo(ReleaseTypeOption.licence.toString())
+            assertThat(updatedEntity1.releaseType).isEqualTo(Cas1ReleaseType.licence)
 
             val createdApp2Id = body[1].id
             val updatedEntity2 = placementApplicationRepository.findByIdOrNull(createdApp2Id)!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/SubjectAccessRequestServiceTestBase.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -70,7 +71,7 @@ open class SubjectAccessRequestServiceTestBase : IntegrationTestBase() {
     const val EVENT_NUMBER = "1"
     const val OFFENCE_ID = "BEING_BAD"
     const val CONVICTION_ID = 2L
-    const val RELEASE_TYPE_CONDITIONAL = "CONDITIONAL"
+    val RELEASE_TYPE_CONDITIONAL = Cas1ReleaseType.reReleasedPostRecall
     const val WITHDRAWAL_REASON_NOT_WITHDRAWN = "NOT WITHDRAWN"
     const val OTHER_WITHDRAWAL_REASON_NOT_APPLICABLE = "NOT APPLICABLE"
     const val SENTENCE_TYPE_CUSTODIAL = "CUSTODIAL"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -89,6 +89,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
@@ -1141,7 +1142,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
             withCreatedByUser(userEntity)
             withData("""{"thingId":123}""")
-            withReleaseType("reReleasedFollowingFixedTermRecall")
+            withReleaseType(Cas1ReleaseType.reReleasedFollowingFixedTermRecall)
           }
 
           val rawResponseBody = webTestClient.get()
@@ -1162,7 +1163,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
           assertThat(responseBody.createdByUserId).isEqualTo(applicationEntity.createdByUser.id)
           assertThat(responseBody.createdByUserName).isEqualTo(applicationEntity.createdByUser.name)
           assertThat(responseBody.submittedAt).isEqualTo(applicationEntity.submittedAt?.toInstant())
-          assertThat(responseBody.releaseType).isEqualTo(ReleaseTypeOption.valueOf(applicationEntity.releaseType!!))
+          assertThat(responseBody.releaseType).isEqualTo(applicationEntity.releaseType!!.apiType)
           assertThat(serializableToJsonNode(responseBody.data)).isEqualTo(serializableToJsonNode(applicationEntity.data))
         }
       }
@@ -1888,7 +1889,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
       assertThat(persistedApplication.sentenceType).isEqualTo(SentenceTypeOption.nonStatutory.toString())
       assertThat(persistedApplication.apArea?.id).isEqualTo(submittingUser.apArea!!.id)
       assertThat(persistedApplication.licenceExpiryDate).isEqualTo(LocalDate.of(2026, 12, 1))
-      assertThat(persistedApplication.releaseType).isEqualTo(ReleaseTypeOption.reReleasedFollowingFixedTermRecall.toString())
+      assertThat(persistedApplication.releaseType).isEqualTo(Cas1ReleaseType.reReleasedFollowingFixedTermRecall)
 
       val createdAssessment =
         approvedPremisesAssessmentRepository.findAll().first { it.application.id == applicationId }
@@ -2620,7 +2621,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             withExpectedArrival(LocalDate.now())
             withRequestedDuration(2)
             withSentenceType(SentenceTypeOption.bailPlacement.name)
-            withReleaseType(ReleaseTypeOption.inCommunity.name)
+            withReleaseType(Cas1ReleaseType.inCommunity)
             withSituation(SituationOption.bailSentence.name)
           }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
@@ -29,7 +29,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCrite
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Problem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateAssessment
@@ -65,6 +64,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
@@ -1165,7 +1165,7 @@ class Cas1AssessmentTest : IntegrationTestBase() {
             withCreatedByUser(userEntity)
             withSubmittedAt(OffsetDateTime.now())
             withSentenceType(SentenceTypeOption.bailPlacement.name)
-            withReleaseType(ReleaseTypeOption.inCommunity.name)
+            withReleaseType(Cas1ReleaseType.inCommunity)
             withSituation(SituationOption.bailSentence.name)
           }
 
@@ -1248,7 +1248,7 @@ class Cas1AssessmentTest : IntegrationTestBase() {
           assertThat(placementApplication.expectedArrival).isEqualTo(placementDates.expectedArrival)
           assertThat(placementApplication.authorisedDuration).isEqualTo(placementDates.duration)
           assertThat(placementApplication.sentenceType).isEqualTo(SentenceTypeOption.bailPlacement.name)
-          assertThat(placementApplication.releaseType).isEqualTo(ReleaseTypeOption.inCommunity.name)
+          assertThat(placementApplication.releaseType).isEqualTo(Cas1ReleaseType.inCommunity)
           assertThat(placementApplication.situation).isEqualTo(SituationOption.bailSentence.name)
 
           assertThat(placementApplicationPlaceholderRepository.findByApplication(application)!!.archived).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestSearchPaginationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestSearchPaginationTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDec
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
@@ -168,7 +169,7 @@ class Cas1PlacementRequestSearchPaginationTest : IntegrationTestBase() {
       withCrn(caseSummary.crn)
       withCreatedByUser(user)
       withSubmittedAt(applicationDate)
-      withReleaseType("licence")
+      withReleaseType(Cas1ReleaseType.licence)
       withName("${caseSummary.name.forename} ${caseSummary.name.surname}")
       withRiskRatings(
         uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole.Companion.removeRolesWithAllProdPermissions
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -1144,7 +1145,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
         withCrn(offenderDetails.otherIds.crn)
         withCreatedByUser(user)
         withSubmittedAt(OffsetDateTime.now())
-        withReleaseType("licence")
+        withReleaseType(Cas1ReleaseType.licence)
         withSubmittedAt(applicationDate)
         withName("${offenderDetails.firstName} ${offenderDetails.surname}")
         withRiskRatings(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1WithdrawalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1WithdrawalTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.jsonForObject
 import java.time.Instant
@@ -1155,7 +1156,7 @@ class Cas1WithdrawalTest : IntegrationTestBase() {
       withSubmittedAt(OffsetDateTime.now())
       withApArea(apArea)
       withCruManagementArea(givenACas1CruManagementArea())
-      withReleaseType("licence")
+      withReleaseType(Cas1ReleaseType.licence)
       withCaseManagerUserDetails(caseManager)
       withCaseManagerIsNotApplicant(caseManager != null)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAPlacementRequest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequ
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
@@ -85,7 +86,7 @@ fun IntegrationTestBase.givenAPlacementRequest(
     withCreatedAt(applicationCreatedAt)
     withCreatedByUser(createdByUser)
     withSubmittedAt(applicationSubmittedAt)
-    withReleaseType("licence")
+    withReleaseType(Cas1ReleaseType.licence)
     withRiskRatings(
       risksFactory.produce(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnAssessment.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAcco
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualification
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
@@ -44,7 +45,7 @@ fun IntegrationTestBase.givenAnAssessmentForApprovedPremises(
     withCrn(crn)
     withCreatedByUser(createdByUser)
     withSubmittedAt(OffsetDateTime.now())
-    withReleaseType("licence")
+    withReleaseType(Cas1ReleaseType.licence)
     withIsWithdrawn(isWithdrawn)
     withApArea(apArea)
     withCruManagementArea(cruManagementArea)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
@@ -129,7 +130,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
                 withCreatedByUser(userEntity)
                 withCreatedAt(OffsetDateTime.now().minusDays(Random.nextLong(1, 25)))
                 withArrivalDate(OffsetDateTime.now().plusDays(Random.nextLong(1, 25)))
-                withReleaseType(it.name)
+                withReleaseType(Cas1ReleaseType.fromApiType(it))
                 withRiskRatings(
                   PersonRisksFactory().withTier(
                     RiskWithStatus(
@@ -315,7 +316,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   @ParameterizedTest
   @EnumSource(ReleaseTypeOption::class)
   fun `findAllApprovedPremisesSummaries filters by release type`(releaseType: ReleaseTypeOption) {
-    val expectedApplications = allApplications.filter { it.releaseType == releaseType.name }
+    val expectedApplications = allApplications.filter { it.releaseType?.apiType == releaseType }
 
     val result = cas1ApplicationService.getAllApprovedPremisesApplications(
       1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationPlaceholderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
@@ -383,7 +384,7 @@ class Cas1ApplicationCreationServiceTest {
           isWomensApplication = false,
           isEmergencyApplication = false,
           apType = apType,
-          releaseType = "rotl",
+          releaseType = ReleaseTypeOption.rotl,
           arrivalDate = LocalDate.parse("2023-04-17"),
           data = updatedData,
           isInapplicable = false,
@@ -398,7 +399,7 @@ class Cas1ApplicationCreationServiceTest {
         assertThat(it.isPipeApplication).isEqualTo(apType == ApType.pipe)
         assertThat(it.isEsapApplication).isEqualTo(apType == ApType.esap)
         assertThat(it.apType).isEqualTo(apType.asApprovedPremisesType())
-        assertThat(it.releaseType).isEqualTo("rotl")
+        assertThat(it.releaseType).isEqualTo(Cas1ReleaseType.rotl)
         assertThat(it.isInapplicable).isEqualTo(false)
         assertThat(it.arrivalDate).isEqualTo(OffsetDateTime.parse("2023-04-17T00:00:00Z"))
         assertThat(it.applicantUserDetails).isNull()
@@ -435,7 +436,7 @@ class Cas1ApplicationCreationServiceTest {
           isWomensApplication = false,
           isEmergencyApplication = noticeType == Cas1ApplicationTimelinessCategory.emergency,
           apType = ApType.pipe,
-          releaseType = "rotl",
+          releaseType = ReleaseTypeOption.rotl,
           arrivalDate = if (noticeType == Cas1ApplicationTimelinessCategory.shortNotice) {
             LocalDate.now().plusDays(10)
           } else {
@@ -661,7 +662,7 @@ class Cas1ApplicationCreationServiceTest {
       assertThatCasResult(result).isSuccess().with {
         assertThat(it.isPipeApplication).isTrue
         assertThat(it.isWomensApplication).isFalse
-        assertThat(it.releaseType).isEqualTo(defaultSubmitApprovedPremisesApplication.releaseType.toString())
+        assertThat(it.releaseType).isEqualTo(Cas1ReleaseType.licence)
         if (situation == null) {
           assertThat(it.situation).isNull()
         } else {
@@ -812,7 +813,7 @@ class Cas1ApplicationCreationServiceTest {
       assertThatCasResult(result).isSuccess().with {
         assertThat(it.isPipeApplication).isTrue
         assertThat(it.isWomensApplication).isFalse
-        assertThat(it.releaseType).isEqualTo(defaultSubmitApprovedPremisesApplication.releaseType.toString())
+        assertThat(it.releaseType).isEqualTo(Cas1ReleaseType.licence)
         assertThat(it.noticeType).isEqualTo(noticeType)
         assertThat(it.targetLocation).isEqualTo(defaultSubmitApprovedPremisesApplication.targetLocation)
         assertThat(it.inmateInOutStatusOnSubmission).isEqualTo("OUT")
@@ -891,7 +892,7 @@ class Cas1ApplicationCreationServiceTest {
         assertThat(it.isEsapApplication).isEqualTo(apType == ApType.esap)
         assertThat(it.apType).isEqualTo(apType.asApprovedPremisesType())
         assertThat(it.isWomensApplication).isFalse
-        assertThat(it.releaseType).isEqualTo(defaultSubmitApprovedPremisesApplication.releaseType.toString())
+        assertThat(it.releaseType).isEqualTo(Cas1ReleaseType.licence)
         assertThat(it.noticeType).isEqualTo(Cas1ApplicationTimelinessCategory.standard)
         assertThat(it.targetLocation).isEqualTo(defaultSubmitApprovedPremisesApplication.targetLocation)
         assertThat(it.inmateInOutStatusOnSubmission).isEqualTo("OUT")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1BookingDomainEventServiceTest.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Bo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventTransferType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.SpaceCharacteristic
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
@@ -36,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TransferType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -82,7 +82,7 @@ class Cas1BookingDomainEventServiceTest {
       .withEventNumber("online app event number")
       .withCreatedByUser(otherUser)
       .withSubmittedAt(OffsetDateTime.now())
-      .withReleaseType(ReleaseTypeOption.licence.toString())
+      .withReleaseType(Cas1ReleaseType.licence)
       .withSentenceType(SentenceTypeOption.nonStatutory.toString())
       .withSituation(SituationOption.bailSentence.toString())
       .produce()
@@ -177,7 +177,7 @@ class Cas1BookingDomainEventServiceTest {
       assertThat(data.arrivalOn).isEqualTo(LocalDate.of(2025, 12, 11))
       assertThat(data.departureOn).isEqualTo(LocalDate.of(2025, 12, 12))
       assertThat(data.applicationSubmittedOn).isEqualTo(application.submittedAt!!.toInstant())
-      assertThat(data.releaseType).isEqualTo(application.releaseType)
+      assertThat(data.releaseType).isEqualTo(application.releaseType.toString())
       assertThat(data.sentenceType).isEqualTo(application.sentenceType)
       assertThat(data.situation).isEqualTo(application.situation)
       assertThat(data.characteristics).isEqualTo(listOf(SpaceCharacteristic.hasEnSuite))
@@ -208,7 +208,7 @@ class Cas1BookingDomainEventServiceTest {
         .withCrn("Application CRN")
         .withCreatedByUser(otherUser)
         .withSubmittedAt(OffsetDateTime.now())
-        .withReleaseType(ReleaseTypeOption.licence.toString())
+        .withReleaseType(Cas1ReleaseType.licence)
         .withSentenceType(SentenceTypeOption.nonStatutory.toString())
         .withSituation(SituationOption.bailSentence.toString())
         .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
@@ -171,7 +172,7 @@ class Cas1PlacementApplicationServiceTest {
         .withSubmittedAt(OffsetDateTime.parse("2018-12-04T10:15:30+01:00"))
         .withDuration(25)
         .withSentenceType(SentenceTypeOption.bailPlacement.name)
-        .withReleaseType(ReleaseTypeOption.licence.name)
+        .withReleaseType(Cas1ReleaseType.licence)
         .withSituation(SituationOption.bailAssessment.name)
         .produce()
 
@@ -216,7 +217,7 @@ class Cas1PlacementApplicationServiceTest {
       assertThat(persisted.allocatedAt).isEqualTo(OffsetDateTime.parse("2018-12-05T10:15:30+01:00"))
       assertThat(persisted.reallocatedAt).isNull()
       assertThat(persisted.sentenceType).isEqualTo(SentenceTypeOption.bailPlacement.name)
-      assertThat(persisted.releaseType).isEqualTo(ReleaseTypeOption.licence.name)
+      assertThat(persisted.releaseType).isEqualTo(Cas1ReleaseType.licence)
       assertThat(persisted.situation).isEqualTo(SituationOption.bailAssessment.name)
 
       verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(persisted, createdByUserName = null) }
@@ -313,18 +314,18 @@ class Cas1PlacementApplicationServiceTest {
 
     @ParameterizedTest
     @CsvSource(
-      "paroleDirectedLicence, RELEASE_FOLLOWING_DECISION",
-      "rotl, ROTL",
-      "licence, ADDITIONAL_PLACEMENT",
-      "hdc, ADDITIONAL_PLACEMENT",
-      "pss, ADDITIONAL_PLACEMENT",
-      "inCommunity, ADDITIONAL_PLACEMENT",
-      "notApplicable, ADDITIONAL_PLACEMENT",
-      "extendedDeterminateLicence, ADDITIONAL_PLACEMENT",
-      "reReleasedPostRecall, ADDITIONAL_PLACEMENT",
-      "reReleasedFollowingFixedTermRecall, ADDITIONAL_PLACEMENT",
+      "paroleDirectedLicence, paroleDirectedLicence, RELEASE_FOLLOWING_DECISION",
+      "rotl, rotl, ROTL",
+      "licence, licence,ADDITIONAL_PLACEMENT",
+      "hdc, hdc,ADDITIONAL_PLACEMENT",
+      "pss, pss,ADDITIONAL_PLACEMENT",
+      "inCommunity, inCommunity,ADDITIONAL_PLACEMENT",
+      "notApplicable, notApplicable,ADDITIONAL_PLACEMENT",
+      "extendedDeterminateLicence, extendedDeterminateLicence,ADDITIONAL_PLACEMENT",
+      "reReleasedPostRecall, reReleasedPostRecall,ADDITIONAL_PLACEMENT",
+      "reReleasedFollowingFixedTermRecall, reReleasedFollowingFixedTermRecall,ADDITIONAL_PLACEMENT",
     )
-    fun `Submitting an application and inferring placement type from release type`(releaseType: String, jpaPlacementType: String) {
+    fun `Submitting an application and inferring placement type from release type`(releaseTypeOption: ReleaseTypeOption, cas1ReleaseType: Cas1ReleaseType, jpaPlacementType: String) {
       every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
       every { userAllocator.getUserForPlacementApplicationAllocation(placementApplication) } returns assigneeUser
       every { placementApplicationRepository.save(any()) } answers { it.invocation.args[0] as PlacementApplicationEntity }
@@ -346,7 +347,7 @@ class Cas1PlacementApplicationServiceTest {
             arrivalFlexible = true,
           ),
         ),
-        releaseType = ReleaseTypeOption.valueOf(releaseType),
+        releaseType = releaseTypeOption,
         sentenceType = null,
         situationType = null,
       )
@@ -363,7 +364,7 @@ class Cas1PlacementApplicationServiceTest {
 
       val updatedPlacementApp = updatedPlacementApplications[0]
 
-      assertThat(updatedPlacementApp.releaseType).isEqualTo(releaseType)
+      assertThat(updatedPlacementApp.releaseType).isEqualTo(cas1ReleaseType)
       assertThat(updatedPlacementApp.placementType.toString()).isEqualTo(jpaPlacementType)
 
       verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(updatedPlacementApp, "theUsername") }
@@ -457,7 +458,7 @@ class Cas1PlacementApplicationServiceTest {
       assertThat(updatedPlacementApp.requestedDuration).isEqualTo(5)
       assertThat(updatedPlacementApp.expectedArrivalFlexible).isTrue
       assertThat(updatedPlacementApp.authorisedDuration).isNull()
-      assertThat(updatedPlacementApp.releaseType).isEqualTo(ReleaseTypeOption.licence.toString())
+      assertThat(updatedPlacementApp.releaseType).isEqualTo(Cas1ReleaseType.licence)
 
       verify { cas1PlacementApplicationDomainEventService.placementApplicationSubmitted(updatedPlacementApp, "theUsername") }
       verify { cas1PlacementApplicationEmailService.placementApplicationAllocated(updatedPlacementApp) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformersTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
@@ -129,7 +130,7 @@ class ApplicationsTransformersTest {
       .withCaseManagerIsNotApplicant(true)
       .withCaseManagerUserDetails(caseManagerUserDetails)
       .withLicenseExpiredDate(LocalDate.of(2026, 5, 5))
-      .withReleaseType(ReleaseTypeOption.notApplicable.name)
+      .withReleaseType(Cas1ReleaseType.notApplicable)
       .withSentenceType(SentenceTypeOption.bailPlacement.name)
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
@@ -229,7 +230,7 @@ class PlacementRequestDetailTransformerTest {
       .produce()
 
     val application = ApprovedPremisesApplicationEntityFactory()
-      .withReleaseType("licence")
+      .withReleaseType(Cas1ReleaseType.licence)
       .withCreatedByUser(user)
       .withSubmittedAt(OffsetDateTime.now().minusDays(3))
       .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequire
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.JpaApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
@@ -75,7 +76,7 @@ class PlacementRequestTransformerTest {
   private val assessmentSubmittedAt = OffsetDateTime.now().minusDays(3)
 
   private val application = ApprovedPremisesApplicationEntityFactory()
-    .withReleaseType("licence")
+    .withReleaseType(Cas1ReleaseType.licence)
     .withCreatedByUser(user)
     .withSubmittedAt(applicationSubmittedAt)
     .produce()
@@ -302,7 +303,18 @@ class PlacementRequestTransformerTest {
         .withNotes("Some notes")
         .produce()
 
-      application.releaseType = releaseTypeOption.name
+      application.releaseType = when (releaseTypeOption) {
+        ReleaseTypeOption.licence -> Cas1ReleaseType.licence
+        ReleaseTypeOption.rotl -> Cas1ReleaseType.rotl
+        ReleaseTypeOption.hdc -> Cas1ReleaseType.hdc
+        ReleaseTypeOption.pss -> Cas1ReleaseType.pss
+        ReleaseTypeOption.inCommunity -> Cas1ReleaseType.inCommunity
+        ReleaseTypeOption.notApplicable -> Cas1ReleaseType.notApplicable
+        ReleaseTypeOption.extendedDeterminateLicence -> Cas1ReleaseType.extendedDeterminateLicence
+        ReleaseTypeOption.paroleDirectedLicence -> Cas1ReleaseType.paroleDirectedLicence
+        ReleaseTypeOption.reReleasedPostRecall -> Cas1ReleaseType.reReleasedPostRecall
+        ReleaseTypeOption.reReleasedFollowingFixedTermRecall -> Cas1ReleaseType.reReleasedFollowingFixedTermRecall
+      }
 
       val result = placementRequestTransformer.transformJpaToApi(
         placementRequestEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
@@ -68,7 +69,7 @@ class RequestForPlacementTransformerTest {
         .withRequestedDuration(48)
         .withAuthorisedDuration(49)
         .withSentenceType(SentenceTypeOption.bailPlacement.name)
-        .withReleaseType(ReleaseTypeOption.licence.name)
+        .withReleaseType(Cas1ReleaseType.licence)
         .withSituation(SituationOption.bailSentence.name)
         .produce()
 
@@ -311,7 +312,7 @@ class RequestForPlacementTransformerTest {
       val application = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(user)
         .withSentenceType(SentenceTypeOption.bailPlacement.name)
-        .withReleaseType(ReleaseTypeOption.rotl.name)
+        .withReleaseType(Cas1ReleaseType.rotl)
         .withSituation(SituationOption.bailAssessment.name)
         .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
@@ -46,7 +47,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PlacementRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ProbationDeliveryUnitTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.TaskTransformer
@@ -60,7 +60,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementType
 class TaskTransformerTest {
   private val mockUserTransformer = mockk<UserTransformer>()
   private val mockRisksTransformer = mockk<RisksTransformer>()
-  private val mockPlacementRequestTransformer = mockk<PlacementRequestTransformer>()
   private val mockApAreaTransformer = mockk<ApAreaTransformer>()
   private val mockAssessmentTransformer = mockk<AssessmentTransformer>()
   private val mockProbationDeliveryUnitTransformer = mockk<ProbationDeliveryUnitTransformer>()
@@ -116,7 +115,6 @@ class TaskTransformerTest {
   private val taskTransformer = TaskTransformer(
     mockUserTransformer,
     mockRisksTransformer,
-    mockPlacementRequestTransformer,
     mockApAreaTransformer,
     mockAssessmentTransformer,
     mockProbationDeliveryUnitTransformer,
@@ -280,12 +278,11 @@ class TaskTransformerTest {
       .produce()
     val application = placementApplication.application
     private val mockTier = mockk<RiskTierEnvelope>()
-    private val releaseType = ReleaseTypeOption.licence
 
     @BeforeEach
     fun setup() {
       every { mockRisksTransformer.transformTierDomainToApi(application.riskRatings!!.tier) } returns mockTier
-      every { mockPlacementRequestTransformer.getReleaseType(application.releaseType) } returns releaseType
+      application.releaseType = Cas1ReleaseType.licence
     }
 
     @Test
@@ -301,7 +298,7 @@ class TaskTransformerTest {
       assertThat(result.status).isEqualTo(TaskStatus.notStarted)
       assertThat(result.id).isEqualTo(placementApplication.id)
       assertThat(result.tier).isEqualTo(mockTier)
-      assertThat(result.releaseType).isEqualTo(releaseType)
+      assertThat(result.releaseType).isEqualTo(ReleaseTypeOption.licence)
       assertThat(result.personName).isEqualTo("First Last")
       assertThat(result.crn).isEqualTo(placementApplication.application.crn)
       assertThat(result.dates).isEqualTo(
@@ -391,7 +388,7 @@ class TaskTransformerTest {
     @Test
     fun `placement application with ApArea is correctly transformed`() {
       val apArea = ApAreaEntityFactory().produce()
-      val application = applicationFactory.withApArea(apArea).produce()
+      val application = applicationFactory.withApArea(apArea).withReleaseType(Cas1ReleaseType.licence).produce()
       val placementApplication = placementApplicationFactory
         .withApplication(application)
         .withSubmittedAt(OffsetDateTime.now())


### PR DESCRIPTION
Before this commit we used a String value in the entity model for `ApprovedPremisesApplicationEntity.releaseType` and `PlacementApplicationEntity.releaseType`, despite the values being mapped to and from an API enumeration.

As part of making this change i've checked usage in the preprod database to ensure only the expected values have been persisted