### PR TITLE
FM-586 Use correct release type in `PlacementRequest`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1StartupScript.kt
@@ -51,6 +51,12 @@ class Cas1StartupScript(
 
     createApplication(
       deliusUserName = "AP_USER_TEST_1",
+      crn = "Y006208",
+      state = Cas1ApplicationSeedService.ApplicationState.AUTHORISED,
+    )
+
+    createApplication(
+      deliusUserName = "AP_USER_TEST_1",
       crn = "X698338",
       state = Cas1ApplicationSeedService.ApplicationState.EXPIRED_AFTER_AUTHORISATION,
     )
@@ -63,7 +69,7 @@ class Cas1StartupScript(
     crn: String,
     state: Cas1ApplicationSeedService.ApplicationState,
   ) {
-    seedLogger.info("Creating application with state $state for CRN X320741")
+    seedLogger.info("Creating application with state $state for CRN $crn")
     try {
       cas1ApplicationSeedService.createApplication(
         deliusUserName = deliusUserName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -41,7 +41,7 @@ class PlacementRequestTransformer(
     risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn),
     applicationId = jpa.application.id,
     assessmentId = jpa.assessment.id,
-    releaseType = jpa.application.releaseType!!.apiType,
+    releaseType = jpa.placementApplication?.releaseType?.apiType ?: jpa.application.releaseType!!.apiType,
     status = getStatus(jpa),
     assessmentDecision = assessmentTransformer.transformJpaDecisionToApi(jpa.assessment.decision)!!,
     assessmentDate = jpa.assessment.submittedAt?.toInstant()!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -76,7 +77,7 @@ class PlacementRequestTransformerTest {
   private val assessmentSubmittedAt = OffsetDateTime.now().minusDays(3)
 
   private val application = ApprovedPremisesApplicationEntityFactory()
-    .withReleaseType(Cas1ReleaseType.licence)
+    .withReleaseType(Cas1ReleaseType.reReleasedPostRecall)
     .withCreatedByUser(user)
     .withSubmittedAt(applicationSubmittedAt)
     .produce()
@@ -108,6 +109,7 @@ class PlacementRequestTransformerTest {
 
   private val placementRequestFactory = PlacementRequestEntityFactory()
     .withApplication(application)
+    .withPlacementApplication(PlacementApplicationEntityFactory().withDefaults().withReleaseType(Cas1ReleaseType.licence).produce())
     .withAssessment(assessment)
 
   private val mockRisks = mockk<PersonRisks>()
@@ -279,42 +281,35 @@ class PlacementRequestTransformerTest {
 
     @ParameterizedTest
     @EnumSource(value = ReleaseTypeOption::class)
-    fun `release types are transformed correctly`(releaseTypeOption: ReleaseTypeOption) {
-      val placementRequirementsEntity = placementRequirementsFactory
-        .withEssentialCriteria(
-          listOf(
-            CharacteristicEntityFactory().withPropertyName("isSemiSpecialistMentalHealth").produce(),
-            CharacteristicEntityFactory().withPropertyName("isRecoveryFocussed").produce(),
-            CharacteristicEntityFactory().withPropertyName("someOtherPropertyName").produce(),
-          ),
-        )
-        .withDesirableCriteria(
-          listOf(
-            CharacteristicEntityFactory().withPropertyName("isWheelchairDesignated").produce(),
-            CharacteristicEntityFactory().withPropertyName("isSingle").produce(),
-            CharacteristicEntityFactory().withPropertyName("hasEnSuite").produce(),
-            CharacteristicEntityFactory().withPropertyName("somethingElse").produce(),
-          ),
-        )
-        .produce()
+    fun `release types are transformed correctly from placement application, if defined`(releaseTypeOption: ReleaseTypeOption) {
+      application.releaseType = null
 
       val placementRequestEntity = placementRequestFactory
-        .withPlacementRequirements(placementRequirementsEntity)
-        .withNotes("Some notes")
+        .withPlacementApplication(
+          PlacementApplicationEntityFactory().withDefaults()
+            .withReleaseType(releaseTypeOption.toJpaType())
+            .produce(),
+        )
+        .withPlacementRequirements(placementRequirementsFactory.produce())
         .produce()
 
-      application.releaseType = when (releaseTypeOption) {
-        ReleaseTypeOption.licence -> Cas1ReleaseType.licence
-        ReleaseTypeOption.rotl -> Cas1ReleaseType.rotl
-        ReleaseTypeOption.hdc -> Cas1ReleaseType.hdc
-        ReleaseTypeOption.pss -> Cas1ReleaseType.pss
-        ReleaseTypeOption.inCommunity -> Cas1ReleaseType.inCommunity
-        ReleaseTypeOption.notApplicable -> Cas1ReleaseType.notApplicable
-        ReleaseTypeOption.extendedDeterminateLicence -> Cas1ReleaseType.extendedDeterminateLicence
-        ReleaseTypeOption.paroleDirectedLicence -> Cas1ReleaseType.paroleDirectedLicence
-        ReleaseTypeOption.reReleasedPostRecall -> Cas1ReleaseType.reReleasedPostRecall
-        ReleaseTypeOption.reReleasedFollowingFixedTermRecall -> Cas1ReleaseType.reReleasedFollowingFixedTermRecall
-      }
+      val result = placementRequestTransformer.transformJpaToApi(
+        placementRequestEntity,
+        PersonInfoResult.Success.Full(offenderDetailSummary.otherIds.crn, offenderDetailSummary, inmateDetail),
+      )
+
+      assertThat(result.releaseType).isEqualTo(releaseTypeOption)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ReleaseTypeOption::class)
+    fun `release types are transformed correctly from application, when no placement application is defined`(releaseTypeOption: ReleaseTypeOption) {
+      application.releaseType = releaseTypeOption.toJpaType()
+
+      val placementRequestEntity = placementRequestFactory
+        .withPlacementApplication(null)
+        .withPlacementRequirements(placementRequirementsFactory.produce())
+        .produce()
 
       val result = placementRequestTransformer.transformJpaToApi(
         placementRequestEntity,
@@ -385,5 +380,18 @@ class PlacementRequestTransformerTest {
         ),
       )
     }
+  }
+
+  fun ReleaseTypeOption.toJpaType() = when (this) {
+    ReleaseTypeOption.licence -> Cas1ReleaseType.licence
+    ReleaseTypeOption.rotl -> Cas1ReleaseType.rotl
+    ReleaseTypeOption.hdc -> Cas1ReleaseType.hdc
+    ReleaseTypeOption.pss -> Cas1ReleaseType.pss
+    ReleaseTypeOption.inCommunity -> Cas1ReleaseType.inCommunity
+    ReleaseTypeOption.notApplicable -> Cas1ReleaseType.notApplicable
+    ReleaseTypeOption.extendedDeterminateLicence -> Cas1ReleaseType.extendedDeterminateLicence
+    ReleaseTypeOption.paroleDirectedLicence -> Cas1ReleaseType.paroleDirectedLicence
+    ReleaseTypeOption.reReleasedPostRecall -> Cas1ReleaseType.reReleasedPostRecall
+    ReleaseTypeOption.reReleasedFollowingFixedTermRecall -> Cas1ReleaseType.reReleasedFollowingFixedTermRecall
   }
 }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/FM-586

Before this commit the value of `PlacementRequest.releaseType` was always derived from the corresponding applicaton. This meant that if the release type was modified for a subsequent request for placement, the wrong type would be returned.

This commit changes that logic to source the release type from the corresponding placement application, falling back to the application’s release type if a placement application doesn’t exist

I test this locally, screenshots are on the ticket