### PR TITLE
FM-665 Adds additional mapping for /cas2-hdc/

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationsController.kt
@@ -77,7 +77,7 @@ class Cas2ApplicationsController(
     val application = extractEntityFromCasResult(applicationResult)
 
     return ResponseEntity
-      .created(URI.create("/cas2/applications/${application.id}"))
+      .created(URI.create("/cas2-hdc/applications/${application.id}"))
       .body(cas2ApplicationsTransformer.transformJpaToApi(application, personInfo))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
@@ -113,7 +113,7 @@ class Cas2AssessmentsController(
     val note = processValidation(validationResult) as Cas2ApplicationNoteEntity
 
     return ResponseEntity
-      .created(URI.create("/cas2/assessments/$assessmentId/notes/${note.id}"))
+      .created(URI.create("/cas2-hdc/assessments/$assessmentId/notes/${note.id}"))
       .body(
         applicationNotesTransformer.transformJpaToApi(note),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2Controller.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2Controller.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 @Retention(AnnotationRetention.RUNTIME)
 @RestController
 @RequestMapping(
-  "\${api.base-path:}/cas2",
+  value = ["\${api.base-path:}/cas2", "\${api.base-path:}/cas2-hdc"],
   produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
 )
 @Parameter(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.generateXlsxS
 
 @RestController
 @RequestMapping(
-  "\${api.base-path:}/cas2",
+  value = ["\${api.base-path:}/cas2", "\${api.base-path:}/cas2-hdc"],
   produces = ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
 )
 class Cas2ReportsController(private val reportService: Cas2ReportsService) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 @Retention(AnnotationRetention.RUNTIME)
 @RestController
 @RequestMapping(
-  "\${api.base-path:}/cas2/external",
+  value = ["\${api.base-path:}/cas2/external", "\${api.base-path:}/cas2-hdc/external"],
   produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
 )
 internal annotation class Cas2ExternalController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -65,6 +65,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.DELETE, "/cache/*", permitAll)
         authorize(HttpMethod.POST, "/migration-job", permitAll)
         authorize(HttpMethod.GET, "/events/cas2/**", hasAuthority("ROLE_CAS2_EVENTS"))
+        authorize(HttpMethod.GET, "/events/cas2-hdc/**", hasAuthority("ROLE_CAS2_EVENTS"))
         authorize(HttpMethod.GET, "/events/**", hasAuthority("ROLE_APPROVED_PREMISES_EVENTS"))
 
         authorize(HttpMethod.GET, "/cas2/external/**", hasRole("APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE"))
@@ -77,6 +78,17 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM", "CAS2_COURT_BAIL_REFERRER", "CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2/reports/**", hasRole("CAS2_MI"))
         authorize("/cas2/**", hasAnyAuthority("ROLE_POM", "ROLE_LICENCE_CA", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+
+        authorize(HttpMethod.GET, "/cas2-hdc/external/**", hasRole("APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE"))
+        authorize(HttpMethod.PUT, "/cas2-hdc/assessments/**", hasRole("CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2-hdc/assessments/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN", "CAS2_COURT_BAIL_REFERRER", "CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.POST, "/cas2-hdc/assessments/*/status-updates", hasRole("CAS2_ASSESSOR"))
+        authorize(HttpMethod.POST, "/cas2-hdc/assessments/*/notes", hasAnyRole("LICENCE_CA", "POM", "CAS2_ASSESSOR", "CAS2_COURT_BAIL_REFERRER", "CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.GET, "/cas2-hdc/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
+        authorize(HttpMethod.POST, "/cas2-hdc/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2-hdc/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM", "CAS2_COURT_BAIL_REFERRER", "CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.GET, "/cas2-hdc/reports/**", hasRole("CAS2_MI"))
+        authorize("/cas2-hdc/**", hasAnyAuthority("ROLE_POM", "ROLE_LICENCE_CA", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
 
         authorize(HttpMethod.PUT, "/cas2v2/assessments/**", hasAuthority("ROLE_CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2v2/assessments/**", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_ADMIN", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -83,7 +83,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas2(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2")
     .displayName("CAS2")
-    .pathsToMatch("/**/cas2/**")
+    .pathsToMatch("/**/cas2/**", "/**/cas2-hdc/**")
     .pathsToExclude("/**/events/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
@@ -119,6 +119,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     .pathsToMatch("/**/events/cas3/**")
     .build()
 
+  @SuppressWarnings("CyclomaticComplexMethod")
   @Bean
   fun openApiCustomizer() = OpenApiCustomizer { openApi: OpenAPI ->
     openApi.paths.values.forEach { pathItem ->
@@ -143,6 +144,8 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
           "cas2v2-"
         } else if (path.startsWith("/cas3/")) {
           "cas3-"
+        } else if (path.startsWith("/cas2-hdc/")) {
+          "cas2-hdc-"
         } else {
           ""
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationAbandonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationAbandonTest.kt
@@ -65,7 +65,7 @@ class Cas2ApplicationAbandonTest : IntegrationTestBase() {
       )
 
       webTestClient.put()
-        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd/abandon")
+        .uri("/cas2-hdc/applications/66911cf0-75b1-4361-84bd-501b176fd4fd/abandon")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -78,7 +78,7 @@ class Cas2ApplicationAbandonTest : IntegrationTestBase() {
     @Test
     fun `Abandon application without JWT returns 401`() {
       webTestClient.put()
-        .uri("/cas2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6/abandon")
+        .uri("/cas2-hdc/applications/9b785e59-b85c-4be0-b271-d9ac287684b6/abandon")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -97,7 +97,7 @@ class Cas2ApplicationAbandonTest : IntegrationTestBase() {
             val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
 
             webTestClient.put()
-              .uri("/cas2/applications/${application.id}/abandon")
+              .uri("/cas2-hdc/applications/${application.id}/abandon")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -118,7 +118,7 @@ class Cas2ApplicationAbandonTest : IntegrationTestBase() {
             val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
 
             webTestClient.put()
-              .uri("/cas2/applications/${application.id}/abandon")
+              .uri("/cas2-hdc/applications/${application.id}/abandon")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ApplicationTest.kt
@@ -103,7 +103,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.post()
-        .uri("/cas2/applications")
+        .uri("/cas2-hdc/applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -120,7 +120,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.put()
-        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd")
+        .uri("/cas2-hdc/applications/66911cf0-75b1-4361-84bd-501b176fd4fd")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -136,7 +136,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/applications")
+        .uri("/cas2-hdc/applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -152,7 +152,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4")
+        .uri("/cas2-hdc/applications/66911cf0-75b1-4361-84bd-501b176fd4")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -165,7 +165,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Get all applications without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2/applications")
+        .uri("/cas2-hdc/applications")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -174,7 +174,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Get single application without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6")
+        .uri("/cas2-hdc/applications/9b785e59-b85c-4be0-b271-d9ac287684b6")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -183,7 +183,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Create new application without JWT returns 401`() {
       webTestClient.post()
-        .uri("/cas2/applications")
+        .uri("/cas2-hdc/applications")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -291,7 +291,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     }
 
     fun doRequestAndGetResponse(assignmentType: AssignmentType, jwt: String): List<Cas2ApplicationSummary> = webTestClient.get()
-      .uri("/cas2/applications?assignmentType=${assignmentType.name}")
+      .uri("/cas2-hdc/applications?assignmentType=${assignmentType.name}")
       .header("Authorization", "Bearer $jwt")
       .header("X-Service-Name", ServiceName.cas2.value)
       .exchange()
@@ -464,7 +464,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             cas2ApplicationRepository.saveAndFlush(unallocatedApplication)
 
             val responseBody = webTestClient.get()
-              .uri("/cas2/applications?assignmentType=${assignmentType.value}")
+              .uri("/cas2-hdc/applications?assignmentType=${assignmentType.value}")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .exchange()
@@ -624,7 +624,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           }
 
           val responseBody = webTestClient.get()
-            .uri("/cas2/applications?assignmentType=${assignmentType.value}")
+            .uri("/cas2-hdc/applications?assignmentType=${assignmentType.value}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .exchange()
@@ -659,7 +659,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             }
 
             val rawResponseBodyPage1 = webTestClient.get()
-              .uri("/cas2/applications?page=1&assignmentType=ALLOCATED")
+              .uri("/cas2-hdc/applications?page=1&assignmentType=ALLOCATED")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .exchange()
@@ -681,7 +681,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             assertThat(isOrderedByCreatedAtDescending(responseBodyPage1)).isTrue()
 
             val rawResponseBodyPage2 = webTestClient.get()
-              .uri("/cas2/applications?page=2&assignmentType=ALLOCATED")
+              .uri("/cas2-hdc/applications?page=2&assignmentType=ALLOCATED")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .exchange()
@@ -713,7 +713,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
 
         produceAndPersistBasicApplication(crn, userEntity)
         webTestClient.get()
-          .uri("/cas2/applications?assignmentType=IN_PROGRESS")
+          .uri("/cas2-hdc/applications?assignmentType=IN_PROGRESS")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -834,7 +834,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               cas2ApplicationRepository.save(otherPrisonApplication)
 
               val responseBody = webTestClient.get()
-                .uri("/cas2/applications?assignmentType=PRISON")
+                .uri("/cas2-hdc/applications?assignmentType=PRISON")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.cas2.value)
                 .exchange()
@@ -927,7 +927,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               addStatusUpdates(userBPrisonAApplicationIds.first(), assessor)
 
               val responseBody = webTestClient.get()
-                .uri("/cas2/applications?assignmentType=PRISON")
+                .uri("/cas2-hdc/applications?assignmentType=PRISON")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.cas2.value)
                 .exchange()
@@ -1023,7 +1023,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               }
 
               val responseBody = webTestClient.get()
-                .uri("/cas2/applications?assignmentType=PRISON")
+                .uri("/cas2-hdc/applications?assignmentType=PRISON")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.cas2.value)
                 .exchange()
@@ -1168,7 +1168,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `returns submitted applications for user when assignmentType is ALLOCATED`() {
       val responseBody = webTestClient.get()
-        .uri("/cas2/applications?assignmentType=ALLOCATED")
+        .uri("/cas2-hdc/applications?assignmentType=ALLOCATED")
         .header("Authorization", "Bearer $jwtForUser")
         .header("X-Service-Name", ServiceName.cas2.value)
         .exchange()
@@ -1189,7 +1189,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `returns submitted applications for user when assignmentType is ALLOCATED and page specified`() {
       val responseBody = webTestClient.get()
-        .uri("/cas2/applications?assignmentType=ALLOCATED&page=1")
+        .uri("/cas2-hdc/applications?assignmentType=ALLOCATED&page=1")
         .header("Authorization", "Bearer $jwtForUser")
         .header("X-Service-Name", ServiceName.cas2.value)
         .exchange()
@@ -1224,7 +1224,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             }
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2/applications/${applicationEntity.id}")
+              .uri("/cas2-hdc/applications/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -1267,7 +1267,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             loadPreemptiveCacheForInmateDetails(offenderDetails.otherIds.nomsNumber!!)
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2/applications/${application.id}")
+              .uri("/cas2-hdc/applications/${application.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -1306,7 +1306,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               setUpSubmittedApplicationWithTimeline(offenderDetails, userEntity, prisonName, omuEmail)
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2/applications/${applicationEntity.id}")
+              .uri("/cas2-hdc/applications/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -1354,7 +1354,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               cas2ApplicationRepository.save(applicationEntity)
 
               val rawResponseBody = webTestClient.get()
-                .uri("/cas2/applications/${applicationEntity.id}")
+                .uri("/cas2-hdc/applications/${applicationEntity.id}")
                 .header("Authorization", "Bearer $otherJwt")
                 .exchange()
                 .expectStatus()
@@ -1409,7 +1409,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               cas2ApplicationRepository.save(applicationEntity)
 
               webTestClient.get()
-                .uri("/cas2/applications/${applicationEntity.id}")
+                .uri("/cas2-hdc/applications/${applicationEntity.id}")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -1444,7 +1444,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               }
 
               webTestClient.get()
-                .uri("/cas2/applications/${applicationEntity.id}")
+                .uri("/cas2-hdc/applications/${applicationEntity.id}")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -1477,7 +1477,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               }
 
               val rawResponseBody = webTestClient.get()
-                .uri("/cas2/applications/${applicationEntity.id}")
+                .uri("/cas2-hdc/applications/${applicationEntity.id}")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -1515,7 +1515,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               }
 
               webTestClient.get()
-                .uri("/cas2/applications/${applicationEntity.id}")
+                .uri("/cas2-hdc/applications/${applicationEntity.id}")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -1540,7 +1540,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             // BAIL-WIP we are passing in ApplicationOrigin.prisonBail BUT WE KNOW that we have not implemented
             // in the cas2 application service this to be set so it will default to homeDetentionCurfew/
             val result = webTestClient.post()
-              .uri("/cas2/applications")
+              .uri("/cas2-hdc/applications")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .bodyValue(
@@ -1555,7 +1555,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .returnResult(Cas2Application::class.java)
 
             assertThat(result.responseHeaders["Location"]).anyMatch {
-              it.matches(Regex("/cas2/applications/.+"))
+              it.matches(Regex("/cas2-hdc/applications/.+"))
             }
 
             assertThat(result.responseBody.blockFirst()!!).matches {
@@ -1576,7 +1576,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           givenAnOffender { offenderDetails, _ ->
 
             val result = webTestClient.post()
-              .uri("/cas2/applications")
+              .uri("/cas2-hdc/applications")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .bodyValue(
@@ -1590,7 +1590,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .returnResult(Cas2Application::class.java)
 
             assertThat(result.responseHeaders["Location"]).anyMatch {
-              it.matches(Regex("/cas2/applications/.+"))
+              it.matches(Regex("/cas2-hdc/applications/.+"))
             }
 
             val returnedApplication = result.responseBody.blockFirst()!!
@@ -1610,7 +1610,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           val crn = "X1234"
 
           webTestClient.post()
-            .uri("/cas2/applications")
+            .uri("/cas2-hdc/applications")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewApplication(
@@ -1643,7 +1643,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           mockInmateDetailPrisonsApiCall(InmateDetail(caseDetail.nomsId!!, InmateStatus.IN, null, bookingId = null))
 
           webTestClient.post()
-            .uri("/cas2/applications")
+            .uri("/cas2-hdc/applications")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewApplication(
@@ -1667,7 +1667,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           givenAnOffender { offenderDetails, _ ->
 
             val result = webTestClient.post()
-              .uri("/cas2/applications")
+              .uri("/cas2-hdc/applications")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .bodyValue(
@@ -1681,7 +1681,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .returnResult(Cas2Application::class.java)
 
             assertThat(result.responseHeaders["Location"]).anyMatch {
-              it.matches(Regex("/cas2/applications/.+"))
+              it.matches(Regex("/cas2-hdc/applications/.+"))
             }
 
             assertThat(result.responseBody.blockFirst()!!).matches {
@@ -1697,7 +1697,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
           val crn = "X1234"
 
           webTestClient.post()
-            .uri("/cas2/applications")
+            .uri("/cas2-hdc/applications")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               NewApplication(
@@ -1732,7 +1732,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             }
 
             val resultBody = webTestClient.put()
-              .uri("/cas2/applications/$applicationId")
+              .uri("/cas2-hdc/applications/$applicationId")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
                 UpdateCas2Application(
@@ -1772,7 +1772,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             }
 
             val resultBody = webTestClient.put()
-              .uri("/cas2/applications/$applicationId")
+              .uri("/cas2-hdc/applications/$applicationId")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
                 UpdateCas2Application(
@@ -1810,7 +1810,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
             }
 
             val resultBody = webTestClient.put()
-              .uri("/cas2/applications/$applicationId")
+              .uri("/cas2-hdc/applications/$applicationId")
               .header("Authorization", "Bearer $jwt")
               .bodyValue(
                 UpdateCas2Application(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2AssessmentNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2AssessmentNotesTest.kt
@@ -56,7 +56,7 @@ class Cas2AssessmentNotesTest(
     @Test
     fun `creating a note without JWT returns 401`() {
       webTestClient.post()
-        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -74,7 +74,7 @@ class Cas2AssessmentNotesTest(
       )
 
       webTestClient.post()
-        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
+        .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/notes")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -104,7 +104,7 @@ class Cas2AssessmentNotesTest(
           Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
           val rawResponseBody = webTestClient.post()
-            .uri("/cas2/assessments/${assessment.id}/notes")
+            .uri("/cas2-hdc/assessments/${assessment.id}/notes")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .bodyValue(
@@ -176,7 +176,7 @@ class Cas2AssessmentNotesTest(
               Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
               val rawResponseBody = webTestClient.post()
-                .uri("/cas2/assessments/${assessment.id}/notes")
+                .uri("/cas2-hdc/assessments/${assessment.id}/notes")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.cas2.value)
                 .bodyValue(
@@ -244,7 +244,7 @@ class Cas2AssessmentNotesTest(
                 Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
                 webTestClient.post()
-                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .uri("/cas2-hdc/assessments/${assessment.id}/notes")
                   .header("Authorization", "Bearer $jwt")
                   .header("X-Service-Name", ServiceName.cas2.value)
                   .bodyValue(
@@ -289,7 +289,7 @@ class Cas2AssessmentNotesTest(
                 Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
                 val rawResponseBody = webTestClient.post()
-                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .uri("/cas2-hdc/assessments/${assessment.id}/notes")
                   .header("Authorization", "Bearer $jwt")
                   .header("X-Service-Name", ServiceName.cas2.value)
                   .bodyValue(
@@ -358,7 +358,7 @@ class Cas2AssessmentNotesTest(
               Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
               val rawResponseBody = webTestClient.post()
-                .uri("/cas2/assessments/${assessment.id}/notes")
+                .uri("/cas2-hdc/assessments/${assessment.id}/notes")
                 .header("Authorization", "Bearer $jwt")
                 .header("X-Service-Name", ServiceName.cas2.value)
                 .bodyValue(
@@ -426,7 +426,7 @@ class Cas2AssessmentNotesTest(
                 Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
                 webTestClient.post()
-                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .uri("/cas2-hdc/assessments/${assessment.id}/notes")
                   .header("Authorization", "Bearer $jwt")
                   .header("X-Service-Name", ServiceName.cas2.value)
                   .bodyValue(
@@ -471,7 +471,7 @@ class Cas2AssessmentNotesTest(
                 Assertions.assertThat(realNotesRepository.count()).isEqualTo(0)
 
                 val rawResponseBody = webTestClient.post()
-                  .uri("/cas2/assessments/${assessment.id}/notes")
+                  .uri("/cas2-hdc/assessments/${assessment.id}/notes")
                   .header("Authorization", "Bearer $jwt")
                   .header("X-Service-Name", ServiceName.cas2.value)
                   .bodyValue(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2AssessmentTest.kt
@@ -41,7 +41,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
       @Test
       fun `updating an assessment without JWT returns 401`() {
         webTestClient.put()
-          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+          .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
           .exchange()
           .expectStatus()
           .isUnauthorized
@@ -59,7 +59,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.put()
-          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+          .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -78,7 +78,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.put()
-          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+          .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -105,7 +105,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
           val updatedAssessorName = "Anne Assessor"
 
           val rawResponseBody = webTestClient.put()
-            .uri("/cas2/assessments/${assessment.id}")
+            .uri("/cas2-hdc/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .bodyValue(
@@ -144,7 +144,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
       @Test
       fun `getting an assessment without JWT returns 401`() {
         webTestClient.get()
-          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+          .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
           .exchange()
           .expectStatus()
           .isUnauthorized
@@ -162,7 +162,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+          .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -181,7 +181,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
+          .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -205,7 +205,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/cas2/assessments/${assessment.id}")
+            .uri("/cas2-hdc/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .exchange()
@@ -240,7 +240,7 @@ class Cas2AssessmentTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/cas2/assessments/${assessment.id}")
+            .uri("/cas2-hdc/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
@@ -20,7 +20,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
   @Test
   fun `Getting Risk to Self by CRN without a JWT returns 401`() {
     webTestClient.get()
-      .uri("/cas2/people/CRN/oasys/risk-to-self")
+      .uri("/cas2-hdc/people/CRN/oasys/risk-to-self")
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -34,7 +34,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
     )
 
     webTestClient.get()
-      .uri("/cas2/people/CRN/oasys/risk-to-self")
+      .uri("/cas2-hdc/people/CRN/oasys/risk-to-self")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -50,7 +50,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
     )
 
     webTestClient.get()
-      .uri("/cas2/people/CRN/oasys/risk-to-self")
+      .uri("/cas2-hdc/people/CRN/oasys/risk-to-self")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -65,7 +65,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
       apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
 
       webTestClient.get()
-        .uri("/cas2/people/$crn/oasys/risk-to-self")
+        .uri("/cas2-hdc/people/$crn/oasys/risk-to-self")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -84,7 +84,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
         apAndOASysMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
 
         webTestClient.get()
-          .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
+          .uri("/cas2-hdc/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -109,7 +109,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
         apAndOASysMockUnsuccessfulRisksToTheIndividualCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
-          .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
+          .uri("/cas2-hdc/people/${offenderDetails.otherIds.crn}/oasys/risk-to-self")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRoshTest.kt
@@ -20,7 +20,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
   @Test
   fun `Getting RoSH by CRN without a JWT returns 401`() {
     webTestClient.get()
-      .uri("/cas2/people/CRN/oasys/rosh")
+      .uri("/cas2-hdc/people/CRN/oasys/rosh")
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -34,7 +34,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
     )
 
     webTestClient.get()
-      .uri("/cas2/people/CRN/oasys/rosh")
+      .uri("/cas2-hdc/people/CRN/oasys/rosh")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -50,7 +50,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
     )
 
     webTestClient.get()
-      .uri("/cas2/people/CRN/oasys/rosh")
+      .uri("/cas2-hdc/people/CRN/oasys/rosh")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -65,7 +65,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
       apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
 
       webTestClient.get()
-        .uri("/cas2/people/$crn/oasys/rosh")
+        .uri("/cas2-hdc/people/$crn/oasys/rosh")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -84,7 +84,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
         apAndOASysMockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, rosh)
 
         webTestClient.get()
-          .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/rosh")
+          .uri("/cas2-hdc/people/${offenderDetails.otherIds.crn}/oasys/rosh")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -109,7 +109,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
         apAndOASysMockUnsuccessfulRoshCallWithDelay(offenderDetails.otherIds.crn, 2500)
 
         webTestClient.get()
-          .uri("/cas2/people/${offenderDetails.otherIds.crn}/oasys/rosh")
+          .uri("/cas2-hdc/people/${offenderDetails.otherIds.crn}/oasys/rosh")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonRisksTest.kt
@@ -22,7 +22,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
   @Test
   fun `Getting risks by CRN without a JWT returns 401`() {
     webTestClient.get()
-      .uri("/cas2/people/CRN/risks")
+      .uri("/cas2-hdc/people/CRN/risks")
       .exchange()
       .expectStatus()
       .isUnauthorized
@@ -36,7 +36,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
     )
 
     webTestClient.get()
-      .uri("/cas2/people/CRN/risks")
+      .uri("/cas2-hdc/people/CRN/risks")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -52,7 +52,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
     )
 
     webTestClient.get()
-      .uri("/cas2/people/CRN/risks")
+      .uri("/cas2-hdc/people/CRN/risks")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -67,7 +67,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
       apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
 
       webTestClient.get()
-        .uri("/cas2/people/$crn/risks")
+        .uri("/cas2-hdc/people/$crn/risks")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -92,7 +92,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2/people/${offenderDetails.otherIds.crn}/risks")
+          .uri("/cas2-hdc/people/${offenderDetails.otherIds.crn}/risks")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonSearchTest.kt
@@ -27,7 +27,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
       @Test
       fun `Searching by NOMIS ID without a JWT returns 401`() {
         webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=nomsNumber").exchange()
+          .uri("/cas2-hdc/people/search?nomsNumber=nomsNumber").exchange()
           .expectStatus()
           .isUnauthorized
       }
@@ -40,7 +40,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=nomsNumber")
+          .uri("/cas2-hdc/people/search?nomsNumber=nomsNumber")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -56,7 +56,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2/people/search?nomsNumber=nomsNumber")
+          .uri("/cas2-hdc/people/search?nomsNumber=nomsNumber")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -69,7 +69,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
           apDeliusContextMockUnsuccessfulCaseSummaryCall(403)
 
           webTestClient.get()
-            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -110,7 +110,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
           prisonAPIMockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
 
           webTestClient.get()
-            .uri("/cas2/people/search?nomsNumber=NOMS456")
+            .uri("/cas2-hdc/people/search?nomsNumber=NOMS456")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -124,7 +124,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
           apDeliusContextMockUnsuccessfulCaseSummaryCall(404)
 
           webTestClient.get()
-            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -138,7 +138,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
           apDeliusContextMockUnsuccessfulCaseSummaryCall()
 
           webTestClient.get()
-            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -181,7 +181,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
           prisonAPIMockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
 
           webTestClient.get()
-            .uri("/cas2/people/search?nomsNumber=NOMS321")
+            .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ReferenceDataTest.kt
@@ -23,7 +23,7 @@ class Cas2ReferenceDataTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt()
 
     webTestClient.get()
-      .uri("/cas2/reference-data/application-status")
+      .uri("/cas2-hdc/reference-data/application-status")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2ReportsTest.kt
@@ -51,7 +51,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/${reportName.value}")
+        .uri("/cas2-hdc/reports/${reportName.value}")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -71,7 +71,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
     )
     fun `Downloading report without JWT returns 401`(reportName: String) {
       webTestClient.get()
-        .uri("/cas2/reports/$reportName")
+        .uri("/cas2-hdc/reports/$reportName")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -90,7 +90,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/${reportName.value}")
+        .uri("/cas2-hdc/reports/${reportName.value}")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -297,7 +297,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/submitted-applications")
+        .uri("/cas2-hdc/reports/submitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -550,7 +550,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/application-status-updates")
+        .uri("/cas2-hdc/reports/application-status-updates")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -643,7 +643,7 @@ class Cas2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2/reports/unsubmitted-applications")
+        .uri("/cas2-hdc/reports/unsubmitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2StatusUpdateTest.kt
@@ -56,7 +56,7 @@ class Cas2StatusUpdateTest(
       )
 
       webTestClient.post()
-        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/status-updates")
+        .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/status-updates")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -69,7 +69,7 @@ class Cas2StatusUpdateTest(
     @Test
     fun `creating a status update without JWT returns 401`() {
       webTestClient.post()
-        .uri("/cas2/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/status-updates")
+        .uri("/cas2-hdc/assessments/de6512fc-a225-4109-bdcd-86c6307a5237/status-updates")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -98,7 +98,7 @@ class Cas2StatusUpdateTest(
           assertThat(realStatusUpdateDetailRepository.count()).isEqualTo(0)
 
           webTestClient.post()
-            .uri("/cas2/assessments/$assessmentId/status-updates")
+            .uri("/cas2-hdc/assessments/$assessmentId/status-updates")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas2AssessmentStatusUpdate(newStatus = "moreInfoRequested"),
@@ -136,7 +136,7 @@ class Cas2StatusUpdateTest(
     fun `Create status update returns 404 when assessment not found`() {
       givenACas2Assessor { _, jwt ->
         webTestClient.post()
-          .uri("/cas2/assessments/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
+          .uri("/cas2-hdc/assessments/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             Cas2AssessmentStatusUpdate(newStatus = "moreInfoRequested"),
@@ -161,7 +161,7 @@ class Cas2StatusUpdateTest(
           }
 
           webTestClient.post()
-            .uri("/cas2/assessments/${assessmemt.id}/status-updates")
+            .uri("/cas2-hdc/assessments/${assessmemt.id}/status-updates")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas2AssessmentStatusUpdate(newStatus = "invalidStatus"),
@@ -203,7 +203,7 @@ class Cas2StatusUpdateTest(
               every { OffsetDateTime.now() } returns now
 
               webTestClient.post()
-                .uri("/cas2/assessments/$assessmentId/status-updates")
+                .uri("/cas2-hdc/assessments/$assessmentId/status-updates")
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   Cas2AssessmentStatusUpdate(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2SubmissionTest.kt
@@ -109,7 +109,7 @@ class Cas2SubmissionTest(
       )
 
       webTestClient.post()
-        .uri("/cas2/submissions?applicationId=de6512fc-a225-4109-bdcd-86c6307a5237")
+        .uri("/cas2-hdc/submissions?applicationId=de6512fc-a225-4109-bdcd-86c6307a5237")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -125,7 +125,7 @@ class Cas2SubmissionTest(
       )
 
       webTestClient.get()
-        .uri("/cas2/submissions")
+        .uri("/cas2-hdc/submissions")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -141,7 +141,7 @@ class Cas2SubmissionTest(
       )
 
       webTestClient.get()
-        .uri("/cas2/submissions/66911cf0-75b1-4361-84bd-501b176fd4fd")
+        .uri("/cas2-hdc/submissions/66911cf0-75b1-4361-84bd-501b176fd4fd")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -154,7 +154,7 @@ class Cas2SubmissionTest(
     @Test
     fun `Get all submitted applications without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2/submissions")
+        .uri("/cas2-hdc/submissions")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -163,7 +163,7 @@ class Cas2SubmissionTest(
     @Test
     fun `Get single submitted application without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2/submissions/9b785e59-b85c-4be0-b271-d9ac287684b6")
+        .uri("/cas2-hdc/submissions/9b785e59-b85c-4be0-b271-d9ac287684b6")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -189,7 +189,7 @@ class Cas2SubmissionTest(
       val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt(username)
 
       webTestClient.get()
-        .uri("/cas2/submissions")
+        .uri("/cas2-hdc/submissions")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -242,7 +242,7 @@ class Cas2SubmissionTest(
               }
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2/submissions?page=1")
+              .uri("/cas2-hdc/submissions?page=1")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .exchange()
@@ -347,7 +347,7 @@ class Cas2SubmissionTest(
       val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt(username)
 
       webTestClient.get()
-        .uri("/cas2/submissions/fea7986d-cae6-4a7a-8420-5b31376ce787")
+        .uri("/cas2-hdc/submissions/fea7986d-cae6-4a7a-8420-5b31376ce787")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -469,7 +469,7 @@ class Cas2SubmissionTest(
             }
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2/submissions/${applicationEntity.id}")
+              .uri("/cas2-hdc/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -546,7 +546,7 @@ class Cas2SubmissionTest(
             )
 
             webTestClient.get()
-              .uri("/cas2/submissions/${applicationEntity.id}")
+              .uri("/cas2-hdc/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -634,7 +634,7 @@ class Cas2SubmissionTest(
                 realApplicationRepository.save(applicationEntity)
 
                 val rawResponseBody = webTestClient.get()
-                  .uri("/cas2/submissions/${applicationEntity.id}")
+                  .uri("/cas2-hdc/submissions/${applicationEntity.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -692,7 +692,7 @@ class Cas2SubmissionTest(
               )
 
               webTestClient.get()
-                .uri("/cas2/submissions/${applicationEntity.id}")
+                .uri("/cas2-hdc/submissions/${applicationEntity.id}")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -743,7 +743,7 @@ class Cas2SubmissionTest(
           assertThat(realAssessmentRepository.count()).isEqualTo(0)
 
           webTestClient.post()
-            .uri("/cas2/submissions")
+            .uri("/cas2-hdc/submissions")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .bodyValue(
@@ -836,7 +836,7 @@ class Cas2SubmissionTest(
           (1..10).map {
             val thread = Thread {
               webTestClient.post()
-                .uri("/cas2/submissions")
+                .uri("/cas2-hdc/submissions")
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   SubmitCas2Application(
@@ -889,7 +889,7 @@ class Cas2SubmissionTest(
           assertThat(realAssessmentRepository.count()).isEqualTo(0)
 
           webTestClient.post()
-            .uri("/cas2/submissions")
+            .uri("/cas2-hdc/submissions")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2.value)
             .bodyValue(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/external/Cas2ExternalReferralHistoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/external/Cas2ExternalReferralHistoryTest.kt
@@ -24,7 +24,7 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
     fun `Get all referrals when user JWT returns 403 Forbidden`() {
       givenACas2PomUser { _, jwt ->
         webTestClient.get()
-          .uri("/cas2/external/referrals/$crn")
+          .uri("/cas2-hdc/external/referrals/$crn")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -35,7 +35,7 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
     @Test
     fun `Get all referrals when no JWT returns 401 Unauthorized`() {
       webTestClient.get()
-        .uri("/cas2/external/referrals/$crn")
+        .uri("/cas2-hdc/external/referrals/$crn")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -125,7 +125,7 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
           )
 
           val response = webTestClient.get()
-            .uri("/cas2/external/referrals/$crn")
+            .uri("/cas2-hdc/external/referrals/$crn")
             .header("Authorization", "Bearer $clientCredentialsJwt")
             .exchange()
             .expectStatus()
@@ -152,7 +152,7 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
           val cancelledApplication = createApplication(user, "Referral cancelled", preferredAreas = "North West", referringPrisonCode = omu.prisonCode)
 
           val response = webTestClient.get()
-            .uri("/cas2/external/referrals/$crn")
+            .uri("/cas2-hdc/external/referrals/$crn")
             .header("Authorization", "Bearer $clientCredentialsJwt")
             .exchange()
             .expectStatus()
@@ -183,7 +183,7 @@ class Cas2ExternalReferralHistoryTest : IntegrationTestBase() {
           val applicationWithPrison = createApplication(user, "Active", referringPrisonCode = omu.prisonCode)
 
           val response = webTestClient.get()
-            .uri("/cas2/external/referrals/$crn")
+            .uri("/cas2-hdc/external/referrals/$crn")
             .header("Authorization", "Bearer $clientCredentialsJwt")
             .exchange()
             .expectStatus()


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-665

Adds additional mapping for `/cas2-hdc/` (whilst leaving existing `/cas2/` mapping)

Adds permisssions to new `/cas2-hdc/` endpoints in line with existing `/cas2/` permissions in `OAuth2ResourceServerSecurityConfiguration.kt`.

Refactors CAS2 endpoint integration tests to use `/cas2-hdc/` to reflect updated URI structure