### PR TITLE
FM-506 Add `suitability strategy` to CAS1 OASys endpoint

### DIFF
--- a/doc/how-to/define_an_api.md
+++ b/doc/how-to/define_an_api.md
@@ -22,7 +22,7 @@ enum class EventChangeRequestType(@get:JsonValue val value: String) {
     companion object {
         @JvmStatic
         @JsonCreator
-        fun forValue(value: kotlin.String) = values().first { it.value == value }
+        fun forValue(value: String) = entries.first { it.value == value }
     }
 }
 ```

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/OASysAssessmentSuitabilityStrategyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/OASysAssessmentSuitabilityStrategyDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class OASysAssessmentSuitabilityStrategyDto(@get:JsonValue val value: String) {
+  ALLOW_ALL("allow_all"),
+  COMPLETED_IN_LAST_SIX_MONTHS("completed_in_last_six_months"),
+  ;
+
+  companion object {
+    @JvmStatic
+    @JsonCreator
+    fun forValue(value: String) = entries.first { it.value == value }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas1/Cas1OasysController.kt
@@ -16,13 +16,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysGroupName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1OASysMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Problem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.OASysAssessmentSuitabilityStrategyDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetailsInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskToTheIndividualInner
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService.SuitabilityStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1UserAccessService
@@ -30,7 +31,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1CreateApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysAssessmentInfoTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysNeedsQuestionTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysOffenceDetailsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 
 @Cas1Controller
@@ -42,7 +42,6 @@ class Cas1OasysController(
   private val oaSysService: OASysService,
   private val cas1OASysAssessmentInfoTransformer: Cas1OASysAssessmentInfoTransformer,
   private val oaSysSectionsTransformer: OASysSectionsTransformer,
-  private val oaSysOffenceDetailsTransformer: Cas1OASysOffenceDetailsTransformer,
   private val userAccessService: Cas1UserAccessService,
 ) {
 
@@ -61,10 +60,11 @@ class Cas1OasysController(
   )
   fun metadata(
     @PathVariable crn: String,
+    @RequestParam(defaultValue = "completed_in_last_six_months", name = "suitabilityStrategy") suitabilityStrategyDto: OASysAssessmentSuitabilityStrategyDto,
   ): ResponseEntity<Cas1OASysMetadata> {
     ensureOffenderAccess(crn)
 
-    val needDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn))
+    val needDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn, suitabilityStrategyDto.toSuitabilityStrategy()))
 
     return ResponseEntity.ok(
       Cas1OASysMetadata(
@@ -92,12 +92,15 @@ class Cas1OasysController(
     @PathVariable @Parameter(description = "CRN of the Person to fetch latest OASys selection") crn: String,
     @RequestParam group: Cas1OASysGroupName,
     @RequestParam includeOptionalSections: List<Int>?,
+    @RequestParam(defaultValue = "completed_in_last_six_months", name = "suitabilityStrategy") suitabilityStrategyDto: OASysAssessmentSuitabilityStrategyDto,
   ): ResponseEntity<Cas1OASysGroup> {
     ensureOffenderAccess(crn)
 
+    val suitabilityStrategy = suitabilityStrategyDto.toSuitabilityStrategy()
+
     val group = when (group) {
       Cas1OASysGroupName.RISK_MANAGEMENT_PLAN -> {
-        val riskManagementPlan = extractNullableOAsysResult(oaSysService.getRiskManagementPlan(crn))
+        val riskManagementPlan = extractNullableOAsysResult(oaSysService.getRiskManagementPlan(crn, suitabilityStrategy))
         Cas1OASysGroup(
           group = group,
           assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(riskManagementPlan),
@@ -105,7 +108,7 @@ class Cas1OasysController(
         )
       }
       Cas1OASysGroupName.OFFENCE_DETAILS -> {
-        val offenceDetails = extractNullableOAsysResult(oaSysService.getOffenceDetails(crn))
+        val offenceDetails = extractNullableOAsysResult(oaSysService.getOffenceDetails(crn, suitabilityStrategy))
         Cas1OASysGroup(
           group = group,
           assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(offenceDetails),
@@ -113,7 +116,7 @@ class Cas1OasysController(
         )
       }
       Cas1OASysGroupName.ROSH_SUMMARY -> {
-        val roshSummary = extractNullableOAsysResult(oaSysService.getRoshSummary(crn))
+        val roshSummary = extractNullableOAsysResult(oaSysService.getRoshSummary(crn, suitabilityStrategy))
         Cas1OASysGroup(
           group = group,
           assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(roshSummary),
@@ -121,8 +124,8 @@ class Cas1OasysController(
         )
       }
       Cas1OASysGroupName.SUPPORTING_INFORMATION -> {
-        val needsDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn))
-        val healthDetails = extractNullableOAsysResult(oaSysService.getHealthDetails(crn))
+        val needsDetails = extractNullableOAsysResult(oaSysService.getNeedsDetails(crn, suitabilityStrategy))
+        val healthDetails = extractNullableOAsysResult(oaSysService.getHealthDetails(crn, suitabilityStrategy))
         Cas1OASysGroup(
           group = group,
           assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(needsDetails),
@@ -134,7 +137,7 @@ class Cas1OasysController(
         )
       }
       Cas1OASysGroupName.RISK_TO_SELF -> {
-        val riskToTheIndividual = extractNullableOAsysResult(oaSysService.getRiskToTheIndividual(crn))
+        val riskToTheIndividual = extractNullableOAsysResult(oaSysService.getRiskToTheIndividual(crn, suitabilityStrategy))
         Cas1OASysGroup(
           group = group,
           assessmentMetadata = cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(riskToTheIndividual),
@@ -160,7 +163,7 @@ class Cas1OasysController(
     val risksToTheIndividualWrapper = extractEntityFromCasResult(
       oaSysService.getRiskToTheIndividual(
         crn = crn,
-        suitabilityStrategy = OASysSuitabilityService.SuitabilityStrategy.AllowAll,
+        suitabilityStrategy = SuitabilityStrategy.AllowAll,
       ),
     )
 
@@ -183,7 +186,7 @@ class Cas1OasysController(
     val healthDetailsWrapper = extractEntityFromCasResult(
       oaSysService.getHealthDetails(
         crn = crn,
-        suitabilityStrategy = OASysSuitabilityService.SuitabilityStrategy.AllowAll,
+        suitabilityStrategy = SuitabilityStrategy.AllowAll,
       ),
     )
 
@@ -208,5 +211,10 @@ class Cas1OasysController(
   private fun <EntityType> extractNullableOAsysResult(result: CasResult<EntityType>) = when (result) {
     is CasResult.NotFound -> null
     else -> extractEntityFromCasResult(result)
+  }
+
+  private fun OASysAssessmentSuitabilityStrategyDto.toSuitabilityStrategy() = when (this) {
+    OASysAssessmentSuitabilityStrategyDto.ALLOW_ALL -> SuitabilityStrategy.AllowAll
+    OASysAssessmentSuitabilityStrategyDto.COMPLETED_IN_LAST_SIX_MONTHS -> SuitabilityStrategy.CompletedInLastSixMonths
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockOffenceDetails404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskManagementPlan404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskToTheIndividual404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRoshSummary404Call
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulHealthDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulOffenceDetailsCall
@@ -105,34 +106,70 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun success() {
+    fun `default 6 month suitability strategy, assessment is less than 6 months old`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
-      val needsDetails = NeedsDetailsFactory().apply {
-        withAssessmentId(34853487)
-        withAccommodationIssuesDetails("Accommodation", true, false)
-        withAttitudeIssuesDetails("Attitude", false, true)
-        withFinanceIssuesDetails(null, null, null)
-      }.produce()
+      val needsDetails = NeedsDetailsFactory().produce()
       apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
 
-      webTestClient.get()
+      val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/metadata")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
         .isOk
-        .expectBody()
-        .json(
-          jsonMapper.writeValueAsString(
-            Cas1OASysMetadata(
-              cas1OASysAssessmentInfoTransformer.toAssessmentMetadata(needsDetails),
-              oaSysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails),
-            ),
-          ),
-        )
+        .bodyAsObject<Cas1OASysMetadata>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.supportingInformation).isEqualTo(oaSysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails))
+    }
+
+    @Test
+    fun `default 6 month suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val needsDetails = NeedsDetailsFactory()
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/metadata")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysMetadata>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.supportingInformation).isEmpty()
+    }
+
+    @Test
+    fun `allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val needsDetails = NeedsDetailsFactory()
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/metadata?suitabilityStrategy=allow_all")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysMetadata>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.supportingInformation).isEqualTo(oaSysNeedsQuestionTransformer.transformToSupportingInformationMetadata(needsDetails))
     }
   }
 
@@ -168,7 +205,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Risk Management Not Found, return empty questions`() {
+    fun `Risk Management - Not Found, return empty answers`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
@@ -194,13 +231,14 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Risk Management Plan Success`() {
+    fun `Risk Management - Default 6 month suitability strategy, assessment is less than 6 months old`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
       val riskManagementPlan = RiskManagementPlanFactory()
         .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(5))
         .produce()
       apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
 
@@ -224,7 +262,69 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Offence Details Not Found, return empty questions`() {
+    fun `Risk Management - Default 6 month suitability strategy, assessment is more than 6 months old, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=riskManagementPlan")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.RISK_MANAGEMENT_PLAN)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `Risk Management - Allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=riskManagementPlan&suitabilityStrategy=allow_all")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.RISK_MANAGEMENT_PLAN)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = "The supervision answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `Offence Details - Not Found, return empty answers`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
@@ -250,13 +350,14 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Offence Details Success`() {
+    fun `Offence Details - Default 6 month suitability strategy, assessment is less than 6 months old`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
       val offenceDetails = OffenceDetailsFactory()
         .withVictimImpact("Victim impact answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(5))
         .produce()
       apAndOASysMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
 
@@ -280,13 +381,103 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `ROSH Summary Success`() {
+    fun `Offence Details - Default 6 month suitability strategy, assessment is more than 6 months old, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val offenceDetails = OffenceDetailsFactory()
+        .withVictimImpact("Victim impact answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=offenceDetails")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.OFFENCE_DETAILS)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Impact on the victim",
+          questionNumber = "2.5",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `Offence Details - Allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val offenceDetails = OffenceDetailsFactory()
+        .withVictimImpact("Victim impact answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulOffenceDetailsCall(CRN, offenceDetails)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=offenceDetails&suitabilityStrategy=allow_all")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.OFFENCE_DETAILS)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Impact on the victim",
+          questionNumber = "2.5",
+          answer = "Victim impact answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `ROSH Summary - Not Found, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      apAndOASysMockRoshSummary404Call(CRN)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=roshSummary")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.ROSH_SUMMARY)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Who is at risk",
+          questionNumber = "R10.1",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `ROSH Summary - Default 6 month suitability strategy, assessment is less than 6 months old`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
       val roshSummary = RoshSummaryFactory()
         .withWhoAtRisk("Who at risk answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(5))
         .produce()
       apAndOASysMockSuccessfulRoSHSummaryCall(CRN, roshSummary)
 
@@ -310,7 +501,69 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Risk to self Success Not Found, return empty questions`() {
+    fun `ROSH Summary - Default 6 month suitability strategy, assessment is more than 6 months old, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val roshSummary = RoshSummaryFactory()
+        .withWhoAtRisk("Who at risk answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRoSHSummaryCall(CRN, roshSummary)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=roshSummary")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.ROSH_SUMMARY)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Who is at risk",
+          questionNumber = "R10.1",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `ROSH Summary - Allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val roshSummary = RoshSummaryFactory()
+        .withWhoAtRisk("Who at risk answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRoSHSummaryCall(CRN, roshSummary)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=roshSummary&suitabilityStrategy=allow_all")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.ROSH_SUMMARY)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Who is at risk",
+          questionNumber = "R10.1",
+          answer = "Who at risk answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `Risk to self - Not Found, return empty answers`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
@@ -324,6 +577,7 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
         .isOk
         .bodyAsObject<Cas1OASysGroup>()
 
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
       assertThat(result.group).isEqualTo(Cas1OASysGroupName.RISK_TO_SELF)
       assertThat(result.answers).contains(
         OASysQuestion(
@@ -335,13 +589,14 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Risk to self Success`() {
+    fun `Risk to self - Default 6 month suitability strategy, assessment is less than 6 months old`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
       val riskToIndividual = RisksToTheIndividualFactory()
         .withCurrentVulnerability("Current vuln answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(5))
         .produce()
       apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, riskToIndividual)
 
@@ -365,7 +620,69 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Supporting Information Not Found, return empty questions`() {
+    fun `Risk to self - Default 6 month suitability strategy, assessment is more than 6 months old, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskToIndividual = RisksToTheIndividualFactory()
+        .withCurrentVulnerability("Current vuln answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, riskToIndividual)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=riskToSelf")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.RISK_TO_SELF)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Analysis of vulnerabilities",
+          questionNumber = "FA64",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `Risk to self - Allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskToIndividual = RisksToTheIndividualFactory()
+        .withCurrentVulnerability("Current vuln answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskToTheIndividualCall(CRN, riskToIndividual)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=riskToSelf&suitabilityStrategy=allow_all")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.RISK_TO_SELF)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Current concerns about Vulnerability",
+          questionNumber = "R8.3.1",
+          answer = "Current vuln answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `Supporting Information - Not Found, return empty answers`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
@@ -401,18 +718,20 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Supporting Information Success`() {
+    fun `Supporting Information - Default 6 month suitability strategy, assessment is less than 6 months old`() {
       val (_, jwt) = givenAUser()
 
       apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
 
       val needsDetails = NeedsDetailsFactory().apply {
+        withDateCompleted(OffsetDateTime.now().minusMonths(5))
         withRelationshipIssuesDetails(linkedToHarm = true, relationshipIssuesDetails = "relationship answer")
         withLifestyleIssuesDetails(linkedToHarm = false, lifestyleIssuesDetails = "lifestyle answer")
         withEmotionalIssuesDetails(linkedToHarm = null, emotionalIssuesDetails = "emotional answer")
       }.produce()
 
       val healthDetails = HealthDetailsFactory().apply {
+        withDateCompleted(OffsetDateTime.now().minusMonths(5))
         withGeneralHealth(generalHealth = false, generalHealthSpecify = "health answer")
       }.produce()
 
@@ -421,6 +740,108 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
 
       val result = webTestClient.get()
         .uri("/cas1/people/$CRN/oasys/answers?group=supportingInformation&includeOptionalSections=10")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.SUPPORTING_INFORMATION)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Relationship issues contributing to risks of offending and harm",
+          questionNumber = "6.9",
+          answer = "relationship answer",
+        ),
+        OASysQuestion(
+          label = "Issues of emotional well-being contributing to risks of offending and harm",
+          questionNumber = "10.9",
+          answer = "emotional answer",
+        ),
+      )
+      assertThat(result.answers).doesNotContain(
+        OASysQuestion(
+          label = "Lifestyle issues contributing to risks of offending and harm",
+          questionNumber = "7.9",
+          answer = "relationship answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `Supporting Information - Default 6 month suitability strategy, assessment is more than 6 months old, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val needsDetails = NeedsDetailsFactory().apply {
+        withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        withRelationshipIssuesDetails(linkedToHarm = true, relationshipIssuesDetails = "relationship answer")
+        withLifestyleIssuesDetails(linkedToHarm = false, lifestyleIssuesDetails = "lifestyle answer")
+        withEmotionalIssuesDetails(linkedToHarm = null, emotionalIssuesDetails = "emotional answer")
+      }.produce()
+
+      val healthDetails = HealthDetailsFactory().apply {
+        withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        withGeneralHealth(generalHealth = false, generalHealthSpecify = "health answer")
+      }.produce()
+
+      apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
+      apAndOASysMockSuccessfulHealthDetailsCall(CRN, healthDetails)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=supportingInformation&includeOptionalSections=10")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.SUPPORTING_INFORMATION)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Relationship issues contributing to risks of offending and harm",
+          questionNumber = "6.9",
+          answer = null,
+        ),
+        OASysQuestion(
+          label = "Issues of emotional well-being contributing to risks of offending and harm",
+          questionNumber = "10.9",
+          answer = null,
+        ),
+        OASysQuestion(
+          label = "Lifestyle issues contributing to risks of offending and harm",
+          questionNumber = "7.9",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `Supporting Information - Allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val needsDetails = NeedsDetailsFactory().apply {
+        withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        withRelationshipIssuesDetails(linkedToHarm = true, relationshipIssuesDetails = "relationship answer")
+        withLifestyleIssuesDetails(linkedToHarm = false, lifestyleIssuesDetails = "lifestyle answer")
+        withEmotionalIssuesDetails(linkedToHarm = null, emotionalIssuesDetails = "emotional answer")
+      }.produce()
+
+      val healthDetails = HealthDetailsFactory().apply {
+        withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        withGeneralHealth(generalHealth = false, generalHealthSpecify = "health answer")
+      }.produce()
+
+      apAndOASysMockSuccessfulNeedsDetailsCall(CRN, needsDetails)
+      apAndOASysMockSuccessfulHealthDetailsCall(CRN, healthDetails)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=supportingInformation&includeOptionalSections=10&suitabilityStrategy=allow_all")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APAndOASysAPI.kt
@@ -31,6 +31,12 @@ fun IntegrationTestBase.apAndOASysMockSuccessfulRiskToTheIndividualCall(crn: Str
   responseBody = response,
 )
 
+fun IntegrationTestBase.apAndOASysMockRoshSummary404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
+  url = "/rosh-summary/$crn",
+  responseStatus = 404,
+  delayMs = 0,
+)
+
 fun IntegrationTestBase.apAndOASysMockRiskToTheIndividual404Call(crn: String) = mockUnsuccessfulGetCallWithDelayedResponse(
   url = "/risk-to-the-individual/$crn",
   responseStatus = 404,


### PR DESCRIPTION
This allows the UI to request information for assessments older than 6 months