### PR TITLE
FM-520 Reduce max container mem in preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,10 +7,9 @@ generic-service:
 
   resources:
     limits:
-      memory: 3Gi
+      memory: 2Gi
     requests:
-      memory: 2.5Gi
-
+      memory: 1.5Gi
 
   ingress:
     host: approved-premises-api-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
During the spring boot upgrade we noted that the container probably has an unneccessary amount of head room given the java heap size.

This PR reduces the amount of max memory provided in preprod to soak test the change. If this is a success we’ll reduce memory usage in prod.