### PR TITLE
Create a `common` top level package

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.Offende
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderDetailsDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/convert/EnumConverterFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/convert/EnumConverterFactory.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.convert
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.convert
 
 import org.springframework.core.convert.converter.Converter
 import org.springframework.core.convert.converter.ConverterFactory

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/convert/UrlTemplateConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/convert/UrlTemplateConverter.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.convert
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.convert
 
 import org.springframework.core.convert.TypeDescriptor
 import org.springframework.core.convert.converter.GenericConverter

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/health/HealthInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/health/HealthInfo.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.health
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.health
 
 import org.springframework.boot.health.contributor.Health
 import org.springframework.boot.health.contributor.HealthIndicator

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/health/VersionOutputter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/health/VersionOutputter.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.health
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.health
 
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationReadyEvent

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/services/OffenderDetailsDataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/services/OffenderDetailsDataSource.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services
 
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/services/OffenderRiskNoteParser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/services/OffenderRiskNoteParser.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.parser
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseDetail

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ConverterConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ConverterConfig.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.FormatterRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.convert.EnumConverterFactory
 
 /**
  * Allows Spring to correctly deserialize enums coming in as controller parameters when the "public" value (as defined
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFac
  * [here](https://github.com/OpenAPITools/openapi-generator/pull/13349)
  * but not for Kotlin as far as I could see.
  *
- * @see uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+ * @see EnumConverterFactory
  */
 @Configuration
 class ConverterConfig : WebMvcConfigurer {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1TasksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1TasksController.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskSortField
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TaskWrapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UserWithWorkload
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.convert.EnumConverterFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -18,12 +18,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.Adjudi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.Agency
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.BookingDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.CsraSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderRiskNoteParser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonAdjudicationsConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonAdjudicationsConfigBindingModel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.parser.OffenderRiskNoteParser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2OffenderServiceTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderDetailsDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/service/Cas2v2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/service/Cas2v2OffenderServiceTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.AssignedLivingUnit
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderDetailsDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/HealthCheckTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.health
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InfoTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.health
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/convert/EnumConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/convert/EnumConverterTest.kt
@@ -1,8 +1,8 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.convert
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.unit.convert
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.convert.EnumConverterFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.convert.EnumConverterFactory
 
 class EnumConverterTest {
   @Suppress("UNUSED") // Should be accessed by the enum converter under test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/health/HealthInfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/health/HealthInfoTest.kt
@@ -1,8 +1,9 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.health
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.unit.health
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.info.BuildProperties
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.health.HealthInfo
 import java.util.Properties
 
 class HealthInfoTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/health/QueueHealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/health/QueueHealthCheckTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.health
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.unit.health
 
 import com.ninjasquad.springmockk.MockkSpyBean
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/services/OffenderDetailsDataSourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/services/OffenderDetailsDataSourceTest.kt
@@ -1,8 +1,8 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.datasource
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.unit.services
 
 import io.mockk.every
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.Offende
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.UserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.UserOffenderAccess
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderDetailsDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseAccess
@@ -39,7 +39,7 @@ class OffenderDetailsDataSourceTest {
 
     val result = offenderDetailsDataSource.getOffenderDetailSummary("SOME-CRN")
 
-    assertThat(result).isEqualTo(expectedResult)
+    Assertions.assertThat(result).isEqualTo(expectedResult)
   }
 
   @Test
@@ -50,8 +50,8 @@ class OffenderDetailsDataSourceTest {
 
     val result = offenderDetailsDataSource.getOffenderDetailSummary("SOME-CRN")
 
-    assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
-    assertThat((result as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
+    Assertions.assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+    Assertions.assertThat((result as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
   }
 
   @Test
@@ -74,7 +74,7 @@ class OffenderDetailsDataSourceTest {
 
     val results = offenderDetailsDataSource.getOffenderDetailSummaries(crns)
 
-    assertThat(results).isEqualTo(expectedResults)
+    Assertions.assertThat(results).isEqualTo(expectedResults)
   }
 
   @Test
@@ -85,10 +85,10 @@ class OffenderDetailsDataSourceTest {
     every { mockApDeliusContextApiClient.getCaseSummaries(crns) } returns cacheTimeoutClientResult
 
     val results = offenderDetailsDataSource.getOffenderDetailSummaries(crns)
-    assertThat(results).hasSize(3)
-    assertThat(results["CRN-A"]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results["CRN-B"]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results["CRN-C"]).isEqualTo(cacheTimeoutClientResult)
+    Assertions.assertThat(results).hasSize(3)
+    Assertions.assertThat(results["CRN-A"]).isEqualTo(cacheTimeoutClientResult)
+    Assertions.assertThat(results["CRN-B"]).isEqualTo(cacheTimeoutClientResult)
+    Assertions.assertThat(results["CRN-C"]).isEqualTo(cacheTimeoutClientResult)
   }
 
   @Test
@@ -107,19 +107,19 @@ class OffenderDetailsDataSourceTest {
 
     val results = offenderDetailsDataSource.getOffenderDetailSummaries(crns)
 
-    assertThat(results).hasSize(3)
+    Assertions.assertThat(results).hasSize(3)
 
     val crnAResult = results["CRN-A"]
-    assertThat(crnAResult).isInstanceOf(ClientResult.Success::class.java)
-    assertThat((crnAResult as ClientResult.Success).body).isEqualTo(crnACaseSummary.asOffenderDetailSummary())
+    Assertions.assertThat(crnAResult).isInstanceOf(ClientResult.Success::class.java)
+    Assertions.assertThat((crnAResult as ClientResult.Success).body).isEqualTo(crnACaseSummary.asOffenderDetailSummary())
 
     val crnBResult = results["CRN-B"]
-    assertThat(crnBResult).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
-    assertThat((crnBResult as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
+    Assertions.assertThat(crnBResult).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+    Assertions.assertThat((crnBResult as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
 
     val crnCResult = results["CRN-C"]
-    assertThat(crnCResult).isInstanceOf(ClientResult.Success::class.java)
-    assertThat((crnCResult as ClientResult.Success).body).isEqualTo(crnCCaseSummary.asOffenderDetailSummary())
+    Assertions.assertThat(crnCResult).isInstanceOf(ClientResult.Success::class.java)
+    Assertions.assertThat((crnCResult as ClientResult.Success).body).isEqualTo(crnCCaseSummary.asOffenderDetailSummary())
   }
 
   @ParameterizedTest
@@ -132,7 +132,7 @@ class OffenderDetailsDataSourceTest {
 
     val result = offenderDetailsDataSource.getUserAccessForOffenderCrn("DELIUS-USER", "SOME-CRN")
 
-    assertThat(result).isEqualTo(expectedResult)
+    Assertions.assertThat(result).isEqualTo(expectedResult)
   }
 
   @Test
@@ -143,8 +143,8 @@ class OffenderDetailsDataSourceTest {
 
     val result = offenderDetailsDataSource.getUserAccessForOffenderCrn("DELIUS-USER", "SOME-CRN")
 
-    assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
-    assertThat((result as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
+    Assertions.assertThat(result).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+    Assertions.assertThat((result as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
   }
 
   @Test
@@ -166,7 +166,7 @@ class OffenderDetailsDataSourceTest {
 
     val results = offenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
 
-    assertThat(results).isEqualTo(expectedResults)
+    Assertions.assertThat(results).isEqualTo(expectedResults)
   }
 
   @Test
@@ -177,10 +177,10 @@ class OffenderDetailsDataSourceTest {
     every { mockApDeliusContextApiClient.getUserAccessForCrns("DELIUS-USER", crns) } returns cacheTimeoutClientResult
 
     val results = offenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
-    assertThat(results).hasSize(3)
-    assertThat(results["CRN-A"]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results["CRN-B"]).isEqualTo(cacheTimeoutClientResult)
-    assertThat(results["CRN-C"]).isEqualTo(cacheTimeoutClientResult)
+    Assertions.assertThat(results).hasSize(3)
+    Assertions.assertThat(results["CRN-A"]).isEqualTo(cacheTimeoutClientResult)
+    Assertions.assertThat(results["CRN-B"]).isEqualTo(cacheTimeoutClientResult)
+    Assertions.assertThat(results["CRN-C"]).isEqualTo(cacheTimeoutClientResult)
   }
 
   @Test
@@ -199,18 +199,18 @@ class OffenderDetailsDataSourceTest {
 
     val results = offenderDetailsDataSource.getUserAccessForOffenderCrns("DELIUS-USER", crns)
 
-    assertThat(results).hasSize(3)
+    Assertions.assertThat(results).hasSize(3)
     val crnAResult = results["CRN-A"]
-    assertThat(crnAResult).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
-    assertThat((crnAResult as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
+    Assertions.assertThat(crnAResult).isInstanceOf(ClientResult.Failure.StatusCode::class.java)
+    Assertions.assertThat((crnAResult as ClientResult.Failure.StatusCode).status).isEqualTo(HttpStatus.NOT_FOUND)
 
     val crnBResult = results["CRN-B"]
-    assertThat(crnBResult).isInstanceOf(ClientResult.Success::class.java)
-    assertThat((crnBResult as ClientResult.Success).body).isEqualTo(crnBCaseAccess.asUserOffenderAccess())
+    Assertions.assertThat(crnBResult).isInstanceOf(ClientResult.Success::class.java)
+    Assertions.assertThat((crnBResult as ClientResult.Success).body).isEqualTo(crnBCaseAccess.asUserOffenderAccess())
 
     val crnCResult = results["CRN-C"]
-    assertThat(crnCResult).isInstanceOf(ClientResult.Success::class.java)
-    assertThat((crnCResult as ClientResult.Success).body).isEqualTo(crnCCaseAccess.asUserOffenderAccess())
+    Assertions.assertThat(crnCResult).isInstanceOf(ClientResult.Success::class.java)
+    Assertions.assertThat((crnCResult as ClientResult.Success).body).isEqualTo(crnCCaseAccess.asUserOffenderAccess())
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/services/OffenderRiskNoteParserTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/services/OffenderRiskNoteParserTest.kt
@@ -1,10 +1,10 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.parser
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.unit.services
 
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderRiskNoteParser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.parser.OffenderRiskNoteParser
 import java.time.LocalDate
 
 class OffenderRiskNoteParserTest {
@@ -26,7 +26,7 @@ class OffenderRiskNoteParserTest {
 
     val result = parser.withParsedRiskNotes(caseDetail)
 
-    assertThat(result.registrations[0].riskNotesDetail).isEmpty()
+    Assertions.assertThat(result.registrations[0].riskNotesDetail).isEmpty()
   }
 
   @Test
@@ -43,7 +43,7 @@ class OffenderRiskNoteParserTest {
 
     val result = parser.withParsedRiskNotes(caseDetail)
 
-    assertThat(result.registrations[0].riskNotesDetail).isEmpty()
+    Assertions.assertThat(result.registrations[0].riskNotesDetail).isEmpty()
   }
 
   @Test
@@ -60,7 +60,7 @@ class OffenderRiskNoteParserTest {
 
     val result = parser.withParsedRiskNotes(caseDetail)
 
-    assertThat(result.registrations[0].riskNotesDetail).isEmpty()
+    Assertions.assertThat(result.registrations[0].riskNotesDetail).isEmpty()
   }
 
   @Test
@@ -79,9 +79,9 @@ class OffenderRiskNoteParserTest {
 
     val result = parser.withParsedRiskNotes(caseDetail)
 
-    assertThat(result.registrations[0].riskNotesDetail).hasSize(1)
-    assertThat(result.registrations[0].riskNotesDetail!![0].note).isEqualTo("This is a risk note")
-    assertThat(result.registrations[0].riskNotesDetail!![0].date).isEqualTo(LocalDate.of(2026, 3, 11))
+    Assertions.assertThat(result.registrations[0].riskNotesDetail).hasSize(1)
+    Assertions.assertThat(result.registrations[0].riskNotesDetail!![0].note).isEqualTo("This is a risk note")
+    Assertions.assertThat(result.registrations[0].riskNotesDetail!![0].date).isEqualTo(LocalDate.of(2026, 3, 11))
   }
 
   @Test
@@ -100,9 +100,9 @@ class OffenderRiskNoteParserTest {
 
     val result = parser.withParsedRiskNotes(caseDetail)
 
-    assertThat(result.registrations[0].riskNotesDetail).hasSize(1)
-    assertThat(result.registrations[0].riskNotesDetail!![0].note).isEqualTo("This is a risk note without a header")
-    assertThat(result.registrations[0].riskNotesDetail!![0].date).isNull()
+    Assertions.assertThat(result.registrations[0].riskNotesDetail).hasSize(1)
+    Assertions.assertThat(result.registrations[0].riskNotesDetail!![0].note).isEqualTo("This is a risk note without a header")
+    Assertions.assertThat(result.registrations[0].riskNotesDetail!![0].date).isNull()
   }
 
   @Test
@@ -126,16 +126,16 @@ class OffenderRiskNoteParserTest {
     val result = parser.withParsedRiskNotes(caseDetail)
 
     val parsedNotes = result.registrations[0].riskNotesDetail!!
-    assertThat(parsedNotes).hasSize(3)
+    Assertions.assertThat(parsedNotes).hasSize(3)
 
-    assertThat(parsedNotes[0].note).isEqualTo("Third note without header")
-    assertThat(parsedNotes[0].date).isNull()
+    Assertions.assertThat(parsedNotes[0].note).isEqualTo("Third note without header")
+    Assertions.assertThat(parsedNotes[0].date).isNull()
 
-    assertThat(parsedNotes[1].note).isEqualTo("Second note")
-    assertThat(parsedNotes[1].date).isEqualTo(LocalDate.of(2026, 1, 2))
+    Assertions.assertThat(parsedNotes[1].note).isEqualTo("Second note")
+    Assertions.assertThat(parsedNotes[1].date).isEqualTo(LocalDate.of(2026, 1, 2))
 
-    assertThat(parsedNotes[2].note).isEqualTo("First note")
-    assertThat(parsedNotes[2].date).isEqualTo(LocalDate.of(2026, 1, 1))
+    Assertions.assertThat(parsedNotes[2].note).isEqualTo("First note")
+    Assertions.assertThat(parsedNotes[2].date).isEqualTo(LocalDate.of(2026, 1, 1))
   }
 
   @Test
@@ -160,8 +160,8 @@ class OffenderRiskNoteParserTest {
     val result = parser.withParsedRiskNotes(caseDetail)
 
     val parsedNotes = result.registrations[0].riskNotesDetail!!
-    assertThat(parsedNotes).hasSize(2)
-    assertThat(parsedNotes[0].note).isEqualTo("Second note")
-    assertThat(parsedNotes[1].note).isEqualTo("First note")
+    Assertions.assertThat(parsedNotes).hasSize(2)
+    Assertions.assertThat(parsedNotes[0].note).isEqualTo("Second note")
+    Assertions.assertThat(parsedNotes[1].note).isEqualTo("First note")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderServiceTest.kt
@@ -23,8 +23,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.UserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.UserOffenderAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.CsraSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderDetailsDataSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.services.OffenderRiskNoteParser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.PrisonAdjudicationsConfigBindingModel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.datasource.OffenderDetailsDataSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationsPageFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AgencyFactory
@@ -38,7 +39,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1OffenderEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1OffenderRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.parser.OffenderRiskNoteParser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.InternalServerErrorProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult


### PR DESCRIPTION
This is the first step to align our code with ADR `0029-package-structure.md`

It only moves packages that aren’t currently being significantly being used/modified in PRs to avoid disruption

converter -> common.converter
datasource -> common.services
health -> common.health
parser -> common.parser