### PR TITLE
Fix swagger doc groups

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -58,7 +58,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas1Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS1Shared")
     .displayName("CAS1 & Shared")
-    .pathsToExclude("/**/cas2/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
+    .pathsToExclude("/**/cas2/**", "/**/cas2-hdc/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -75,7 +75,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas2Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2Shared")
     .displayName("CAS2 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2-hdc/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -100,7 +100,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas2v2Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2v2Shared")
     .displayName("CAS2v2 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2-hdc/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -108,7 +108,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas3Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS3Shared")
     .displayName("CAS3 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2v2/**", "/**/events/**", "/queue-admin/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2-hdc/**", "/**/cas2v2/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 


### PR DESCRIPTION
Update `pathsToExclude` configurations to include `/cas2-hdc/` across grouped OpenAPI definitions