### PR TITLE
SAS-467: Referral history add name back into the Cas3StaffDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3StaffDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3StaffDto.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
 
 data class Cas3StaffDto(
+  val name: String,
   val username: String,
   val staffCode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -140,5 +140,5 @@ class Cas3AssessmentTransformer(
     null -> null
   }
 
-  fun transformToCas3StaffDto(user: UserEntity) = Cas3StaffDto(user.deliusUsername, user.deliusStaffCode)
+  fun transformToCas3StaffDto(user: UserEntity) = Cas3StaffDto(user.name, user.deliusUsername, user.deliusStaffCode)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
@@ -161,7 +161,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
     }
   }
 
-  private fun createCas3StaffDto(user: UserEntity) = Cas3StaffDto(user.deliusUsername, user.deliusStaffCode)
+  private fun createCas3StaffDto(user: UserEntity) = Cas3StaffDto(user.name, user.deliusUsername, user.deliusStaffCode)
 
   private fun createAssessment(
     user: UserEntity,


### PR DESCRIPTION
Adds the staff **name** back onto the CAS3 referral history “referredBy” payload by extending `Cas3StaffDto` and updating the transformer + integration test to populate/assert it.

**Changes:**
- Extend `Cas3StaffDto` with a new `name` field.
- Populate `name` when transforming `UserEntity` → `Cas3StaffDto` in `Cas3AssessmentTransformer`.
- Update the external referral integration test helper to construct the updated DTO.