### PR TITLE
Fix open api groups

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -58,7 +58,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas1Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS1Shared")
     .displayName("CAS1 & Shared")
-    .pathsToExclude("/**/cas2/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**")
+    .pathsToExclude("/**/cas2/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -66,7 +66,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas1DomainEvents(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS1DomainEvents")
     .displayName("CAS1 Domain Events")
-    .pathsToExclude("/**/events/cas2/**", "/**/events/cas3/**")
+    .pathsToExclude("/**/events/cas2/**", "/**/events/cas3/**", "/queue-admin/**")
     .pathsToMatch("/**/events/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
@@ -75,7 +75,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas2Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2Shared")
     .displayName("CAS2 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -100,7 +100,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas2v2Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2v2Shared")
     .displayName("CAS2v2 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**", "/**/events/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -108,7 +108,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas3Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS3Shared")
     .displayName("CAS3 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2v2/**", "/**/events/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2v2/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -146,7 +146,6 @@ spring:
             token-uri: ${hmpps.auth.url}/oauth/token
 
 springdoc:
-  paths-to-exclude: "/queue-admin/**"
   swagger-ui:
     urls-primary-name: "All CAS"
   remove-broken-reference-definitions: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/OpenApiDocsTest.kt
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.info.BuildProperties
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 
 /**
  * This is taken from hmpps-template-kotlin, with some tweaks
@@ -129,5 +130,17 @@ class OpenApiDocsTest : IntegrationTestBase() {
       .expectStatus().isOk
       .expectBody()
       .jsonPath("$.paths[*][*][?(!@.security)]").doesNotExist()
+  }
+
+  @Test
+  fun `groups exclude other CASs`() {
+    val openApiDoc = webTestClient.get()
+      .uri("/v3/api-docs/CAS1Shared")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .bodyAsObject<String>()
+
+    assertThat(openApiDoc).doesNotContainIgnoringCase("Cas3Premises")
   }
 }


### PR DESCRIPTION
Recently we added `paths-to-exclude` entry in the `application.yml` to exclude the `queue-admin/**` urls from all open api documents. This overwrote our custom exclude rules defined in `OpenApiConfiguration`. This commit removes that entry, and instead adds it into the `OpenApiConfiguration`. It also adds a regression test to capture similar breakages in the future