### PR TITLE
Add OpenAPI 3.0 version configuration to local development settings

### DIFF
--- a/src/main/resources/application-localdev.yml
+++ b/src/main/resources/application-localdev.yml
@@ -51,6 +51,8 @@ spring:
 
 springdoc:
   pre-loading-enabled: false
+  api-docs:
+    version: openapi_3_0
 
 user-allocations:
   rules:


### PR DESCRIPTION
Local swagger docs at http://localhost:8080/v3/api-docs/CAS2 are created using OpenAPI version 3.1 however the openapi-typescript-codegen used to generate the UI types only supports 3.0.

Pinning the version for local dev to 3.0 resolves the problem so that UI types can be generated when the url in the generate-types script is set to localhost (rather than dev).
