### PR TITLE
Audit POC - Javers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,7 @@ dependencies {
   implementation("com.github.ben-manes.caffeine:caffeine")
   implementation("com.google.guava:guava:33.6.0-jre")
   implementation("org.postgresql:postgresql:42.7.11")
-  implementation("org.javers:javers-core:7.11.1")
-
+  implementation("org.javers:javers-spring-boot-starter-sql:7.11.0")
   val springDocOpenApiStarterVersion = "3.0.2"
   // https://github.com/springdoc/springdoc-openapi/pull/3256 significantly changed our
   // generated schema, making it incompatible with the typescript generators and in some
@@ -96,6 +95,7 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.43") {
     exclude(group = "io.swagger.core.v3")
   }
+  testImplementation("org.springframework.security:spring-security-test")
 }
 
 springBoot {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimeLineRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimeLineRecord.kt
@@ -1,42 +1,10 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.Instant
 
-/**
- * {
- *   "author": "audit_user",
- *   "commitDate": "2026-06-03T06:35:03Z",
- *   "sections": [
- *     {
- *       "entityType": "RELEASE_PLAN",
- *       "changes": [
- *         {
- *           "changeType": "UPDATE",
- *           "field": "description",
- *           "oldValue": "Initial Plan",
- *           "newValue": "Updated Plan",
- *           "message": "Description changed from 'Initial Plan' to 'Updated Plan'"
- *         }
- *       ]
- *     },
- *     {
- *       "entityType": "RELEASE_ACTION",
- *       "changes": [
- *         {
- *           "changeType": "CREATE",
- *           "message": "Created release action with description 'Action 2'"
- *         },
- *         {
- *           "changeType": "DELETE",
- *           "message": "Deleted release action with description 'Action 1'"
- *         }
- *       ]
- *     }
- *   ]
- * }
- */
-
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class TimelineRecord(
   val author: String,
 
@@ -58,8 +26,10 @@ data class TimelineSection(
 enum class AuditEntityType {
   RELEASE_PLAN,
   RELEASE_ACTION,
+  MONITORING_INFORMATION,
 }
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class TimelineChange(
 
   val changeType: ChangeType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimeLineRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimeLineRecord.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
+import java.time.Instant
+
+data class TimelineRecord(
+  val type: AuditRecordType,
+  val author: String,
+  @field:JsonFormat(
+    shape = JsonFormat.Shape.STRING,
+    pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
+    timezone = "UTC",
+  )
+  val commitDate: Instant,
+  val changes: List<FieldChange>,
+  @field:JsonInclude(JsonInclude.Include.NON_NULL)
+  val extraInformation: Map<String, String>? = null,
+)
+
+enum class AuditRecordType {
+  CREATE,
+  UPDATE,
+  DELETE,
+}
+
+interface FieldChange {
+  var field: String
+  var value: String?
+}
+
+data class UpdateFieldChange(
+  override var field: String,
+  override var value: String?,
+  var oldValue: String?,
+) : FieldChange
+
+data class CreateFieldChange(
+  override var field: String,
+  override var value: String?,
+) : FieldChange

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimeLineRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimeLineRecord.kt
@@ -1,41 +1,86 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.Instant
 
+/**
+ * {
+ *   "author": "audit_user",
+ *   "commitDate": "2026-06-03T06:35:03Z",
+ *   "sections": [
+ *     {
+ *       "entityType": "RELEASE_PLAN",
+ *       "changes": [
+ *         {
+ *           "changeType": "UPDATE",
+ *           "field": "description",
+ *           "oldValue": "Initial Plan",
+ *           "newValue": "Updated Plan",
+ *           "message": "Description changed from 'Initial Plan' to 'Updated Plan'"
+ *         }
+ *       ]
+ *     },
+ *     {
+ *       "entityType": "RELEASE_ACTION",
+ *       "changes": [
+ *         {
+ *           "changeType": "CREATE",
+ *           "message": "Created release action with description 'Action 2'"
+ *         },
+ *         {
+ *           "changeType": "DELETE",
+ *           "message": "Deleted release action with description 'Action 1'"
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
+
 data class TimelineRecord(
-  val type: AuditRecordType,
   val author: String,
+
   @field:JsonFormat(
     shape = JsonFormat.Shape.STRING,
     pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
     timezone = "UTC",
   )
   val commitDate: Instant,
-  val changes: List<FieldChange>,
-  @field:JsonInclude(JsonInclude.Include.NON_NULL)
-  val extraInformation: Map<String, String>? = null,
+
+  val sections: List<TimelineSection>,
 )
 
-enum class AuditRecordType {
+data class TimelineSection(
+  val entityType: AuditEntityType,
+  val changes: List<TimelineChange>,
+)
+
+enum class AuditEntityType {
+  RELEASE_PLAN,
+  RELEASE_ACTION,
+}
+
+data class TimelineChange(
+
+  val changeType: ChangeType,
+
+  /**
+   * Message for UI.
+   */
+  val message: String,
+
+  /**
+   * Only for UPDATE changes.
+   */
+  val field: String? = null,
+
+  val oldValue: String? = null,
+
+  val newValue: String? = null,
+)
+
+enum class ChangeType {
   CREATE,
   UPDATE,
   DELETE,
 }
-
-interface FieldChange {
-  var field: String
-  var value: String?
-}
-
-data class UpdateFieldChange(
-  override var field: String,
-  override var value: String?,
-  var oldValue: String?,
-) : FieldChange
-
-data class CreateFieldChange(
-  override var field: String,
-  override var value: String?,
-) : FieldChange

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimelineRecordV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/TimelineRecordV2.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.Instant
+
+data class TimelineRecordV2(
+  val author: String,
+
+  @field:JsonFormat(
+    shape = JsonFormat.Shape.STRING,
+    pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
+    timezone = "UTC",
+  )
+  val commitDate: Instant,
+
+  val message: String,
+
+  val changes: List<TimelineChange>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/JaversConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/JaversConfig.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
+
+import org.javers.spring.auditable.AuthorProvider
+import org.javers.spring.auditable.CommitPropertiesProvider
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanEntity
+
+@Configuration
+class JaversConfig {
+  @Bean
+  fun authorProvider(): AuthorProvider = AuthorProvider {
+    SecurityContextHolder.getContext().authentication?.name ?: "System"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/JaversConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/JaversConfig.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import org.javers.spring.auditable.AuthorProvider
+import org.javers.spring.auditable.CommitPropertiesProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanEntity
 
 @Configuration
 class JaversConfig {
@@ -11,4 +13,21 @@ class JaversConfig {
   fun authorProvider(): AuthorProvider = AuthorProvider {
     SecurityContextHolder.getContext().authentication?.name ?: "System"
   }
+
+  @Bean
+  fun commitPropertiesProvider(): CommitPropertiesProvider = object : CommitPropertiesProvider {
+
+    override fun provideForCommittedObject(savedDomainObject: Any): Map<String, String> = propertiesFor(savedDomainObject)
+
+    override fun provideForDeletedObject(deletedDomainObject: Any): Map<String, String> = propertiesFor(deletedDomainObject)
+
+    private fun propertiesFor(domainObject: Any): Map<String, String> = when (domainObject) {
+      is ReleasePlanEntity -> releasePlanCommitProperties(domainObject)
+      else -> emptyMap()
+    }
+  }
+
+  private fun releasePlanCommitProperties(releasePlan: ReleasePlanEntity): Map<String, String> = mapOf(
+    "spaceBookingId" to releasePlan.spaceBooking.id.toString(),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/JaversConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/JaversConfig.kt
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.config
 
 import org.javers.spring.auditable.AuthorProvider
-import org.javers.spring.auditable.CommitPropertiesProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.core.context.SecurityContextHolder
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanEntity
 
 @Configuration
 class JaversConfig {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleaseActionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleaseActionEntity.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.javers.core.metamodel.annotation.Entity as JaversEntity
+import org.javers.core.metamodel.annotation.TypeName
+import java.util.UUID
+
+@Entity
+@JaversEntity
+@TypeName("ReleaseAction")
+@Table(name = "release_action")
+class ReleaseActionEntity(
+  @Id
+  val id: UUID,
+
+  var description: String,
+  var actionCadence: String,
+  var otherInformation: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleaseActionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleaseActionEntity.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.javers.core.metamodel.annotation.Entity as JaversEntity
 import org.javers.core.metamodel.annotation.TypeName
 import java.util.UUID
+import org.javers.core.metamodel.annotation.Entity as JaversEntity
 
 @Entity
 @JaversEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleaseActionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleaseActionEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.javers.core.metamodel.annotation.DiffIgnore
 import org.javers.core.metamodel.annotation.TypeName
 import java.util.UUID
 import org.javers.core.metamodel.annotation.Entity as JaversEntity
@@ -13,6 +14,7 @@ import org.javers.core.metamodel.annotation.Entity as JaversEntity
 @Table(name = "release_action")
 class ReleaseActionEntity(
   @Id
+  @DiffIgnore
   val id: UUID,
 
   var description: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleasePlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleasePlanEntity.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.javers.core.metamodel.annotation.DiffIgnore
+import org.javers.core.metamodel.annotation.Entity as JaversEntity
+import org.javers.core.metamodel.annotation.TypeName
+import org.javers.spring.annotation.JaversSpringDataAuditable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalTime
+import java.util.UUID
+
+@Repository
+@JaversSpringDataAuditable
+interface ReleasePlanRepository : JpaRepository<ReleasePlanEntity, UUID> {
+
+  fun getBySpaceBooking(spaceBooking: Cas1SpaceBookingEntity): List<ReleasePlanEntity>?
+}
+
+@Entity
+@JaversEntity
+@TypeName("ReleasePlan")
+@Table(name = "release_plan")
+class ReleasePlanEntity(
+  @Id
+  val id: UUID,
+
+  @ManyToOne
+  @DiffIgnore
+  val spaceBooking: Cas1SpaceBookingEntity,
+
+  var expectedReleaseTime: LocalTime?,
+
+  var expectedArrivalTime: LocalTime?,
+
+  var description: String?,
+
+  var otherInformation: String?,
+
+  @OneToMany(
+    cascade = [CascadeType.ALL],
+    orphanRemoval = true,
+  )
+  @JoinColumn(name = "release_plan_id", nullable = false)
+  var releaseActions: MutableList<ReleaseActionEntity> = mutableListOf(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleasePlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleasePlanEntity.kt
@@ -1,7 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import jakarta.persistence.CascadeType
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Embeddable
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -29,6 +34,7 @@ interface ReleasePlanRepository : JpaRepository<ReleasePlanEntity, UUID> {
 @Table(name = "release_plan")
 class ReleasePlanEntity(
   @Id
+  @DiffIgnore
   val id: UUID,
 
   @ManyToOne
@@ -49,4 +55,22 @@ class ReleasePlanEntity(
   )
   @JoinColumn(name = "release_plan_id", nullable = false)
   var releaseActions: MutableList<ReleaseActionEntity> = mutableListOf(),
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+    name = "monitoring_information",
+    joinColumns = [JoinColumn(name = "release_plan_id")],
+  )
+  var monitoringInformation: MutableList<MonitoringInformation> = mutableListOf(),
+)
+
+@TypeName("MonitoringInformation")
+@Embeddable
+@Table(name = "monitoring_information")
+class MonitoringInformation(
+  @Column(name = "monitoring_info_description")
+  var description: String?,
+  @Column(name = "monitoring_info_other_information")
+  var otherInformation: String?,
+
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleasePlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReleasePlanEntity.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
 import jakarta.persistence.CascadeType
-import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -9,13 +8,13 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.javers.core.metamodel.annotation.DiffIgnore
-import org.javers.core.metamodel.annotation.Entity as JaversEntity
 import org.javers.core.metamodel.annotation.TypeName
 import org.javers.spring.annotation.JaversSpringDataAuditable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalTime
 import java.util.UUID
+import org.javers.core.metamodel.annotation.Entity as JaversEntity
 
 @Repository
 @JaversSpringDataAuditable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JaversTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JaversTimelineService.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.javers.core.ChangesByCommit
+import org.javers.core.Javers
+import org.javers.repository.jql.QueryBuilder
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AuditRecordType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CreateFieldChange
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineRecord
+import java.util.UUID
+
+@Service
+class JaversTimelineService(
+  private val javers: Javers,
+) {
+
+  fun <T : Any> getFullAuditHistory(id: UUID, entityClass: Class<T>): List<TimelineRecord> {
+    val query = QueryBuilder.byInstanceId(id, entityClass)
+      .limit(200)
+      .build()
+
+    return javers.findChanges(query)
+      .groupByCommit()
+      .map { it.toTimelineRecord() }
+  }
+
+  private fun ChangesByCommit.toTimelineRecord(): TimelineRecord {
+    val commit = getCommit()
+    return TimelineRecord(
+      type = AuditRecordType.UPDATE,
+      author = commit.author,
+      commitDate = commit.commitDateInstant,
+      changes = get().map { it.toString() }.map { CreateFieldChange(field = "Change", value = it) },
+      extraInformation = mapOf("commitId" to commit.id.toString()),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JaversTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JaversTimelineService.kt
@@ -4,8 +4,6 @@ import org.javers.core.ChangesByCommit
 import org.javers.core.Javers
 import org.javers.repository.jql.QueryBuilder
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AuditRecordType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CreateFieldChange
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineRecord
 import java.util.UUID
 
@@ -27,11 +25,10 @@ class JaversTimelineService(
   private fun ChangesByCommit.toTimelineRecord(): TimelineRecord {
     val commit = getCommit()
     return TimelineRecord(
-      type = AuditRecordType.UPDATE,
       author = commit.author,
       commitDate = commit.commitDateInstant,
-      changes = get().map { it.toString() }.map { CreateFieldChange(field = "Change", value = it) },
-      extraInformation = mapOf("commitId" to commit.id.toString()),
+      //  changes = get().map { it.toString() }.map { TimelineSection() },
+      sections = TODO(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JaversTimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/JaversTimelineService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
-import org.javers.core.ChangesByCommit
 import org.javers.core.Javers
 import org.javers.repository.jql.QueryBuilder
 import org.springframework.stereotype.Service
@@ -10,25 +9,27 @@ import java.util.UUID
 @Service
 class JaversTimelineService(
   private val javers: Javers,
+  private val timelineMapper: TimeLineMapper,
 ) {
 
-  fun <T : Any> getFullAuditHistory(id: UUID, entityClass: Class<T>): List<TimelineRecord> {
-    val query = QueryBuilder.byInstanceId(id, entityClass)
+  fun getTimelineRecordsForSpaceBooking(spaceBookingId: UUID): List<TimelineRecord> {
+    val query = QueryBuilder.anyDomainObject()
+      .withCommitProperty(COMMIT_PROPERTY_SPACE_BOOKING_ID, spaceBookingId.toString())
       .limit(200)
       .build()
 
     return javers.findChanges(query)
       .groupByCommit()
-      .map { it.toTimelineRecord() }
+      .map { changesByCommit ->
+        TimelineRecord(
+          author = changesByCommit.commit.author,
+          commitDate = changesByCommit.commit.commitDateInstant,
+          sections = timelineMapper.buildSections(changesByCommit.get()),
+        )
+      }
   }
 
-  private fun ChangesByCommit.toTimelineRecord(): TimelineRecord {
-    val commit = getCommit()
-    return TimelineRecord(
-      author = commit.author,
-      commitDate = commit.commitDateInstant,
-      //  changes = get().map { it.toString() }.map { TimelineSection() },
-      sections = TODO(),
-    )
+  companion object {
+    private const val COMMIT_PROPERTY_SPACE_BOOKING_ID = "spaceBookingId"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TimeLineMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TimeLineMapper.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.javers.core.diff.Change
+import org.javers.core.diff.changetype.InitialValueChange
+import org.javers.core.diff.changetype.NewObject
+import org.javers.core.diff.changetype.ObjectRemoved
+import org.javers.core.diff.changetype.PropertyChange
+import org.javers.core.diff.changetype.TerminalValueChange
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.diff.changetype.container.ContainerChange
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AuditEntityType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ChangeType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineChange
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineSection
+
+@Component
+class TimeLineMapper {
+
+  fun buildSections(changes: List<Change>): List<TimelineSection> = changes
+    .groupBy { it.toAuditEntityType() }
+    .filter { it.key != null }
+    .map { (entityType, changesForType) ->
+      TimelineSection(
+        entityType = entityType!!,
+        changes = changesForType.map { it.toTimelineChange() },
+      )
+    }
+
+  private fun Change.toAuditEntityType(): AuditEntityType? = when {
+    affectedGlobalId.value().contains("ReleaseAction") -> AuditEntityType.RELEASE_ACTION
+    affectedGlobalId.value().contains("ReleasePlan") -> AuditEntityType.RELEASE_PLAN
+    affectedGlobalId.value().contains("MonitoringInformation") -> AuditEntityType.MONITORING_INFORMATION
+    else -> null
+  }
+
+  private fun Change.toTimelineChange(): TimelineChange = when (this) {
+    is InitialValueChange -> TimelineChange(
+      changeType = ChangeType.CREATE,
+      message = "Created ${objectLabel()} with ${fieldLabel()} '${right.toTimelineValue()}'",
+      field = fieldLabel(),
+      newValue = right.toTimelineValue(),
+    )
+
+    is TerminalValueChange -> TimelineChange(
+      changeType = ChangeType.DELETE,
+      message = "Deleted ${objectLabel()} with ${fieldLabel()} '${left.toTimelineValue()}'",
+      field = fieldLabel(),
+      oldValue = left.toTimelineValue(),
+    )
+
+    is ValueChange -> TimelineChange(
+      changeType = ChangeType.UPDATE,
+      message = "${fieldLabel().capitalize()} changed from '${left.toTimelineValue()}' to '${right.toTimelineValue()}'",
+      field = fieldLabel(),
+      oldValue = left.toTimelineValue(),
+      newValue = right.toTimelineValue(),
+    )
+
+    is ContainerChange<*> ->
+      TimelineChange(
+        changeType = ChangeType.UPDATE,
+        message = "${fieldLabel().capitalize()} changed from '${left.toTimelineValue()}' to '${right.toTimelineValue()}'",
+        field = fieldLabel(),
+        oldValue = left.toTimelineValue(),
+        newValue = right.toTimelineValue(),
+      )
+
+    is NewObject -> TimelineChange(
+      changeType = ChangeType.CREATE,
+      message = "Created ${objectLabel()}",
+    )
+
+    is ObjectRemoved -> TimelineChange(
+      changeType = ChangeType.DELETE,
+      message = "Deleted ${objectLabel()}",
+    )
+
+    else -> TimelineChange(
+      changeType = ChangeType.UPDATE,
+      message = "Updated ${objectLabel()}",
+    )
+  }
+
+  private fun PropertyChange<*>.fieldLabel(): String = getPropertyNameWithPath().toDisplayName()
+
+  private fun Change.objectLabel(): String = when {
+    affectedGlobalId.value().contains("ReleaseAction") -> "release action"
+    affectedGlobalId.value().contains("ReleasePlan") -> "release plan"
+    affectedGlobalId.value().contains("MonitoringInformation") -> "monitoring information"
+    else -> "object"
+  }
+
+  private fun String.toDisplayName(): String = split(Regex("(?=\\p{Upper})|_"))
+    .filter { it.isNotBlank() }
+    .joinToString(" ") { it.lowercase() }
+
+  private fun Any?.toTimelineValue(): String? = when (this) {
+    null -> null
+    is Collection<*> -> joinToString(prefix = "[", postfix = "]") { it.toTimelineValue().orEmpty() }
+    else -> toString()
+  }
+
+  private fun String.capitalize() = replaceFirstChar { it.uppercase() }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TimelineMapperV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TimelineMapperV2.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.javers.core.ChangesByCommit
+import org.javers.core.diff.Change
+import org.javers.core.diff.changetype.NewObject
+import org.javers.core.diff.changetype.ObjectRemoved
+import org.javers.core.diff.changetype.PropertyChange
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.diff.changetype.container.ContainerChange
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ChangeType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineChange
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineRecordV2
+
+@Component
+class TimelineMapperV2 {
+
+  fun toTimelineRecord(commitChanges: ChangesByCommit): TimelineRecordV2 {
+    val commit = commitChanges.commit
+
+    val changes = commitChanges.get()
+      .filterNot { it.isNoise() }
+      .mapNotNull { it.toTimelineChange() }
+
+    return TimelineRecordV2(
+      author = commit.author,
+      commitDate = commit.commitDateInstant,
+      message = buildCommitMessage(changes),
+      changes = changes,
+    )
+  }
+
+  private fun buildCommitMessage(changes: List<TimelineChange>): String {
+    val hasCreate = changes.any { it.changeType == ChangeType.CREATE }
+    val hasUpdate = changes.any { it.changeType == ChangeType.UPDATE }
+    val hasDelete = changes.any { it.changeType == ChangeType.DELETE }
+
+    return when {
+      hasCreate && hasUpdate -> "Release plan updated"
+      hasCreate -> "Release plan created"
+      hasDelete && !hasCreate -> "Release plan deleted"
+      else -> "Release plan updated"
+    }
+  }
+
+  private fun Change.toTimelineChange(): TimelineChange? = when (this) {
+    /**
+     * For CREATE commit
+     */
+    /*    is InitialValueChange -> TimelineChange(
+      changeType = ChangeType.CREATE,
+      message = "Created ${objectLabel()} with ${fieldLabel()} '${right.toTimelineValue()}'",
+      field = fieldLabel(),
+      newValue = right.toTimelineValue(),
+    )*/
+
+    /**
+     * For DELTET commit
+     */
+
+    /*    is TerminalValueChange -> TimelineChange(
+          changeType = ChangeType.DELETE,
+          message = "Deleted ${objectLabel()} with ${fieldLabel()} '${left.toTimelineValue()}'",
+          field = fieldLabel(),
+          oldValue = left.toTimelineValue(),
+        )*/
+
+    /**
+     * For UPDATE commit using collections
+     */
+
+    /*    is ContainerChange<*> -> TimelineChange(
+          changeType = ChangeType.UPDATE,
+          message = "${fieldLabel().capitalize()} changed",
+          field = fieldLabel(),
+          oldValue = left.toTimelineValue(),
+          newValue = right.toTimelineValue(),
+        )*/
+
+    is ValueChange ->
+      if (left == null || right == null) {
+        return null
+      } else {
+        TimelineChange(
+          changeType = ChangeType.UPDATE,
+          message = "${fieldLabel().capitalize()} changed from '${left.toTimelineValue()}' to '${right.toTimelineValue()}'",
+          field = fieldLabel(),
+          oldValue = left.toTimelineValue(),
+          newValue = right.toTimelineValue(),
+        )
+      }
+
+    is NewObject -> TimelineChange(
+      changeType = ChangeType.CREATE,
+      message = "Created ${objectLabel()}",
+    )
+
+    is ObjectRemoved -> TimelineChange(
+      changeType = ChangeType.DELETE,
+      message = "Deleted ${objectLabel()}",
+    )
+
+    else -> null
+  }
+
+  private fun Change.isNoise(): Boolean = this is ContainerChange<*> &&
+    getPropertyNameWithPath() in setOf(
+      "releaseActions",
+      "monitoringInformation",
+    )
+
+  private fun PropertyChange<*>.fieldLabel(): String = getPropertyNameWithPath()
+    .split(Regex("(?=\\p{Upper})|_"))
+    .filter { it.isNotBlank() }
+    .joinToString(" ") { it.lowercase() }
+
+  private fun Change.objectLabel(): String = when {
+    affectedGlobalId.value().contains("ReleaseAction") -> "release action"
+    affectedGlobalId.value().contains("ReleasePlan") -> "release plan"
+    affectedGlobalId.value().contains("MonitoringInformation") -> "monitoring information"
+    else -> "object"
+  }
+
+  private fun Any?.toTimelineValue(): String? = when (this) {
+    null -> null
+    is Collection<*> -> joinToString(prefix = "[", postfix = "]") { it.toTimelineValue().orEmpty() }
+    else -> toString()
+  }
+
+  private fun String.capitalize(): String = replaceFirstChar { it.uppercase() }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TimelineService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/TimelineService.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
+
+import org.javers.core.Javers
+import org.javers.repository.jql.QueryBuilder
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineRecordV2
+import java.util.UUID
+
+@Service
+class TimelineService(
+  private val javers: Javers,
+  private val timelineMapperV2: TimelineMapperV2,
+) {
+
+  fun getTimelineRecordsForSpaceBooking(
+    spaceBookingId: UUID,
+  ): List<TimelineRecordV2> {
+    val query = QueryBuilder.anyDomainObject()
+      .withCommitProperty(
+        COMMIT_PROPERTY_SPACE_BOOKING_ID,
+        spaceBookingId.toString(),
+      )
+      .limit(200)
+      .build()
+
+    return javers.findChanges(query)
+      .groupByCommit()
+      .map { timelineMapperV2.toTimelineRecord(it) }
+  }
+
+  companion object {
+    private const val COMMIT_PROPERTY_SPACE_BOOKING_ID = "spaceBookingId"
+  }
+}

--- a/src/main/resources/db/migration/all/20260603120000__add_release_plan_tables.sql
+++ b/src/main/resources/db/migration/all/20260603120000__add_release_plan_tables.sql
@@ -1,0 +1,25 @@
+CREATE TABLE release_plan
+(
+    id                    UUID NOT NULL,
+    space_booking_id      UUID NOT NULL,
+    expected_release_time TIME,
+    expected_arrival_time TIME,
+    description           TEXT,
+    other_information     TEXT,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_release_plan_space_booking FOREIGN KEY (space_booking_id) REFERENCES cas1_space_bookings (id)
+);
+
+CREATE TABLE release_action
+(
+    id                UUID NOT NULL,
+    release_plan_id   UUID NOT NULL,
+    description       TEXT NOT NULL,
+    action_cadence    TEXT NOT NULL,
+    other_information TEXT,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_release_action_release_plan FOREIGN KEY (release_plan_id) REFERENCES release_plan (id)
+);
+
+CREATE INDEX idx_release_action_release_plan_id
+    ON release_action(release_plan_id);

--- a/src/main/resources/db/migration/all/20260603120000__add_release_plan_tables.sql
+++ b/src/main/resources/db/migration/all/20260603120000__add_release_plan_tables.sql
@@ -23,3 +23,11 @@ CREATE TABLE release_action
 
 CREATE INDEX idx_release_action_release_plan_id
     ON release_action(release_plan_id);
+
+create table monitoring_information
+(
+    release_plan_id   UUID NOT NULL,
+    monitoring_info_description       TEXT NOT NULL,
+    monitoring_info_other_information TEXT,
+    CONSTRAINT fk_monitoring_information_release_plan FOREIGN KEY (release_plan_id) REFERENCES release_plan (id)
+)

--- a/src/main/resources/db/migration/all/20260603121000__add_javers_tables.sql
+++ b/src/main/resources/db/migration/all/20260603121000__add_javers_tables.sql
@@ -1,0 +1,59 @@
+CREATE SEQUENCE jv_global_id_pk_seq START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE jv_commit_pk_seq START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE jv_snapshot_pk_seq START WITH 1 INCREMENT BY 1;
+
+CREATE TABLE jv_global_id
+(
+    global_id_pk BIGINT NOT NULL,
+    local_id     VARCHAR(191),
+    fragment     VARCHAR(200),
+    type_name    VARCHAR(200),
+    owner_id_fk  BIGINT,
+    PRIMARY KEY (global_id_pk),
+    CONSTRAINT jv_global_id_owner_id_fk FOREIGN KEY (owner_id_fk) REFERENCES jv_global_id (global_id_pk)
+);
+
+CREATE INDEX jv_global_id_local_id_idx ON jv_global_id (local_id);
+CREATE INDEX jv_global_id_owner_id_fk_idx ON jv_global_id (owner_id_fk);
+
+CREATE TABLE jv_commit
+(
+    commit_pk           BIGINT NOT NULL,
+    author              VARCHAR(200),
+    commit_date         TIMESTAMP,
+    commit_date_instant VARCHAR(30),
+    commit_id           NUMERIC(22, 2),
+    PRIMARY KEY (commit_pk)
+);
+
+CREATE INDEX jv_commit_commit_id_idx ON jv_commit (commit_id);
+
+CREATE TABLE jv_commit_property
+(
+    commit_fk      BIGINT NOT NULL,
+    property_name  VARCHAR(191) NOT NULL,
+    property_value VARCHAR(600),
+    PRIMARY KEY (commit_fk, property_name),
+    CONSTRAINT jv_commit_property_commit_fk FOREIGN KEY (commit_fk) REFERENCES jv_commit (commit_pk)
+);
+
+CREATE INDEX jv_commit_property_commit_fk_idx ON jv_commit_property (commit_fk);
+CREATE INDEX jv_commit_property_property_name_property_value_idx ON jv_commit_property (property_name, property_value);
+
+CREATE TABLE jv_snapshot
+(
+    snapshot_pk        BIGINT NOT NULL,
+    type               VARCHAR(200),
+    version            BIGINT,
+    state              TEXT,
+    changed_properties TEXT,
+    managed_type       VARCHAR(200),
+    global_id_fk       BIGINT,
+    commit_fk          BIGINT,
+    PRIMARY KEY (snapshot_pk),
+    CONSTRAINT jv_snapshot_global_id_fk FOREIGN KEY (global_id_fk) REFERENCES jv_global_id (global_id_pk),
+    CONSTRAINT jv_snapshot_commit_fk FOREIGN KEY (commit_fk) REFERENCES jv_commit (commit_pk)
+);
+
+CREATE INDEX jv_snapshot_global_id_fk_idx ON jv_snapshot (global_id_fk);
+CREATE INDEX jv_snapshot_commit_fk_idx ON jv_snapshot (commit_fk);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/JaversPocTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/JaversPocTest.kt
@@ -1,16 +1,19 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
 
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.test.context.support.WithMockUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineRecord
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateFieldChange
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MonitoringInformation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleaseActionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JaversTimelineService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.TimelineService
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -23,25 +26,47 @@ class JaversPocTest : IntegrationTestBase() {
   @Autowired
   lateinit var javersTimelineService: JaversTimelineService
 
+  @Autowired
+  lateinit var timelineService: TimelineService
+
   @Test
   @WithMockUser(username = "audit_user")
   fun `print all audit timeline entries for a space booking`() {
     val spaceBooking = createSpaceBooking()
 
+    /**
+     * Create release plan
+     */
     val releasePlan = createReleasePlan(spaceBooking, "Initial Plan")
+    releasePlanRepository.saveAndFlush(releasePlan)
+
+    /**
+     * Create release action and monitoring information
+     */
     val action1 = ReleaseActionEntity(
       id = UUID.randomUUID(),
       description = "Action 1",
       actionCadence = "Daily",
     )
 
-    releasePlan.releaseActions.add(action1)
-    releasePlanRepository.save(releasePlan)
-    releasePlanRepository.flush()
+    val monitoringInformation = MonitoringInformation(
+      description = "some description",
+      otherInformation = null,
+    )
 
+    releasePlan.releaseActions.add(action1)
+    releasePlan.monitoringInformation.add(monitoringInformation)
+    releasePlanRepository.saveAndFlush(releasePlan)
+
+    /**
+     * Update release plan
+     */
     releasePlan.description = "Updated Plan"
     releasePlan.expectedReleaseTime = LocalTime.of(11, 0)
 
+    /**
+     * Add release action and remove the release action
+     */
     val action2 = ReleaseActionEntity(
       id = UUID.randomUUID(),
       description = "Action 2",
@@ -49,50 +74,33 @@ class JaversPocTest : IntegrationTestBase() {
     )
 
     releasePlan.releaseActions.add(action2)
-    releasePlanRepository.save(releasePlan)
-    releasePlanRepository.flush()
-
     releasePlan.releaseActions.remove(action1)
-    action2.description = "Modified Action 2"
-
-    releasePlanRepository.save(releasePlan)
-    releasePlanRepository.flush()
-
-    releasePlanRepository.delete(releasePlan)
-
-    val timelines = javersTimelineService.getFullAuditHistory(releasePlan.id, ReleasePlanEntity::class.java)
+    releasePlanRepository.saveAndFlush(releasePlan)
 
     /**
-     *UPDATE by audit_user on 2026-06-03T12:20:31.724134Z
-     * - Change: 'ObjectRemoved{ object removed: ReleasePlan/ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1 }'
-     * - Change: 'TerminalValueChange{ property: 'id', left:'ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1',  right:'' }'
-     * - Change: 'TerminalValueChange{ property: 'expectedReleaseTime', left:'11:00:00',  right:'' }'
-     * - Change: 'TerminalValueChange{ property: 'expectedArrivalTime', left:'14:00:00',  right:'' }'
-     * - Change: 'TerminalValueChange{ property: 'description', left:'Updated Plan',  right:'' }'
-     * - Change: 'TerminalValueChange{ property: 'otherInformation', left:'Info',  right:'' }'
-     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:1, left.size: 1, right.size: 0}'
-     *
-     * UPDATE by audit_user on 2026-06-03T12:20:31.652459Z
-     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:2, left.size: 2, right.size: 1}'
-     *
-     * UPDATE by audit_user on 2026-06-03T12:20:31.593295Z
-     * - Change: 'ValueChange{ property: 'expectedReleaseTime', left:'10:00:00',  right:'11:00:00' }'
-     * - Change: 'ValueChange{ property: 'description', left:'Initial Plan',  right:'Updated Plan' }'
-     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:1, left.size: 1, right.size: 2}'
-     *
-     * UPDATE by audit_user on 2026-06-03T12:20:31.524545Z
-     * - Change: 'NewObject{ new object: ReleasePlan/ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1 }'
-     * - Change: 'InitialValueChange{ property: 'id', left:'',  right:'ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1' }'
-     * - Change: 'InitialValueChange{ property: 'expectedReleaseTime', left:'',  right:'10:00:00' }'
-     * - Change: 'InitialValueChange{ property: 'expectedArrivalTime', left:'',  right:'14:00:00' }'
-     * - Change: 'InitialValueChange{ property: 'description', left:'',  right:'Initial Plan' }'
-     * - Change: 'InitialValueChange{ property: 'otherInformation', left:'',  right:'Info' }'
-     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:1, left.size: 0, right.size: 1}'
+     * Delete release plan
      */
+    releasePlanRepository.delete(releasePlan)
 
-    println("--- JaVers Timeline Records ---")
-    timelines.forEach { println(it.renderForPoc()) }
-    println("-------------------------------")
+    val mapper = JsonMapper.builder()
+      .addModule(JavaTimeModule())
+      .enable(SerializationFeature.INDENT_OUTPUT)
+      .build()
+
+    println("********TimelineRecordsV1************")
+
+    val timelinesV1 = javersTimelineService.getTimelineRecordsForSpaceBooking(spaceBooking.id)
+
+    println(mapper.writeValueAsString(timelinesV1))
+
+    println("*****************************")
+
+    println("********TimelineRecordsV2************")
+
+    val timelinesV2 = timelineService.getTimelineRecordsForSpaceBooking(spaceBooking.id)
+
+    println(mapper.writeValueAsString(timelinesV2))
+    println("*****************************")
   }
 
   private fun createSpaceBooking(): Cas1SpaceBookingEntity = givenACas1SpaceBooking(
@@ -115,7 +123,7 @@ class JaversPocTest : IntegrationTestBase() {
   )
 }
 
-private fun TimelineRecord.renderForPoc(): String = buildString {
+/*private fun TimelineRecord.renderForPoc(): String = buildString {
   appendLine("$type by $author on $commitDate")
   changes.forEach { change ->
     when (change) {
@@ -123,4 +131,4 @@ private fun TimelineRecord.renderForPoc(): String = buildString {
       else -> appendLine("- ${change.field}: '${change.value}'")
     }
   }
-}
+}*/

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/JaversPocTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/JaversPocTest.kt
@@ -1,0 +1,126 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.context.support.WithMockUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineRecord
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateFieldChange
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1SpaceBooking
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleaseActionEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReleasePlanRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.JaversTimelineService
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+class JaversPocTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var releasePlanRepository: ReleasePlanRepository
+
+  @Autowired
+  lateinit var javersTimelineService: JaversTimelineService
+
+  @Test
+  @WithMockUser(username = "audit_user")
+  fun `print all audit timeline entries for a space booking`() {
+    val spaceBooking = createSpaceBooking()
+
+    val releasePlan = createReleasePlan(spaceBooking, "Initial Plan")
+    val action1 = ReleaseActionEntity(
+      id = UUID.randomUUID(),
+      description = "Action 1",
+      actionCadence = "Daily",
+    )
+
+    releasePlan.releaseActions.add(action1)
+    releasePlanRepository.save(releasePlan)
+    releasePlanRepository.flush()
+
+    releasePlan.description = "Updated Plan"
+    releasePlan.expectedReleaseTime = LocalTime.of(11, 0)
+
+    val action2 = ReleaseActionEntity(
+      id = UUID.randomUUID(),
+      description = "Action 2",
+      actionCadence = "Weekly",
+    )
+
+    releasePlan.releaseActions.add(action2)
+    releasePlanRepository.save(releasePlan)
+    releasePlanRepository.flush()
+
+    releasePlan.releaseActions.remove(action1)
+    action2.description = "Modified Action 2"
+
+    releasePlanRepository.save(releasePlan)
+    releasePlanRepository.flush()
+
+    releasePlanRepository.delete(releasePlan)
+
+    val timelines = javersTimelineService.getFullAuditHistory(releasePlan.id, ReleasePlanEntity::class.java)
+
+    /**
+     *UPDATE by audit_user on 2026-06-03T12:20:31.724134Z
+     * - Change: 'ObjectRemoved{ object removed: ReleasePlan/ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1 }'
+     * - Change: 'TerminalValueChange{ property: 'id', left:'ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1',  right:'' }'
+     * - Change: 'TerminalValueChange{ property: 'expectedReleaseTime', left:'11:00:00',  right:'' }'
+     * - Change: 'TerminalValueChange{ property: 'expectedArrivalTime', left:'14:00:00',  right:'' }'
+     * - Change: 'TerminalValueChange{ property: 'description', left:'Updated Plan',  right:'' }'
+     * - Change: 'TerminalValueChange{ property: 'otherInformation', left:'Info',  right:'' }'
+     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:1, left.size: 1, right.size: 0}'
+     *
+     * UPDATE by audit_user on 2026-06-03T12:20:31.652459Z
+     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:2, left.size: 2, right.size: 1}'
+     *
+     * UPDATE by audit_user on 2026-06-03T12:20:31.593295Z
+     * - Change: 'ValueChange{ property: 'expectedReleaseTime', left:'10:00:00',  right:'11:00:00' }'
+     * - Change: 'ValueChange{ property: 'description', left:'Initial Plan',  right:'Updated Plan' }'
+     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:1, left.size: 1, right.size: 2}'
+     *
+     * UPDATE by audit_user on 2026-06-03T12:20:31.524545Z
+     * - Change: 'NewObject{ new object: ReleasePlan/ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1 }'
+     * - Change: 'InitialValueChange{ property: 'id', left:'',  right:'ff527f4a-40b5-4ed3-a0b8-9e3c07a2a3f1' }'
+     * - Change: 'InitialValueChange{ property: 'expectedReleaseTime', left:'',  right:'10:00:00' }'
+     * - Change: 'InitialValueChange{ property: 'expectedArrivalTime', left:'',  right:'14:00:00' }'
+     * - Change: 'InitialValueChange{ property: 'description', left:'',  right:'Initial Plan' }'
+     * - Change: 'InitialValueChange{ property: 'otherInformation', left:'',  right:'Info' }'
+     * - Change: 'ListChange{ property: 'releaseActions', elementChanges:1, left.size: 0, right.size: 1}'
+     */
+
+    println("--- JaVers Timeline Records ---")
+    timelines.forEach { println(it.renderForPoc()) }
+    println("-------------------------------")
+  }
+
+  private fun createSpaceBooking(): Cas1SpaceBookingEntity = givenACas1SpaceBooking(
+    crn = "CRN123",
+    actualArrivalDate = null,
+    expectedArrivalDate = LocalDate.of(2025, 3, 25),
+    expectedDepartureDate = LocalDate.of(2025, 4, 10),
+    cancellationOccurredAt = null,
+    nonArrivalConfirmedAt = null,
+  )
+
+  private fun createReleasePlan(spaceBooking: Cas1SpaceBookingEntity, description: String): ReleasePlanEntity = ReleasePlanEntity(
+    id = UUID.randomUUID(),
+    spaceBooking = spaceBooking,
+    expectedReleaseTime = LocalTime.of(10, 0),
+    expectedArrivalTime = LocalTime.of(14, 0),
+    description = description,
+    otherInformation = "Info",
+    releaseActions = mutableListOf(),
+  )
+}
+
+private fun TimelineRecord.renderForPoc(): String = buildString {
+  appendLine("$type by $author on $commitDate")
+  changes.forEach { change ->
+    when (change) {
+      is UpdateFieldChange -> appendLine("- ${change.field}: '${change.oldValue}' -> '${change.value}'")
+      else -> appendLine("- ${change.field}: '${change.value}'")
+    }
+  }
+}


### PR DESCRIPTION
From my initial Javers PoC, it seems much easier to generate the timeline JSON with minimal engineering effort. Unlike Envers, which primarily tracks entity revisions, Javers tracks object-level changes and relationships within the object graph.

Based on what I've seen so far, Javers appears to be a better fit if our primary goal is to provide users with a timeline of changes. It can capture creates, updates, deletes, and collection changes with significantly less custom logic than the Envers approach.

In my PoC, I performed a simple exercise by porting a timeline record from SAS. SAS is primarily interested in timelines at the individual entity level, whereas our requirement is to generate timelines at the Space Booking level.

I haven't spent much time implementing that part yet, but based on what I've seen so far, it appears to require some additional development to set up a CommitPropertiesProvider so that Space Booking context can be associated with each commit and later used as a queryable property when retrieving timeline entries.

Assuming that approach works as expected, we should be able to retrieve all changes related to a Space Booking without having to reconstruct the timeline from entity relationships, which is one of the areas where the Envers solution becomes more complex.

********************************
I like Envers from an ORM and persistence perspective, as it integrates naturally with Hibernate and provides automatic auditing with minimal setup. However, when it comes to the complex queries and aggregation logic required to build a user-facing timeline, Javers provides much more out-of-the-box functionality.

As a result, I'm increasingly leaning towards Javers for this particular use case. From a UI perspective, it aligns more closely with our requirements and significantly reduces the amount of custom code needed to generate timeline events.

The main limitation with Envers, in my view, is the additional effort required whenever we introduce a new entity to audit or need to expose new types of changes in the timeline. This typically involves adding new audit queries and updating aggregation logic. In contrast, with Javers, this is largely handled automatically, which reduces ongoing maintenance overhead.
*******************************
