### PR TITLE
FM-711 Remove unused CAS2 risk fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ApplicationSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/Cas2v2ApplicationSummary.kt
@@ -32,8 +32,6 @@ data class Cas2v2ApplicationSummary(
 
   @get:JsonProperty("latestStatusUpdate") val latestStatusUpdate: LatestCas2v2StatusUpdate? = null,
 
-  @get:JsonProperty("risks") val risks: PersonRisks? = null,
-
   @get:JsonProperty("hdcEligibilityDate") val hdcEligibilityDate: LocalDate? = null,
 
   @get:JsonProperty("nomsNumber") val nomsNumber: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/dto/Cas2HdcApplicationSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/dto/Cas2HdcApplicationSummary.kt
@@ -3,33 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonRisks
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-/**
- *
- * @param type
- * @param id
- * @param createdAt
- * @param createdByUserId
- * @param status
- * @param personName
- * @param crn
- * @param nomsNumber
- * @param allocatedPomUserId
- * @param allocatedPomName
- * @param assignmentDate
- * @param submittedAt
- * @param createdByUserName
- * @param latestStatusUpdate
- * @param risks
- * @param hdcEligibilityDate
- * @param currentPrisonName
- * @param applicationOrigin
- * @param bailHearingDate
- */
 data class Cas2HdcApplicationSummary(
 
   @get:JsonProperty("type", required = true) val type: String,
@@ -59,8 +36,6 @@ data class Cas2HdcApplicationSummary(
   @get:JsonProperty("createdByUserName") val createdByUserName: String? = null,
 
   @get:JsonProperty("latestStatusUpdate") val latestStatusUpdate: Cas2HdcLatestStatusUpdate? = null,
-
-  @get:JsonProperty("risks") val risks: PersonRisks? = null,
 
   @get:JsonProperty("hdcEligibilityDate") val hdcEligibilityDate: LocalDate? = null,
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/transformer/Cas2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/transformer/Cas2ApplicationsTransformerTest.kt
@@ -347,7 +347,6 @@ class Cas2ApplicationsTransformerTest {
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.createdByUserId.toString()).isEqualTo(application.userId)
-      assertThat(result.risks).isNull()
       assertThat(result.personName).isEqualTo("firstName surname")
       assertThat(result.crn).isEqualTo(application.crn)
       assertThat(result.nomsNumber).isEqualTo(application.nomsNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -197,7 +197,6 @@ class Cas2v2ApplicationTransformerTest {
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.createdByUserId.toString()).isEqualTo(application.userId)
-      assertThat(result.risks).isNull()
       assertThat(result.personName).isEqualTo("firstName surname")
       assertThat(result.crn).isEqualTo(application.crn)
       assertThat(result.nomsNumber).isEqualTo(application.nomsNumber)


### PR DESCRIPTION
A `risk` property exists on both the CAS2 HDC and CAS2 Application Summary DTOs, but it is never populated. This PR removes the property.