### PR TITLE
FM-696 Remove unneccessary CAS3 OASys Calls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PeopleController.kt
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3OASysOffenceDetailsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3OASysAssessmentInfoTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -19,25 +19,19 @@ class Cas3PeopleController(
   private val userService: UserService,
   private val oaSysService: OASysService,
   private val oaSysSectionsTransformer: OASysSectionsTransformer,
-  private val oaSysOffenceDetailsTransformer: Cas3OASysOffenceDetailsTransformer,
+  private val oaSysAssessmentInfoTransformer: Cas3OASysAssessmentInfoTransformer,
 ) {
 
   @GetMapping("/people/{crn}/oasys/riskManagement")
   fun riskManagement(@PathVariable crn: String): ResponseEntity<Cas3OASysGroup> {
     ensureOffenderAccess(crn)
 
-    val offenceDetails = extractEntityFromCasResult(oaSysService.getOffenceDetails(crn))
-
-    val assessmentMetadata = oaSysOffenceDetailsTransformer.toAssessmentMetadata(offenceDetails)
-
-    val answers = oaSysSectionsTransformer.riskManagementPlanAnswers(
-      extractEntityFromCasResult(oaSysService.getRiskManagementPlan(crn)).riskManagementPlan,
-    )
+    val riskManagementPlan = extractEntityFromCasResult(oaSysService.getRiskManagementPlan(crn))
 
     return ResponseEntity.ok(
       Cas3OASysGroup(
-        assessmentMetadata = assessmentMetadata,
-        answers = answers,
+        assessmentMetadata = oaSysAssessmentInfoTransformer.toAssessmentMetadata(riskManagementPlan),
+        answers = oaSysSectionsTransformer.riskManagementPlanAnswers(riskManagementPlan.riskManagementPlan),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3OASysAssessmentInfoTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3OASysAssessmentInfoTransformer.kt
@@ -2,15 +2,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysAssessmentMetadata
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OffenceDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
 
 @Service
-class Cas3OASysOffenceDetailsTransformer {
-  fun toAssessmentMetadata(offenceDetails: OffenceDetails?) = offenceDetails?.let {
+class Cas3OASysAssessmentInfoTransformer {
+
+  fun toAssessmentMetadata(assessmentInfo: AssessmentInfo?) = assessmentInfo?.let {
     Cas3OASysAssessmentMetadata(
       hasApplicableAssessment = true,
-      dateStarted = offenceDetails.initiationDate.toInstant(),
-      dateCompleted = offenceDetails.dateCompleted?.toInstant(),
+      dateStarted = assessmentInfo.initiationDate.toInstant(),
+      dateCompleted = assessmentInfo.dateCompleted?.toInstant(),
     )
   } ?: Cas3OASysAssessmentMetadata(hasApplicableAssessment = false)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PeopleTest.kt
@@ -6,14 +6,11 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1OAsysTest.Companion.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockNeedsDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockOffenceDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskManagementPlanCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
@@ -33,26 +30,10 @@ class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Return 404 if offence details record can't be found for the CRN`() {
-      val (_, jwt) = givenAUser()
-
-      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apAndOASysMockOffenceDetails404Call(CRN)
-
-      webTestClient.get()
-        .uri("/cas3/people/$CRN/oasys/riskManagement")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isNotFound
-    }
-
-    @Test
     fun `Return 404 if needs record can't be found for the CRN`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
       apAndOASysMockNeedsDetails404Call(CRN)
 
       webTestClient.get()
@@ -68,8 +49,6 @@ class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-
-      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, OffenceDetailsFactory().produce())
 
       val riskManagementPlan = RiskManagementPlanFactory()
         .withSupervision("The supervision answer")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3OASysAssessmentInfoTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3OASysAssessmentInfoTransformerTest.kt
@@ -3,14 +3,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.unit.transformer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3OASysOffenceDetailsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3OASysAssessmentInfoTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import java.time.Instant
 import java.time.OffsetDateTime
 
-class Cas3OASysOffenceDetailsTransformerTest {
+class Cas3OASysAssessmentInfoTransformerTest {
 
-  private val transformer = Cas3OASysOffenceDetailsTransformer()
+  private val transformer = Cas3OASysAssessmentInfoTransformer()
 
   @Nested
   inner class ToAssessmentMetadata {


### PR DESCRIPTION
Before this commit we were fetching the `OffenceDetails` for every OAsys request, and using it populate metadata in the OAsys response. This is unneccessary because the fields required to populate that metadata are available on almost all responses from OASys (as represented by the `AssessmentInfo` abstract class).

This commit updates the `Cas3PeopleController` to make use of these metadata fields, allowing us to remove unneccessary upstream calls to get `OffenceDetails ` for every OAsys request.