### PR TITLE
FM-550 - Adds CAS2V2 ROSH Summary Endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2V2OASysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2V2OASysController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRiskToSelfDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRoshSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2OASysTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
@@ -38,5 +39,17 @@ class Cas2V2OASysController(
     }
 
     return ResponseEntity.ok(cas2v2OASysTransformer.toOASysRiskToSelfDto(risksToTheIndividual))
+  }
+
+  @GetMapping("/people/{crn}/oasys/rosh-summary")
+  fun getRoshSummary(
+    @PathVariable crn: String,
+  ): ResponseEntity<Cas2v2OAsysRoshSummaryDto> {
+    val roshSummary = when (val result = oasysService.getRoshSummary(crn)) {
+      is CasResult.NotFound -> null
+      else -> extractEntityFromCasResult(result)
+    }
+
+    return ResponseEntity.ok(cas2v2OASysTransformer.toOASysRoshSummaryDto(roshSummary))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/model/Cas2v2OAsysRoshSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/model/Cas2v2OAsysRoshSummaryDto.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model
+
+data class Cas2v2OAsysRoshSummaryDto(
+  val metadata: Cas2v2OASysAssessmentMetadataDto,
+  val whoIsAtRisk: String?,
+  val natureOfRisk: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2OASysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/transformer/Cas2v2OASysTransformer.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRiskToSelfDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRoshSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 
 @Service
 class Cas2v2OASysTransformer {
@@ -23,5 +25,15 @@ class Cas2v2OASysTransformer {
     ),
     analysisSuicideSelfharm = risksToTheIndividual?.riskToTheIndividual?.analysisSuicideSelfharm,
     analysisVulnerabilities = risksToTheIndividual?.riskToTheIndividual?.analysisVulnerabilities,
+  )
+
+  fun toOASysRoshSummaryDto(roshSummary: RoshSummary?) = Cas2v2OAsysRoshSummaryDto(
+    metadata = Cas2v2OASysAssessmentMetadataDto(
+      hasApplicableAssessment = roshSummary != null,
+      dateStarted = roshSummary?.initiationDate?.toInstant(),
+      dateCompleted = roshSummary?.dateCompleted?.toInstant(),
+    ),
+    whoIsAtRisk = roshSummary?.roshSummary?.whoIsAtRisk,
+    natureOfRisk = roshSummary?.roshSummary?.natureOfRisk,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
@@ -7,11 +7,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OASysAssessmentMetadataDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRiskToSelfDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.model.Cas2v2OAsysRoshSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockAssessmentSummaryNotFound
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskToTheIndividual404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRoSHSummary404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOAsysMockAssessmentSummaryResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 
@@ -132,6 +136,66 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
         .expectStatus()
         .isOk
         .bodyAsObject<Cas2v2OAsysRiskToSelfDto>()
+
+      assertThat(result.metadata.hasApplicableAssessment).isTrue
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /cas2v2/people/{crn}/oasys/rosh-summary")
+  inner class GetRoshSummary {
+
+    @Test
+    fun `Get without JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Cas2v2NonReferrerRoles
+    @ParameterizedTest
+    fun `Get without referrer role returns 403`(role: RoleAndAuthSource) {
+      webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .addJwtForRoleAndAuthSource(role)
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Cas2v2ReferrerRoles
+    @ParameterizedTest
+    fun `Assessment not available`(role: RoleAndAuthSource) {
+      apAndOASysMockRoSHSummary404Call("CRN123")
+
+      val result = webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .addJwtForRoleAndAuthSource(role)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas2v2OAsysRoshSummaryDto>()
+
+      assertThat(result.metadata.hasApplicableAssessment).isFalse
+    }
+
+    @Cas2v2ReferrerRoles
+    @ParameterizedTest
+    fun `Assessment available`(role: RoleAndAuthSource) {
+      apAndOASysMockSuccessfulRoSHSummaryCall(
+        crn = "CRN123",
+        response = RoshSummaryFactory().produce(),
+      )
+
+      val result = webTestClient.get()
+        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .addJwtForRoleAndAuthSource(role)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas2v2OAsysRoshSummaryDto>()
 
       assertThat(result.metadata.hasApplicableAssessment).isTrue
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2OASysTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2OASysTransformerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.transformer.Cas2v2OASysTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.client.apandoasys.OASysAssessmentSummaryFactory
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -72,6 +73,41 @@ class Cas2v2OASysTransformerTest {
 
       assertThat(result.analysisSuicideSelfharm).isNull()
       assertThat(result.analysisVulnerabilities).isNull()
+    }
+  }
+
+  @Nested
+  inner class ToCas2v2OAsysRoshSummaryDto {
+
+    @Test
+    fun found() {
+      val result = transformer.toOASysRoshSummaryDto(
+        RoshSummaryFactory()
+          .withWhoAtRisk("who at risk answer")
+          .withNatureOfRisk("nature of risk answer")
+          .withInitiationDate(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"))
+          .withDateCompleted(OffsetDateTime.parse("2008-12-03T10:15:30+01:00"))
+          .produce(),
+      )
+
+      assertThat(result.metadata.hasApplicableAssessment).isTrue()
+      assertThat(result.metadata.dateStarted).isEqualTo(Instant.parse("2007-12-03T10:15:30+01:00"))
+      assertThat(result.metadata.dateCompleted).isEqualTo(Instant.parse("2008-12-03T10:15:30+01:00"))
+
+      assertThat(result.whoIsAtRisk).isEqualTo("who at risk answer")
+      assertThat(result.natureOfRisk).isEqualTo("nature of risk answer")
+    }
+
+    @Test
+    fun not_found() {
+      val result = transformer.toOASysRoshSummaryDto(null)
+
+      assertThat(result.metadata.hasApplicableAssessment).isFalse()
+      assertThat(result.metadata.dateStarted).isNull()
+      assertThat(result.metadata.dateCompleted).isNull()
+
+      assertThat(result.whoIsAtRisk).isNull()
+      assertThat(result.natureOfRisk).isNull()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
@@ -26,6 +26,12 @@ fun IntegrationTestBase.apAndOASysMockSuccessfulRoSHSummaryCall(crn: String, res
   responseBody = response,
 )
 
+fun IntegrationTestBase.apAndOASysMockRoSHSummary404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+  url = "/rosh-summary/$crn",
+  responseStatus = 404,
+  delayMs = 0,
+)
+
 fun IntegrationTestBase.apAndOASysMockSuccessfulRiskToTheIndividualCall(crn: String, response: RisksToTheIndividual) = mockSuccessfulGetCallWithJsonResponse(
   url = "/risk-to-the-individual/$crn",
   responseBody = response,


### PR DESCRIPTION
## Summary

Adds a new CASv2 OASys ROSH Summary endpoint to retrieve ROSH Summary assessment data from OASys.

## Changes

- Added ROSH Summary endpoint: `GET  /cas2v2/people/{crn}oasys/rosh-summary`
- Added `Cas2v2OASysRoshSummaryDto`
- Added ROSH Summary mapping in transformer
- Included assessment metadata (`hasApplicableAssessment`, `dateStarted`, `dateCompleted`)
  
## Testing 

- All unit tests pass locally
- All integration tests pass locally