### PR TITLE
Remove explicit use of `PGObject`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("com.github.ben-manes.caffeine:caffeine")
   implementation("com.google.guava:guava:33.6.0-jre")
-  implementation("org.postgresql:postgresql:42.7.11")
   implementation("org.javers:javers-core:7.11.1")
 
   val springDocOpenApiStarterVersion = "3.0.2"
@@ -52,6 +51,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("io.sentry:sentry-spring-boot-4:8.43.1")
 
+  runtimeOnly("org.postgresql:postgresql:42.7.11")
   runtimeOnly("org.ehcache:ehcache")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/SubjectAccessRequestRepositoryBase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/SubjectAccessRequestRepositoryBase.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
 
-import org.postgresql.util.PGobject
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -306,7 +305,7 @@ open class SubjectAccessRequestRepositoryBase(val jdbcTemplate: NamedParameterJd
     return toJsonString(result)
   }
 
-  protected fun toJsonString(result: Map<String, Any?>) = (result["json"] as PGobject?)?.value
+  protected fun toJsonString(result: Map<String, Any?>): String? = result["json"]?.toString()
   protected fun MapSqlParameterSource.addSarParameters(
     crn: String?,
     nomsNumber: String?,


### PR DESCRIPTION
We’ve seen an issue related to PGObject when ugprading to kotlin 2.4.0

```/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/SubjectAccessRequestRepositoryBase.kt:309:90 Type annotation class 'org.checkerframework.checker.nullness.qual.Nullable' of the inferred type is inaccessible. Check the module classpath for missing or conflicting dependencies.```

As `PGObject.toString()` is the same as PGObject.value`, we don’t need to explicitly reference this class