### PR TITLE
FM-694 Remove unnecessary OASys calls for CAS1

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1CreateApplicationLaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysAssessmentInfoTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
@@ -39,6 +40,7 @@ class Cas1OasysController(
   private val userService: UserService,
   private val cas1OASysNeedsQuestionTransformer: Cas1OASysNeedsQuestionTransformer,
   private val oaSysService: OASysService,
+  private val cas1OASysAssessmentInfoTransformer: Cas1OASysAssessmentInfoTransformer,
   private val oaSysSectionsTransformer: OASysSectionsTransformer,
   private val oaSysOffenceDetailsTransformer: Cas1OASysOffenceDetailsTransformer,
   private val userAccessService: Cas1UserAccessService,
@@ -62,14 +64,12 @@ class Cas1OasysController(
   ): ResponseEntity<Cas1OASysMetadata> {
     ensureOffenderAccess(crn)
 
+    val needDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn))
+
     return ResponseEntity.ok(
       Cas1OASysMetadata(
-        assessmentMetadata = oaSysOffenceDetailsTransformer.toAssessmentMetadata(
-          extractNullableOAsysResult(oaSysService.getOffenceDetails(crn)),
-        ),
-        supportingInformation = cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(
-          extractNullableOAsysResult(oaSysService.getNeedsDetails(crn)),
-        ),
+        assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(needDetails),
+        supportingInformation = cas1OASysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needDetails),
       ),
     )
   }
@@ -94,35 +94,55 @@ class Cas1OasysController(
   ): ResponseEntity<Cas1OASysGroup> {
     ensureOffenderAccess(crn)
 
-    val offenceDetails = extractNullableOAsysResult(oaSysService.getOffenceDetails(crn))
-
-    val assessmentMetadata = oaSysOffenceDetailsTransformer.toAssessmentMetadata(offenceDetails)
-
-    val answers = when (group) {
-      Cas1OASysGroupName.RISK_MANAGEMENT_PLAN -> oaSysSectionsTransformer.riskManagementPlanAnswers(
-        extractNullableOAsysResult(oaSysService.getRiskManagementPlan(crn))?.riskManagementPlan,
-      )
-      Cas1OASysGroupName.OFFENCE_DETAILS -> oaSysSectionsTransformer.offenceDetailsAnswers(offenceDetails?.offence)
-      Cas1OASysGroupName.ROSH_SUMMARY -> oaSysSectionsTransformer.roshSummaryAnswers(
-        extractNullableOAsysResult(oaSysService.getRoshSummary(crn))?.roshSummary,
-      )
-      Cas1OASysGroupName.SUPPORTING_INFORMATION -> cas1OASysNeedsQuestionTransformer.transformToOASysQuestion(
-        needsDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn)),
-        includeOptionalSections = includeOptionalSections ?: emptyList(),
-        health = extractNullableOAsysResult(oaSysService.getHealthDetails(crn)),
-      )
-      Cas1OASysGroupName.RISK_TO_SELF -> oaSysSectionsTransformer.riskToSelfAnswers(
-        extractNullableOAsysResult(oaSysService.getRiskToTheIndividual(crn))?.riskToTheIndividual,
-      )
+    val group = when (group) {
+      Cas1OASysGroupName.RISK_MANAGEMENT_PLAN -> {
+        val riskManagementPlan = extractNullableOAsysResult(oaSysService.getRiskManagementPlan(crn))
+        Cas1OASysGroup(
+          group = group,
+          assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(riskManagementPlan),
+          answers = oaSysSectionsTransformer.riskManagementPlanAnswers(riskManagementPlan?.riskManagementPlan),
+        )
+      }
+      Cas1OASysGroupName.OFFENCE_DETAILS -> {
+        val offenceDetails = extractNullableOAsysResult(oaSysService.getOffenceDetails(crn))
+        Cas1OASysGroup(
+          group = group,
+          assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(offenceDetails),
+          answers = oaSysSectionsTransformer.offenceDetailsAnswers(offenceDetails?.offence),
+        )
+      }
+      Cas1OASysGroupName.ROSH_SUMMARY -> {
+        val roshSummary = extractNullableOAsysResult(oaSysService.getRoshSummary(crn))
+        Cas1OASysGroup(
+          group = group,
+          assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(roshSummary),
+          answers = oaSysSectionsTransformer.roshSummaryAnswers(roshSummary?.roshSummary),
+        )
+      }
+      Cas1OASysGroupName.SUPPORTING_INFORMATION -> {
+        val needsDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn))
+        val healthDetails = extractNullableOAsysResult(oaSysService.getHealthDetails(crn))
+        Cas1OASysGroup(
+          group = group,
+          assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(needsDetails),
+          answers = cas1OASysNeedsQuestionTransformer.transformToOASysQuestion(
+            needsDetails = needsDetails,
+            includeOptionalSections = includeOptionalSections ?: emptyList(),
+            health = healthDetails,
+          ),
+        )
+      }
+      Cas1OASysGroupName.RISK_TO_SELF -> {
+        val riskToTheIndividual = extractNullableOAsysResult(oaSysService.getRiskToTheIndividual(crn))
+        Cas1OASysGroup(
+          group = group,
+          assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(riskToTheIndividual),
+          answers = oaSysSectionsTransformer.riskToSelfAnswers(riskToTheIndividual?.riskToTheIndividual),
+        )
+      }
     }
 
-    return ResponseEntity.ok(
-      Cas1OASysGroup(
-        group = group,
-        assessmentMetadata = assessmentMetadata,
-        answers = answers,
-      ),
-    )
+    return ResponseEntity.ok(group)
   }
 
   @Operation(summary = "Returns OASys risk to the individual for a Person.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysSuitabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysSuitabilityService.kt
@@ -19,9 +19,9 @@ class OASysSuitabilityService(
     val suitable = (dateCompleted ?: initiationDate).isAfter(sixMonthThreshold)
 
     if (dateCompleted == null) {
-      sentryService.captureErrorMessage("No completion date defined on assessment for $crn. Using initiation date of $initiationDate")
+      sentryService.captureErrorMessage("No completion date defined on assessment for $crn. Using initiation date/time of $initiationDate")
     } else if (!suitable) {
-      sentryService.captureErrorMessage("Have received an assessment with a completion date more than 6 months ago for $crn and date $dateCompleted")
+      sentryService.captureErrorMessage("Have received an assessment with a completion date/time more than 6 months ago for $crn and date/time $dateCompleted")
     }
 
     return suitable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysAssessmentInfoTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysAssessmentInfoTransformer.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysAssessmentMetadata
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
+
+@Service
+class Cas1OASysAssessmentInfoTransformer {
+
+  fun toAssessmentMetadata(assessmentInfo: AssessmentInfo?) = assessmentInfo?.let {
+    Cas1OASysAssessmentMetadata(
+      hasApplicableAssessment = true,
+      dateStarted = assessmentInfo.initiationDate.toInstant(),
+      dateCompleted = assessmentInfo.dateCompleted?.toInstant(),
+    )
+  } ?: Cas1OASysAssessmentMetadata(hasApplicableAssessment = false)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysAssessmentInfoTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
@@ -38,6 +39,9 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
   @Autowired
   lateinit var oaSysOffenceDetailsTransformer: Cas1OASysOffenceDetailsTransformer
+
+  @Autowired
+  lateinit var cas1OASysAssessmentInfoTransformer: Cas1OASysAssessmentInfoTransformer
 
   companion object {
     const val CRN = "CRN123"
@@ -101,9 +105,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      val offenceDetails = OffenceDetailsFactory().produce()
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
-
       val needsDetails = NeedsDetailsFactory().apply {
         withAssessmentId(34853487)
         withAccommodationIssuesDetails("Accommodation", true, false)
@@ -122,7 +123,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         .json(
           jsonMapper.writeValueAsString(
             Cas1OASysMetadata(
-              oaSysOffenceDetailsTransformer.toAssessmentMetadata(offenceDetails),
+              cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(needsDetails),
               oaSysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails),
             ),
           ),
@@ -166,7 +167,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apAndOASysMockOffenceDetails404Call(CRN)
       apAndOASysMockRiskManagementPlan404Call(CRN)
 
       val result = webTestClient.get()
@@ -193,8 +193,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val riskManagementPlan = RiskManagementPlanFactory()
         .withSupervision("The supervision answer")
@@ -282,8 +280,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
-
       val roshSummary = RoshSummaryFactory()
         .withWhoAtRisk("Who at risk answer")
         .produce()
@@ -313,7 +309,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
       apAndOASysMockRiskToTheIndividual404Call(CRN)
 
       val result = webTestClient.get()
@@ -339,8 +334,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val riskToIndividual = RiskToTheIndividualFactory()
         .withCurrentVulnerability("Current vuln answer")
@@ -371,7 +364,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apAndOASysMockOffenceDetails404Call(CRN)
       apAndOASysMockNeedsDetails404Call(CRN)
 
       val result = webTestClient.get()
@@ -408,8 +400,6 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val needsDetails = NeedsDetailsFactory().apply {
         withRelationshipIssuesDetails(linkedToHarm = true, relationshipIssuesDetails = "relationship answer")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysSuitabilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OASysSuitabilityServiceTest.kt
@@ -68,7 +68,7 @@ class OASysSuitabilityServiceTest {
 
       if (!isUsable) {
         verify {
-          sentryService.captureErrorMessage("Have received an assessment with a completion date more than 6 months ago for CRN1122 and date $completionDateTime")
+          sentryService.captureErrorMessage("Have received an assessment with a completion date/time more than 6 months ago for CRN1122 and date/time $completionDateTime")
         }
       }
     }
@@ -109,7 +109,7 @@ class OASysSuitabilityServiceTest {
       assertThat(result).isEqualTo(isUsable)
 
       verify {
-        sentryService.captureErrorMessage("No completion date defined on assessment for CRN1122. Using initiation date of $initiationDate")
+        sentryService.captureErrorMessage("No completion date defined on assessment for CRN1122. Using initiation date/time of $initiationDate")
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysAssessmentInfoTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysAssessmentInfoTransformerTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysAssessmentInfoTransformer
+import java.time.Instant
+import java.time.OffsetDateTime
+
+class Cas1OASysAssessmentInfoTransformerTest {
+
+  private val transformer = Cas1OASysAssessmentInfoTransformer()
+
+  @Nested
+  inner class ToAssessmentMetadata {
+
+    @Test
+    fun `has applicable assessment`() {
+      val initiationDate = OffsetDateTime.parse("2020-05-02T12:01:00+00:00")
+      val completionDate = OffsetDateTime.parse("2021-05-02T12:02:00+00:00")
+
+      val result = transformer.toAssessmentMetadata(
+        OffenceDetailsFactory()
+          .withInitiationDate(initiationDate)
+          .withDateCompleted(completionDate)
+          .produce(),
+      )
+
+      assertThat(result.hasApplicableAssessment).isTrue()
+      assertThat(result.dateStarted).isEqualTo(Instant.parse("2020-05-02T12:01:00+00:00"))
+      assertThat(result.dateCompleted).isEqualTo(Instant.parse("2021-05-02T12:02:00+00:00"))
+    }
+
+    @Test
+    fun `no applicable assessment`() {
+      val result = transformer.toAssessmentMetadata(null)
+
+      assertThat(result.hasApplicableAssessment).isFalse()
+      assertThat(result.dateStarted).isNull()
+      assertThat(result.dateCompleted).isNull()
+    }
+  }
+}


### PR DESCRIPTION
Before this commit we were fetching the `NeedDetails` for every OAsys request, and using it populate the `CAS1OASysMetadata`. This is unneccessary because the fields required to populate that metadata are available on almost all responses from OASys (as represented by the `AssessmentInfo` abstract class).

This commit updates the `Cas1OASysController` to make use of these metadata fields, allowing us to remove unneccessary upstream calls to get `NeedsDetail` for every OAsys request.