### PR TITLE
FM-650 Allow Risk & Health OAsys info > 6 months for CAS1

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskManagementPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskManagementPlan.kt
@@ -11,7 +11,7 @@ class RiskManagementPlan(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val riskManagementPlan: RiskManagementPlanInner?,
+  val riskManagementPlan: RiskManagementPlanInner,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskToTheIndividual.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RiskToTheIndividual.kt
@@ -11,7 +11,7 @@ class RisksToTheIndividual(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val riskToTheIndividual: RiskToTheIndividualInner?,
+  val riskToTheIndividual: RiskToTheIndividualInner,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RoshSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/apandoasys/RoshSummary.kt
@@ -11,7 +11,7 @@ class RoshSummary(
   assessmentStatus: String,
   superStatus: String?,
   limitedAccessOffender: Boolean,
-  val roshSummary: RoshSummaryInner?,
+  val roshSummary: RoshSummaryInner,
 ) : AssessmentInfo(
   assessmentId,
   assessmentType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -155,7 +155,6 @@ class Cas1OasysController(
     )
 
     val riskToTheIndividual = risksToTheIndividualWrapper.riskToTheIndividual
-      ?: throw NotFoundProblem(crn, "RiskToTheIndividual")
 
     return ResponseEntity.ok(riskToTheIndividual)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -20,9 +20,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.Health
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserAccessService
@@ -47,11 +47,11 @@ class Cas1OasysController(
 ) {
 
   @Operation(
-    summary = "Returns metadata about supporting information questions for a given CRN",
+    summary = "Returns metadata about supporting information questions for a given CRN,",
     operationId = "metadata",
     responses = [
       ApiResponse(responseCode = "200", description = "successful operation", content = [Content(schema = Schema(implementation = Cas1OASysMetadata::class))]),
-      ApiResponse(responseCode = "404", description = "invalid CRN", content = [Content(schema = Schema(implementation = Problem::class))]),
+      ApiResponse(responseCode = "404", description = "An OASys assessment completed in the last 6 months doesn't exist", content = [Content(schema = Schema(implementation = Problem::class))]),
     ],
   )
   @RequestMapping(
@@ -75,11 +75,12 @@ class Cas1OasysController(
   }
 
   @Operation(
-    summary = "Returns OASys answers for the requested group. The Supporting Information answers are returned if linked to harm and optionally if their section number appears in the selected-sections query parameter.",
+    summary = "Returns OASys answers for the requested group, if the most recent OAsys Assessment was completed in the last 6 months. " +
+      "The Supporting Information answers are returned if linked to harm and optionally if their section number appears in the selected-sections query parameter.",
     operationId = "answers",
     responses = [
       ApiResponse(responseCode = "200", description = "successful operation", content = [Content(schema = Schema(implementation = Cas1OASysGroup::class))]),
-      ApiResponse(responseCode = "404", description = "invalid CRN", content = [Content(schema = Schema(implementation = Problem::class))]),
+      ApiResponse(responseCode = "404", description = "An OASys assessment completed in the last 6 months doesn't exist", content = [Content(schema = Schema(implementation = Problem::class))]),
     ],
   )
   @RequestMapping(
@@ -145,13 +146,22 @@ class Cas1OasysController(
     return ResponseEntity.ok(group)
   }
 
-  @Operation(summary = "Returns OASys risk to the individual for a Person.")
+  @Operation(
+    summary = "Returns OASys risk to the individual for a Person. This will be taken from the most recently completed OASys assessment, regardless of its age",
+    responses = [
+      ApiResponse(responseCode = "200", description = "successful operation", content = [Content(schema = Schema(implementation = Cas1OASysGroup::class))]),
+      ApiResponse(responseCode = "404", description = "A completed OASys assessment doesn't exist", content = [Content(schema = Schema(implementation = Problem::class))]),
+    ],
+  )
   @GetMapping("/people/{crn}/oasys/risks-to-individual")
   fun getOasysRisksToIndividual(@PathVariable crn: String): ResponseEntity<RiskToTheIndividualInner> {
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_AP_RESIDENT_PROFILE)
 
     val risksToTheIndividualWrapper = extractEntityFromCasResult(
-      oaSysService.getRiskToTheIndividual(crn),
+      oaSysService.getRiskToTheIndividual(
+        crn = crn,
+        suitabilityStrategy = OASysSuitabilityService.SuitabilityStrategy.AllowAll,
+      ),
     )
 
     val riskToTheIndividual = risksToTheIndividualWrapper.riskToTheIndividual
@@ -159,13 +169,22 @@ class Cas1OasysController(
     return ResponseEntity.ok(riskToTheIndividual)
   }
 
-  @Operation(summary = "Returns OASys health details for a Person.")
+  @Operation(
+    summary = "Returns OASys health details for a Person. This will be taken from the most recently completed OASys assessment, regardless of its age",
+    responses = [
+      ApiResponse(responseCode = "200", description = "successful operation", content = [Content(schema = Schema(implementation = Cas1OASysGroup::class))]),
+      ApiResponse(responseCode = "404", description = "A completed OASys assessment doesn't exist", content = [Content(schema = Schema(implementation = Problem::class))]),
+    ],
+  )
   @GetMapping("/people/{crn}/oasys/health-details")
   fun getOasysHealthDetails(@PathVariable crn: String): ResponseEntity<HealthDetailsInner> {
     userAccessService.ensureCurrentUserHasPermission(UserPermission.CAS1_AP_RESIDENT_PROFILE)
 
     val healthDetailsWrapper = extractEntityFromCasResult(
-      oaSysService.getHealthDetails(crn),
+      oaSysService.getHealthDetails(
+        crn = crn,
+        suitabilityStrategy = OASysSuitabilityService.SuitabilityStrategy.AllowAll,
+      ),
     )
 
     val healthDetails = healthDetailsWrapper.health

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
@@ -13,15 +13,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskMa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService.SuitabilityStrategy
 
 @Service
 class OASysService(
   private val apAndOASysClient: ApAndOASysClient,
   private val oasysSuitabilityService: OASysSuitabilityService,
 ) {
-  fun getAssessmentSummary(crn: String): CasResult<OASysAssessmentSummary> = handleResponse(
+  fun getAssessmentSummary(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<OASysAssessmentSummary> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getLatestAssessmentSummary(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = {
       OASysSuitabilityService.OASysAssessmentDates(
         crn = crn,
@@ -31,50 +36,79 @@ class OASysService(
     },
   )
 
-  fun getNeedsDetails(crn: String): CasResult<NeedsDetails> = handleResponse(
+  fun getNeedsDetails(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<NeedsDetails> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getNeedsDetails(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = { it.toAssessmentDates(crn) },
   )
 
-  fun getOffenceDetails(crn: String): CasResult<OffenceDetails> = handleResponse(
+  fun getOffenceDetails(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<OffenceDetails> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getOffenceDetails(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = { it.toAssessmentDates(crn) },
   )
 
-  fun getRiskManagementPlan(crn: String): CasResult<RiskManagementPlan> = handleResponse(
+  fun getRiskManagementPlan(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<RiskManagementPlan> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getRiskManagementPlan(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = { it.toAssessmentDates(crn) },
   )
 
-  fun getRoshSummary(crn: String): CasResult<RoshSummary> = handleResponse(
+  fun getRoshSummary(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<RoshSummary> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getRoshSummary(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = { it.toAssessmentDates(crn) },
   )
 
-  fun getRiskToTheIndividual(crn: String): CasResult<RisksToTheIndividual> = handleResponse(
+  fun getRiskToTheIndividual(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<RisksToTheIndividual> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getRiskToTheIndividual(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = { it.toAssessmentDates(crn) },
   )
 
-  fun getHealthDetails(crn: String): CasResult<HealthDetails> = handleResponse(
+  fun getHealthDetails(
+    crn: String,
+    suitabilityStrategy: SuitabilityStrategy = SuitabilityStrategy.CompletedInLastSixMonths,
+  ): CasResult<HealthDetails> = handleResponse(
     crn = crn,
     response = apAndOASysClient.getHealth(crn),
+    suitabilityStrategy = suitabilityStrategy,
     toAssessmentDates = { it.toAssessmentDates(crn) },
   )
 
   private fun <T> handleResponse(
     crn: String,
     response: ClientResult<T>,
+    suitabilityStrategy: SuitabilityStrategy,
     toAssessmentDates: (T) -> OASysSuitabilityService.OASysAssessmentDates,
   ) = when (response) {
     is ClientResult.Success -> {
       val body = response.body
-      if (oasysSuitabilityService.isSuitable(toAssessmentDates(body))) {
+      if (oasysSuitabilityService.isSuitable(
+          assessmentDates = toAssessmentDates(body),
+          strategy = suitabilityStrategy,
+        )
+      ) {
         CasResult.Success(body)
       } else {
         notFound(crn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysSuitabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysSuitabilityService.kt
@@ -9,12 +9,22 @@ class OASysSuitabilityService(
   private val clock: Clock,
   private val sentryService: SentryService,
 ) {
-  fun isSuitable(info: OASysAssessmentDates): Boolean {
+  fun isSuitable(
+    assessmentDates: OASysAssessmentDates,
+    strategy: SuitabilityStrategy,
+  ) = when (strategy) {
+    SuitabilityStrategy.AllowAll -> true
+    SuitabilityStrategy.CompletedInLastSixMonths -> limitToSixMonths(assessmentDates)
+  }
+
+  private fun limitToSixMonths(
+    assessmentDates: OASysAssessmentDates,
+  ): Boolean {
     val sixMonthThreshold = OffsetDateTime.now(clock).minusMonths(6)
 
-    val crn = info.crn
-    val initiationDate = info.initiationDate
-    val dateCompleted = info.dateCompleted
+    val crn = assessmentDates.crn
+    val initiationDate = assessmentDates.initiationDate
+    val dateCompleted = assessmentDates.dateCompleted
 
     val suitable = (dateCompleted ?: initiationDate).isAfter(sixMonthThreshold)
 
@@ -32,4 +42,9 @@ class OASysSuitabilityService(
     val initiationDate: OffsetDateTime,
     val dateCompleted: OffsetDateTime?,
   )
+
+  enum class SuitabilityStrategy {
+    AllowAll,
+    CompletedInLastSixMonths,
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2OAsysSectionsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2PersonOASysRiskToSelfTest.kt
@@ -3,8 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2OAsysSectionsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
@@ -76,7 +75,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
   fun `Getting Risk to Self for a CRN returns OK with correct body`() {
     givenACas2PomUser { _, jwt ->
       givenAnOffender { offenderDetails, _ ->
-        val risksToTheIndividual = RiskToTheIndividualFactory().produce()
+        val risksToTheIndividual = RisksToTheIndividualFactory().produce()
         apAndOASysMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
 
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2OAsysSectionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2OAsysSectionsTransformerTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysAssessmentState
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2OAsysSectionsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 
@@ -36,7 +36,7 @@ class Cas2OAsysSectionsTransformerTest {
       fun `transforms correctly`() {
         every { featureFlagService.getBooleanFlag("cas2-oasys-use-new-questions") } returns false
 
-        val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+        val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
           withCurrentConcernsSelfHarmSuicide("currentConcernsSelfHarmSuicideAnswer")
           withPreviousConcernsSelfHarmSuicide("previousConcernsSelfHarmSuicideAnswer")
           withCurrentVulnerability("currentVulnerabilityAnswer")
@@ -71,7 +71,7 @@ class Cas2OAsysSectionsTransformerTest {
       fun `transforms correctly, no answers`() {
         every { featureFlagService.getBooleanFlag("cas2-oasys-use-new-questions") } returns false
 
-        val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+        val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
           withCurrentConcernsSelfHarmSuicide(null)
           withPreviousConcernsSelfHarmSuicide(null)
           withCurrentVulnerability(null)
@@ -121,7 +121,7 @@ class Cas2OAsysSectionsTransformerTest {
       ) {
         every { featureFlagService.getBooleanFlag("cas2-oasys-use-new-questions") } returns true
 
-        val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+        val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
           withCurrentConcernsSelfHarmSuicide(currentConcernsSelfHarmSuicideAnswer)
           withPreviousConcernsSelfHarmSuicide(previousConcernsSelfHarmSuicideAnswer)
           withCurrentVulnerability("currentVulnerabilityAnswer")
@@ -152,7 +152,7 @@ class Cas2OAsysSectionsTransformerTest {
       fun `transforms correctly, post NOD 1057 assessment`() {
         every { featureFlagService.getBooleanFlag("cas2-oasys-use-new-questions") } returns true
 
-        val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+        val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
           withCurrentConcernsSelfHarmSuicide(null)
           withCurrentVulnerability(null)
           withPreviousConcernsSelfHarmSuicide(null)
@@ -185,7 +185,7 @@ class Cas2OAsysSectionsTransformerTest {
       fun `transforms correctly, no answers`() {
         every { featureFlagService.getBooleanFlag("cas2-oasys-use-new-questions") } returns true
 
-        val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+        val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
           withCurrentConcernsSelfHarmSuicide(null)
           withPreviousConcernsSelfHarmSuicide(null)
           withCurrentVulnerability(null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRiskToSelfDto
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockAssessmentSummaryNotFound
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskToTheIndividual404Call
@@ -122,7 +122,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
     fun `Assessment available`(role: RoleAndAuthSource) {
       apAndOASysMockSuccessfulRiskToTheIndividualCall(
         crn = "CRN123",
-        response = RiskToTheIndividualFactory().produce(),
+        response = RisksToTheIndividualFactory().produce(),
       )
 
       val result = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2OASysTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2OASysTransformerTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2OASysTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -46,7 +46,7 @@ class Cas2v2OASysTransformerTest {
     @Test
     fun found() {
       val result = transformer.toOASysRiskToSelfDto(
-        RiskToTheIndividualFactory()
+        RisksToTheIndividualFactory()
           .withAnalysisSuicideSelfharm("self harm answer")
           .withAnalysisVulnerabilities("vulnerability answer")
           .withInitiationDate(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RisksToTheIndividualFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RisksToTheIndividualFactory.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskTo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 
-class RiskToTheIndividualFactory : AssessmentInfoFactory<RisksToTheIndividual>() {
+class RisksToTheIndividualFactory : AssessmentInfoFactory<RisksToTheIndividual>() {
   private var currentConcernsSelfHarmSuicide: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
   private var previousConcernsSelfHarmSuicide: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }
   private var currentCustodyHostelCoping: Yielded<String?> = { randomStringMultiCaseWithNumbers(20) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
@@ -93,7 +93,7 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
         val roshSummary = RoshSummaryFactory().produce()
         apAndOASysMockSuccessfulRoSHSummaryCall(offenderDetails.otherIds.crn, roshSummary)
 
-        val risksToTheIndividual = RiskToTheIndividualFactory().produce()
+        val risksToTheIndividual = RisksToTheIndividualFactory().produce()
         apAndOASysMockSuccessfulRiskToTheIndividualCall(offenderDetails.otherIds.crn, risksToTheIndividual)
 
         val riskManagementPlan = RiskManagementPlanFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -8,6 +8,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthIssue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.HealthDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
@@ -17,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndivid
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockHealthDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockNeedsDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockOffenceDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskManagementPlan404Call
@@ -32,6 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OAS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+import java.time.OffsetDateTime
 
 class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -443,6 +449,176 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
           answer = "relationship answer",
         ),
       )
+    }
+  }
+
+  @Nested
+  inner class GetRisksToIndividual {
+    @Test
+    fun `Getting OASys risks to individual without a JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas1/people/CRN/oasys/risks-to-individual")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Getting OASys risks to individual returns OK with correct body`() {
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+        val crn = "CRN"
+        val risksToTheIndividual = RisksToTheIndividual(
+          assessmentId = 1,
+          assessmentType = "TYPE",
+          dateCompleted = OffsetDateTime.now(),
+          assessorSignedDate = OffsetDateTime.now(),
+          initiationDate = OffsetDateTime.now(),
+          assessmentStatus = "STATUS",
+          superStatus = "SUPER",
+          limitedAccessOffender = false,
+          riskToTheIndividual = RiskToTheIndividualInner(
+            currentConcernsSelfHarmSuicide = "currentConcernsSelfHarmSuicide",
+            previousConcernsSelfHarmSuicide = "previousConcernsSelfHarmSuicide",
+            currentCustodyHostelCoping = "currentCustodyHostelCoping",
+            previousCustodyHostelCoping = "previousCustodyHostelCoping",
+            currentVulnerability = "currentVulnerability",
+            previousVulnerability = "previousVulnerability",
+            riskOfSeriousHarm = "riskOfSeriousHarm",
+            currentConcernsBreachOfTrustText = "currentConcernsBreachOfTrustText",
+            analysisSuicideSelfharm = "analysisSuicideSelfharm",
+            analysisCoping = "analysisCoping",
+            analysisVulnerabilities = "analysisVulnerabilities",
+          ),
+        )
+
+        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
+
+        webTestClient.get()
+          .uri("/cas1/people/$crn/oasys/risks-to-individual")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            jsonMapper.writeValueAsString(risksToTheIndividual.riskToTheIndividual),
+          )
+      }
+    }
+
+    @Test
+    fun `Getting OASys risks to individual returns 404 when OASys returns 404`() {
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+        val crn = "CRN"
+
+        apAndOASysMockRiskToTheIndividual404Call(crn)
+
+        webTestClient.get()
+          .uri("/cas1/people/$crn/oasys/risks-to-individual")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+
+    @Test
+    fun `Getting OASys risks to individual returns 404 when riskToTheIndividual is null`() {
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+        val crn = "CRN"
+        val risksToTheIndividual = RisksToTheIndividual(
+          assessmentId = 1,
+          assessmentType = "TYPE",
+          dateCompleted = OffsetDateTime.now(),
+          assessorSignedDate = OffsetDateTime.now(),
+          initiationDate = OffsetDateTime.now(),
+          assessmentStatus = "STATUS",
+          superStatus = "SUPER",
+          limitedAccessOffender = false,
+          riskToTheIndividual = null,
+        )
+
+        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
+
+        webTestClient.get()
+          .uri("/cas1/people/$crn/oasys/risks-to-individual")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
+    }
+  }
+
+  @Nested
+  inner class GetHealthDetails {
+    @Test
+    fun `Getting OASys health details without a JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas1/people/CRN/oasys/health-details")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Getting OASys health details returns OK with correct body`() {
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+        val crn = "CRN"
+        val drugsMisuse = HealthIssue(
+          community = "drugs community",
+          electronicMonitoring = "drugs em",
+          programme = "drugs programme",
+        )
+        val alcoholMisuse = HealthIssue(
+          community = "alcohol community",
+          electronicMonitoring = "alcohol em",
+          programme = "alcohol programme",
+        )
+
+        val healthDetails = HealthDetailsFactory()
+          .withGeneralHealth(true, "some health issues")
+          .withDrugsMisuse(drugsMisuse)
+          .withAlcoholMisuse(alcoholMisuse)
+          .produce()
+
+        apAndOASysMockSuccessfulHealthDetailsCall(crn, healthDetails)
+
+        val response = webTestClient.get()
+          .uri("/cas1/people/$crn/oasys/health-details")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody(HealthDetailsInner::class.java)
+          .returnResult()
+          .responseBody!!
+
+        assertThat(response.generalHealth).isEqualTo(healthDetails.health.generalHealth)
+        assertThat(response.generalHealthSpecify).isEqualTo(healthDetails.health.generalHealthSpecify)
+        assertThat(response.drugsMisuse!!.community).isEqualTo(drugsMisuse.community)
+        assertThat(response.drugsMisuse.electronicMonitoring).isEqualTo(drugsMisuse.electronicMonitoring)
+        assertThat(response.drugsMisuse.programme).isEqualTo(drugsMisuse.programme)
+        assertThat(response.alcoholMisuse!!.community).isEqualTo(alcoholMisuse.community)
+        assertThat(response.alcoholMisuse.electronicMonitoring).isEqualTo(alcoholMisuse.electronicMonitoring)
+        assertThat(response.alcoholMisuse.programme).isEqualTo(alcoholMisuse.programme)
+      }
+    }
+
+    @Test
+    fun `Getting OASys health details returns 404 when OASys returns 404`() {
+      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
+        val crn = "CRN"
+
+        apAndOASysMockHealthDetails404Call(crn)
+
+        webTestClient.get()
+          .uri("/cas1/people/$crn/oasys/health-details")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isNotFound
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -4,14 +4,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthIssue
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.HealthDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
@@ -38,7 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OAS
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
-import java.time.OffsetDateTime
 
 class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -456,143 +454,109 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
   @Nested
   inner class GetRisksToIndividual {
     @Test
-    fun `Getting OASys risks to individual without a JWT returns 401`() {
+    fun `Request without a JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas1/people/CRN/oasys/risks-to-individual")
+        .uri("/cas1/people/$CRN/oasys/risks-to-individual")
         .exchange()
         .expectStatus()
         .isUnauthorized
     }
 
     @Test
-    fun `Getting OASys risks to individual returns OK with correct body`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-        val risksToTheIndividual = RisksToTheIndividual(
-          assessmentId = 1,
-          assessmentType = "TYPE",
-          dateCompleted = OffsetDateTime.now(),
-          assessorSignedDate = OffsetDateTime.now(),
-          initiationDate = OffsetDateTime.now(),
-          assessmentStatus = "STATUS",
-          superStatus = "SUPER",
-          limitedAccessOffender = false,
-          riskToTheIndividual = RiskToTheIndividualInner(
-            currentConcernsSelfHarmSuicide = "currentConcernsSelfHarmSuicide",
-            previousConcernsSelfHarmSuicide = "previousConcernsSelfHarmSuicide",
-            currentCustodyHostelCoping = "currentCustodyHostelCoping",
-            previousCustodyHostelCoping = "previousCustodyHostelCoping",
-            currentVulnerability = "currentVulnerability",
-            previousVulnerability = "previousVulnerability",
-            riskOfSeriousHarm = "riskOfSeriousHarm",
-            currentConcernsBreachOfTrustText = "currentConcernsBreachOfTrustText",
-            analysisSuicideSelfharm = "analysisSuicideSelfharm",
-            analysisCoping = "analysisCoping",
-            analysisVulnerabilities = "analysisVulnerabilities",
-          ),
+    fun `Returns OK with correct body`() {
+      val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+      val risksToTheIndividual = RisksToTheIndividualFactory().produce()
+
+      apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, risksToTheIndividual)
+
+      webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/risks-to-individual")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          jsonMapper.writeValueAsString(risksToTheIndividual.riskToTheIndividual),
         )
-
-        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/risks-to-individual")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .json(
-            jsonMapper.writeValueAsString(risksToTheIndividual.riskToTheIndividual),
-          )
-      }
     }
 
     @Test
-    fun `Getting OASys risks to individual returns 404 when OASys returns 404`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
+    fun `Returns 404 when OASys returns 404`() {
+      val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+      apAndOASysMockRiskToTheIndividual404Call(CRN)
 
-        apAndOASysMockRiskToTheIndividual404Call(crn)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/risks-to-individual")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isNotFound
-      }
+      webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/risks-to-individual")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
     }
   }
 
   @Nested
   inner class GetHealthDetails {
     @Test
-    fun `Getting OASys health details without a JWT returns 401`() {
+    fun `Request without a JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas1/people/CRN/oasys/health-details")
+        .uri("/cas1/people/$CRN/oasys/health-details")
         .exchange()
         .expectStatus()
         .isUnauthorized
     }
 
     @Test
-    fun `Getting OASys health details returns OK with correct body`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-        val drugsMisuse = HealthIssue(
-          community = "drugs community",
-          electronicMonitoring = "drugs em",
-          programme = "drugs programme",
-        )
-        val alcoholMisuse = HealthIssue(
-          community = "alcohol community",
-          electronicMonitoring = "alcohol em",
-          programme = "alcohol programme",
-        )
+    fun `Returns OK with correct body`() {
+      val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+      val drugsMisuse = HealthIssue(
+        community = "drugs community",
+        electronicMonitoring = "drugs em",
+        programme = "drugs programme",
+      )
+      val alcoholMisuse = HealthIssue(
+        community = "alcohol community",
+        electronicMonitoring = "alcohol em",
+        programme = "alcohol programme",
+      )
 
-        val healthDetails = HealthDetailsFactory()
-          .withGeneralHealth(true, "some health issues")
-          .withDrugsMisuse(drugsMisuse)
-          .withAlcoholMisuse(alcoholMisuse)
-          .produce()
+      val healthDetails = HealthDetailsFactory()
+        .withGeneralHealth(true, "some health issues")
+        .withDrugsMisuse(drugsMisuse)
+        .withAlcoholMisuse(alcoholMisuse)
+        .produce()
 
-        apAndOASysMockSuccessfulHealthDetailsCall(crn, healthDetails)
+      apAndOASysMockSuccessfulHealthDetailsCall(CRN, healthDetails)
 
-        val response = webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/health-details")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody(HealthDetailsInner::class.java)
-          .returnResult()
-          .responseBody!!
+      val response = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/health-details")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<HealthDetailsInner>()
 
-        assertThat(response.generalHealth).isEqualTo(healthDetails.health.generalHealth)
-        assertThat(response.generalHealthSpecify).isEqualTo(healthDetails.health.generalHealthSpecify)
-        assertThat(response.drugsMisuse!!.community).isEqualTo(drugsMisuse.community)
-        assertThat(response.drugsMisuse.electronicMonitoring).isEqualTo(drugsMisuse.electronicMonitoring)
-        assertThat(response.drugsMisuse.programme).isEqualTo(drugsMisuse.programme)
-        assertThat(response.alcoholMisuse!!.community).isEqualTo(alcoholMisuse.community)
-        assertThat(response.alcoholMisuse.electronicMonitoring).isEqualTo(alcoholMisuse.electronicMonitoring)
-        assertThat(response.alcoholMisuse.programme).isEqualTo(alcoholMisuse.programme)
-      }
+      assertThat(response.generalHealth).isEqualTo(healthDetails.health.generalHealth)
+      assertThat(response.generalHealthSpecify).isEqualTo(healthDetails.health.generalHealthSpecify)
+      assertThat(response.drugsMisuse!!.community).isEqualTo(drugsMisuse.community)
+      assertThat(response.drugsMisuse.electronicMonitoring).isEqualTo(drugsMisuse.electronicMonitoring)
+      assertThat(response.drugsMisuse.programme).isEqualTo(drugsMisuse.programme)
+      assertThat(response.alcoholMisuse!!.community).isEqualTo(alcoholMisuse.community)
+      assertThat(response.alcoholMisuse.electronicMonitoring).isEqualTo(alcoholMisuse.electronicMonitoring)
+      assertThat(response.alcoholMisuse.programme).isEqualTo(alcoholMisuse.programme)
     }
 
     @Test
-    fun `Getting OASys health details returns 404 when OASys returns 404`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
+    fun `Returns 404 when OASys returns 404`() {
+      val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+      apAndOASysMockHealthDetails404Call(CRN)
 
-        apAndOASysMockHealthDetails404Call(crn)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/health-details")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isNotFound
-      }
+      webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/health-details")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -522,33 +522,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
           .isNotFound
       }
     }
-
-    @Test
-    fun `Getting OASys risks to individual returns 404 when riskToTheIndividual is null`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-        val risksToTheIndividual = RisksToTheIndividual(
-          assessmentId = 1,
-          assessmentType = "TYPE",
-          dateCompleted = OffsetDateTime.now(),
-          assessorSignedDate = OffsetDateTime.now(),
-          initiationDate = OffsetDateTime.now(),
-          assessmentStatus = "STATUS",
-          superStatus = "SUPER",
-          limitedAccessOffender = false,
-          riskToTheIndividual = null,
-        )
-
-        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/risks-to-individual")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isNotFound
-      }
-    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
@@ -16,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.HealthDetailsFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
@@ -33,10 +31,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysAssessmentInfoTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+import java.time.OffsetDateTime
 
 class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
@@ -340,7 +340,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      val riskToIndividual = RiskToTheIndividualFactory()
+      val riskToIndividual = RisksToTheIndividualFactory()
         .withCurrentVulnerability("Current vuln answer")
         .produce()
       apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, riskToIndividual)
@@ -482,6 +482,27 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
+    fun `Returns OK with correct body if assessment is older than 6 months`() {
+      val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+      val risksToTheIndividual = RisksToTheIndividualFactory()
+        .withDateCompleted(OffsetDateTime.now().minusMonths(10))
+        .produce()
+
+      apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, risksToTheIndividual)
+
+      webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/risks-to-individual")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          jsonMapper.writeValueAsString(risksToTheIndividual.riskToTheIndividual),
+        )
+    }
+
+    @Test
     fun `Returns 404 when OASys returns 404`() {
       val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
       apAndOASysMockRiskToTheIndividual404Call(CRN)
@@ -544,6 +565,24 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       assertThat(response.alcoholMisuse!!.community).isEqualTo(alcoholMisuse.community)
       assertThat(response.alcoholMisuse.electronicMonitoring).isEqualTo(alcoholMisuse.electronicMonitoring)
       assertThat(response.alcoholMisuse.programme).isEqualTo(alcoholMisuse.programme)
+    }
+
+    @Test
+    fun `Returns OK with correct body if assessment is older than 6 months`() {
+      val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
+
+      val healthDetails = HealthDetailsFactory()
+        .withDateCompleted(OffsetDateTime.now().minusMonths(10))
+        .produce()
+
+      apAndOASysMockSuccessfulHealthDetailsCall(CRN, healthDetails)
+
+      webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/health-details")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
@@ -14,10 +14,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEv
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1TimelineEventUrlType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ProbationRegion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthIssue
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Address
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Name
@@ -36,7 +32,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DietAndAllergyDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DietAndAllergyResponseFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DietaryItemDtoFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.HealthDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MappaDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
@@ -52,10 +47,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockHealthDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskToTheIndividual404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulHealthDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
@@ -86,104 +77,6 @@ import kotlin.collections.listOf
 class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
   @Autowired
   lateinit var personTransformer: PersonTransformer
-
-  @Nested
-  inner class GetOasysRisksToIndividual {
-    @Test
-    fun `Getting OASys risks to individual without a JWT returns 401`() {
-      webTestClient.get()
-        .uri("/cas1/people/CRN/oasys/risks-to-individual")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `Getting OASys risks to individual returns OK with correct body`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-        val risksToTheIndividual = RisksToTheIndividual(
-          assessmentId = 1,
-          assessmentType = "TYPE",
-          dateCompleted = OffsetDateTime.now(),
-          assessorSignedDate = OffsetDateTime.now(),
-          initiationDate = OffsetDateTime.now(),
-          assessmentStatus = "STATUS",
-          superStatus = "SUPER",
-          limitedAccessOffender = false,
-          riskToTheIndividual = RiskToTheIndividualInner(
-            currentConcernsSelfHarmSuicide = "currentConcernsSelfHarmSuicide",
-            previousConcernsSelfHarmSuicide = "previousConcernsSelfHarmSuicide",
-            currentCustodyHostelCoping = "currentCustodyHostelCoping",
-            previousCustodyHostelCoping = "previousCustodyHostelCoping",
-            currentVulnerability = "currentVulnerability",
-            previousVulnerability = "previousVulnerability",
-            riskOfSeriousHarm = "riskOfSeriousHarm",
-            currentConcernsBreachOfTrustText = "currentConcernsBreachOfTrustText",
-            analysisSuicideSelfharm = "analysisSuicideSelfharm",
-            analysisCoping = "analysisCoping",
-            analysisVulnerabilities = "analysisVulnerabilities",
-          ),
-        )
-
-        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/risks-to-individual")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody()
-          .json(
-            jsonMapper.writeValueAsString(risksToTheIndividual.riskToTheIndividual),
-          )
-      }
-    }
-
-    @Test
-    fun `Getting OASys risks to individual returns 404 when OASys returns 404`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-
-        apAndOASysMockRiskToTheIndividual404Call(crn)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/risks-to-individual")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isNotFound
-      }
-    }
-
-    @Test
-    fun `Getting OASys risks to individual returns 404 when riskToTheIndividual is null`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-        val risksToTheIndividual = RisksToTheIndividual(
-          assessmentId = 1,
-          assessmentType = "TYPE",
-          dateCompleted = OffsetDateTime.now(),
-          assessorSignedDate = OffsetDateTime.now(),
-          initiationDate = OffsetDateTime.now(),
-          assessmentStatus = "STATUS",
-          superStatus = "SUPER",
-          limitedAccessOffender = false,
-          riskToTheIndividual = null,
-        )
-
-        apAndOASysMockSuccessfulRiskToTheIndividualCall(crn, risksToTheIndividual)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/risks-to-individual")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isNotFound
-      }
-    }
-  }
 
   @Nested
   inner class GetTimelineForCrn {
@@ -1343,78 +1236,6 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
         .exchange()
         .expectStatus()
         .isForbidden
-    }
-  }
-
-  @Nested
-  inner class GetOasysHealthDetails {
-    @Test
-    fun `Getting OASys health details without a JWT returns 401`() {
-      webTestClient.get()
-        .uri("/cas1/people/CRN/oasys/health-details")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `Getting OASys health details returns OK with correct body`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-        val drugsMisuse = HealthIssue(
-          community = "drugs community",
-          electronicMonitoring = "drugs em",
-          programme = "drugs programme",
-        )
-        val alcoholMisuse = HealthIssue(
-          community = "alcohol community",
-          electronicMonitoring = "alcohol em",
-          programme = "alcohol programme",
-        )
-
-        val healthDetails = HealthDetailsFactory()
-          .withGeneralHealth(true, "some health issues")
-          .withDrugsMisuse(drugsMisuse)
-          .withAlcoholMisuse(alcoholMisuse)
-          .produce()
-
-        apAndOASysMockSuccessfulHealthDetailsCall(crn, healthDetails)
-
-        val response = webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/health-details")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isOk
-          .expectBody(HealthDetailsInner::class.java)
-          .returnResult()
-          .responseBody!!
-
-        assertThat(response.generalHealth).isEqualTo(healthDetails.health.generalHealth)
-        assertThat(response.generalHealthSpecify).isEqualTo(healthDetails.health.generalHealthSpecify)
-        assertThat(response.drugsMisuse!!.community).isEqualTo(drugsMisuse.community)
-        assertThat(response.drugsMisuse.electronicMonitoring).isEqualTo(drugsMisuse.electronicMonitoring)
-        assertThat(response.drugsMisuse.programme).isEqualTo(drugsMisuse.programme)
-        assertThat(response.alcoholMisuse!!.community).isEqualTo(alcoholMisuse.community)
-        assertThat(response.alcoholMisuse.electronicMonitoring).isEqualTo(alcoholMisuse.electronicMonitoring)
-        assertThat(response.alcoholMisuse.programme).isEqualTo(alcoholMisuse.programme)
-      }
-    }
-
-    @Test
-    fun `Getting OASys health details returns 404 when OASys returns 404`() {
-      givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER)) { _, jwt ->
-        val crn = "CRN"
-
-        apAndOASysMockHealthDetails404Call(crn)
-
-        webTestClient.get()
-          .uri("/cas1/people/$crn/oasys/health-details")
-          .header("Authorization", "Bearer $jwt")
-          .exchange()
-          .expectStatus()
-          .isNotFound
-      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysServiceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService.OASysAssessmentDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService.SuitabilityStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.OffsetDateTime
 
@@ -42,6 +43,7 @@ class OASysServiceTest {
     val INITIATION_DATE: OffsetDateTime = OffsetDateTime.parse("2007-12-03T10:15:30+01:00")
     val COMPLETION_DATE: OffsetDateTime = OffsetDateTime.parse("2007-12-04T10:15:30+01:00")
     val APPLICABILITY_INFO: OASysAssessmentDates = OASysAssessmentDates(CRN, INITIATION_DATE, COMPLETION_DATE)
+    val DEFAULT_SUITABILITY_STRATEGY = SuitabilityStrategy.CompletedInLastSixMonths
   }
 
   @Nested
@@ -54,7 +56,7 @@ class OASysServiceTest {
         .withCompletedDate(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getLatestAssessmentSummary(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -70,7 +72,7 @@ class OASysServiceTest {
         .withCompletedDate(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getLatestAssessmentSummary(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -117,7 +119,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getNeedsDetails(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -133,7 +135,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getNeedsDetails(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -189,7 +191,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getOffenceDetails(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -205,7 +207,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getOffenceDetails(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -252,7 +254,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getRiskManagementPlan(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -268,7 +270,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getRiskManagementPlan(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -324,7 +326,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getRoshSummary(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -340,7 +342,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getRoshSummary(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -396,7 +398,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getRiskToTheIndividual(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -412,7 +414,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getRiskToTheIndividual(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -468,7 +470,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns true
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns true
 
       every { apAndOASysClient.getHealth(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 
@@ -484,7 +486,7 @@ class OASysServiceTest {
         .withDateCompleted(COMPLETION_DATE)
         .produce()
 
-      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO) } returns false
+      every { oasysApplicabilitySevice.isSuitable(APPLICABILITY_INFO, DEFAULT_SUITABILITY_STRATEGY) } returns false
 
       every { apAndOASysClient.getHealth(CRN) } returns ClientResult.Success(HttpStatus.OK, upstreamResponse)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysServiceTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.HealthDetailsFac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
@@ -393,7 +393,7 @@ class OASysServiceTest {
 
     @Test
     fun `success if assessment exists and is usable`() {
-      val upstreamResponse = RiskToTheIndividualFactory()
+      val upstreamResponse = RisksToTheIndividualFactory()
         .withInitiationDate(INITIATION_DATE)
         .withDateCompleted(COMPLETION_DATE)
         .produce()
@@ -409,7 +409,7 @@ class OASysServiceTest {
 
     @Test
     fun `not found if assessment exists but isnt usable`() {
-      val upstreamResponse = RiskToTheIndividualFactory()
+      val upstreamResponse = RisksToTheIndividualFactory()
         .withInitiationDate(INITIATION_DATE)
         .withDateCompleted(COMPLETION_DATE)
         .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysSuitabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysSuitabilityServiceTest.kt
@@ -6,11 +6,13 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.ClockConfiguration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService.SuitabilityStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.time.OffsetDateTime
 
@@ -31,85 +33,127 @@ class OASysSuitabilityServiceTest {
   @Nested
   inner class IsSuitable {
 
-    @ParameterizedTest
-    @CsvSource(
-      // in the future (shouldn't really happen, but should allow)
-      "2010-07-02T11:00:00+00:00,true",
-      // very recent
-      "2010-07-01T11:00:00+00:00,true",
-      // 3 months old
-      "2010-04-01T12:00:00+00:00,true",
-      // 5 months old
-      "2010-02-01T12:00:00+00:00,true",
-      // just under 6 months old
-      "2010-01-01T13:00:00+00:00,true",
-      // just over 6 months old
-      "2010-01-01T11:00:00+00:00,false",
-      // 7 months old
-      "2009-12-01T12:00:00+00:00,false",
-      // 2 years old
-      "2008-07-01T12:00:00+00:00,false",
-    )
-    fun `completion defined`(
-      completionDateTime: OffsetDateTime,
-      isUsable: Boolean,
-    ) {
-      clock.setNow(OffsetDateTime.parse("2010-07-01T12:00:00+00:00"))
+    @Nested
+    inner class StrategyAllowAll {
 
-      val result = service.isSuitable(
-        OASysSuitabilityService.OASysAssessmentDates(
-          crn = CRN,
-          initiationDate = completionDateTime.minusMonths(12),
-          dateCompleted = completionDateTime,
-        ),
-      )
+      @Test
+      fun `completion defined`() {
+        clock.setNow(OffsetDateTime.parse("2010-07-01T12:00:00+00:00"))
 
-      assertThat(result).isEqualTo(isUsable)
+        val result = service.isSuitable(
+          OASysSuitabilityService.OASysAssessmentDates(
+            crn = CRN,
+            initiationDate = OffsetDateTime.parse("2001-07-01T12:00:00+00:00"),
+            dateCompleted = OffsetDateTime.parse("2008-07-01T12:00:00+00:00"),
+          ),
+          strategy = SuitabilityStrategy.AllowAll,
+        )
 
-      if (!isUsable) {
-        verify {
-          sentryService.captureErrorMessage("Have received an assessment with a completion date/time more than 6 months ago for CRN1122 and date/time $completionDateTime")
-        }
+        assertThat(result).isEqualTo(true)
+      }
+
+      @Test
+      fun `completion not defined`() {
+        clock.setNow(OffsetDateTime.parse("2010-07-01T12:00:00+00:00"))
+
+        val result = service.isSuitable(
+          OASysSuitabilityService.OASysAssessmentDates(
+            crn = CRN,
+            initiationDate = OffsetDateTime.parse("2001-07-01T12:00:00+00:00"),
+            dateCompleted = null,
+          ),
+          strategy = SuitabilityStrategy.AllowAll,
+        )
+
+        assertThat(result).isEqualTo(true)
       }
     }
 
-    @ParameterizedTest
-    @CsvSource(
-      // in the future (shouldn't really happen, but should allow)
-      "2010-07-02T11:00:00+00:00,true",
-      // very recent
-      "2010-07-01T11:00:00+00:00,true",
-      // 3 months old
-      "2010-04-01T12:00:00+00:00,true",
-      // 5 months old
-      "2010-02-01T12:00:00+00:00,true",
-      // just under 6 months old
-      "2010-01-01T13:00:00+00:00,true",
-      // just over 6 months old
-      "2010-01-01T11:00:00+00:00,false",
-      // 7 months old
-      "2009-12-01T12:00:00+00:00,false",
-      // 2 years old
-      "2008-07-01T12:00:00+00:00,false",
-    )
-    fun `if completion isn't defined fall back to initiation date and raise an alert`(
-      initiationDate: OffsetDateTime,
-      isUsable: Boolean,
-    ) {
-      clock.setNow(OffsetDateTime.parse("2010-07-01T12:00:00+00:00"))
+    @Nested
+    inner class StrategyCompletedInLastSixMonths {
 
-      val result = service.isSuitable(
-        OASysSuitabilityService.OASysAssessmentDates(
-          crn = CRN,
-          initiationDate = initiationDate,
-          dateCompleted = null,
-        ),
+      @ParameterizedTest
+      @CsvSource(
+        // in the future (shouldn't really happen, but should allow)
+        "2010-07-02T11:00:00+00:00,true",
+        // very recent
+        "2010-07-01T11:00:00+00:00,true",
+        // 3 months old
+        "2010-04-01T12:00:00+00:00,true",
+        // 5 months old
+        "2010-02-01T12:00:00+00:00,true",
+        // just under 6 months old
+        "2010-01-01T13:00:00+00:00,true",
+        // just over 6 months old
+        "2010-01-01T11:00:00+00:00,false",
+        // 7 months old
+        "2009-12-01T12:00:00+00:00,false",
+        // 2 years old
+        "2008-07-01T12:00:00+00:00,false",
       )
+      fun `completion defined`(
+        completionDateTime: OffsetDateTime,
+        isUsable: Boolean,
+      ) {
+        clock.setNow(OffsetDateTime.parse("2010-07-01T12:00:00+00:00"))
 
-      assertThat(result).isEqualTo(isUsable)
+        val result = service.isSuitable(
+          OASysSuitabilityService.OASysAssessmentDates(
+            crn = CRN,
+            initiationDate = completionDateTime.minusMonths(12),
+            dateCompleted = completionDateTime,
+          ),
+          strategy = SuitabilityStrategy.CompletedInLastSixMonths,
+        )
 
-      verify {
-        sentryService.captureErrorMessage("No completion date defined on assessment for CRN1122. Using initiation date/time of $initiationDate")
+        assertThat(result).isEqualTo(isUsable)
+
+        if (!isUsable) {
+          verify {
+            sentryService.captureErrorMessage("Have received an assessment with a completion date/time more than 6 months ago for CRN1122 and date/time $completionDateTime")
+          }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+          // in the future (shouldn't really happen, but should allow)
+          "2010-07-02T11:00:00+00:00,true",
+          // very recent
+          "2010-07-01T11:00:00+00:00,true",
+          // 3 months old
+          "2010-04-01T12:00:00+00:00,true",
+          // 5 months old
+          "2010-02-01T12:00:00+00:00,true",
+          // just under 6 months old
+          "2010-01-01T13:00:00+00:00,true",
+          // just over 6 months old
+          "2010-01-01T11:00:00+00:00,false",
+          // 7 months old
+          "2009-12-01T12:00:00+00:00,false",
+          // 2 years old
+          "2008-07-01T12:00:00+00:00,false",
+        )
+        fun `if completion isn't defined fall back to initiation date and raise an alert`(
+          initiationDate: OffsetDateTime,
+          isUsable: Boolean,
+        ) {
+          clock.setNow(OffsetDateTime.parse("2010-07-01T12:00:00+00:00"))
+
+          val result = service.isSuitable(
+            OASysSuitabilityService.OASysAssessmentDates(
+              crn = CRN,
+              initiationDate = initiationDate,
+              dateCompleted = null,
+            ),
+            strategy = SuitabilityStrategy.CompletedInLastSixMonths,
+          )
+
+          assertThat(result).isEqualTo(isUsable)
+
+          verify {
+            sentryService.captureErrorMessage("No completion date defined on assessment for CRN1122. Using initiation date/time of $initiationDate")
+          }
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/OASysSectionsTransformerTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysSupportin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 
@@ -243,7 +243,7 @@ class OASysSectionsTransformerTest {
 
     @Test
     fun `transforms correctly, post NOD 1057 assessment`() {
-      val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+      val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
         withCurrentConcernsSelfHarmSuicide(null)
         withCurrentCustodyHostelCoping(null)
         withCurrentVulnerability(null)
@@ -276,7 +276,7 @@ class OASysSectionsTransformerTest {
 
     @Test
     fun `transforms correctly, pre NOD 1057 assessment`() {
-      val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+      val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
         withCurrentConcernsSelfHarmSuicide("currentConcernsSelfHarmSuicide")
         withCurrentCustodyHostelCoping("currentCustodyHostelCoping")
         withCurrentVulnerability("currentVulnerability")
@@ -480,7 +480,7 @@ class OASysSectionsTransformerTest {
         withRiskReductionLikelyTo("Reduction Likely To")
       }.produce()
 
-      val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().apply {
+      val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().apply {
         withAssessmentId(34853487)
         withDateCompleted(null)
         withCurrentConcernsSelfHarmSuicide("currentConcernsSelfHarmSuicide")
@@ -655,7 +655,7 @@ class OASysSectionsTransformerTest {
     fun `for supporting information includes optional sections, alcohol, drugs and those that are linked to harm`() {
       val offenceDetailsApiResponse = OffenceDetailsFactory().produce()
       val roshSummaryApiResponse = RoshSummaryFactory().produce()
-      val risksToTheIndividualApiResponse = RiskToTheIndividualFactory().produce()
+      val risksToTheIndividualApiResponse = RisksToTheIndividualFactory().produce()
       val riskManagementPlanApiResponse = RiskManagementPlanFactory().produce()
 
       val requestedOptionalSections = listOf(4, 5)


### PR DESCRIPTION
This commit updates the following two endpoints to remove the limit on OASys assessment age:

* /people/{crn}/oasys/risks-to-individual
* /people/{crn}/oasys/health-details

This is done by introducing an OASys `SuitabilityStrategy` with two options:

* AllowAll
* CompletedInLastSixMonths (default)