### PR TITLE
FM-708 update open api aliases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2DomainEventsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2DomainEventsController.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 class Cas2DomainEventsController(private val domainEventService: Cas2DomainEventService) {
 
   @GetMapping("application-submitted/{eventId}")
-  fun eventsCas2HdcApplicationSubmittedEventIdGet(@PathVariable eventId: UUID): ResponseEntity<Cas2ApplicationSubmittedEvent> {
+  fun getApplicationSubmittedEvent(@PathVariable eventId: UUID): ResponseEntity<Cas2ApplicationSubmittedEvent> {
     val event = domainEventService.getApplicationSubmittedDomainEvent(eventId)
       ?: throw NotFoundProblem(eventId, "DomainEvent")
 
@@ -24,7 +24,7 @@ class Cas2DomainEventsController(private val domainEventService: Cas2DomainEvent
   }
 
   @GetMapping("application-status-updated/{eventId}")
-  fun eventsCas2HdcApplicationStatusUpdatedEventIdGet(@PathVariable eventId: UUID): ResponseEntity<Cas2ApplicationStatusUpdatedEvent> {
+  fun getApplicationStatusUpdatedEvent(@PathVariable eventId: UUID): ResponseEntity<Cas2ApplicationStatusUpdatedEvent> {
     val event = domainEventService.getApplicationStatusUpdatedDomainEvent(eventId)
       ?: throw NotFoundProblem(eventId, "DomainEvent")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -149,10 +149,6 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
         if (pathItem.delete != null) pathItem.delete.operationId = prefix + pathItem.delete.operationId
       }
 
-    addDeprecatedSchemaAlias(openApi, "Cas2ApplicationStatusSeeding", "Cas2HdcApplicationStatusSeeding")
-    addDeprecatedSchemaAlias(openApi, "Cas2PersistedApplicationStatus", "Cas2HdcPersistedApplicationStatus")
-    addDeprecatedSchemaAlias(openApi, "Cas2PersistedApplicationStatusDetail", "Cas2HdcPersistedApplicationStatusDetail")
-    addDeprecatedSchemaAlias(openApi, "Cas2PersistedApplicationStatusFinder", "Cas2HdcPersistedApplicationStatusFinder")
     addDeprecatedSchemaAlias(openApi, "Cas2Application", "Cas2HdcApplication")
     addDeprecatedSchemaAlias(openApi, "Cas2ApplicationNote", "Cas2HdcApplicationNote")
     addDeprecatedSchemaAlias(openApi, "Cas2ApplicationStatus", "Cas2HdcApplicationStatus")
@@ -164,14 +160,12 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     addDeprecatedSchemaAlias(openApi, "LatestCas2StatusUpdate", "Cas2HdcLatestStatusUpdate")
     addDeprecatedSchemaAlias(openApi, "NewCas2ApplicationNote", "Cas2HdcNewApplicationNote")
     addDeprecatedSchemaAlias(openApi, "Cas2ReportName", "Cas2HdcReportName")
-    addDeprecatedSchemaAlias(openApi, "Cas2ServiceOrigin", "Cas2HdcServiceOrigin")
     addDeprecatedSchemaAlias(openApi, "Cas2StatusUpdate", "Cas2HdcStatusUpdate")
     addDeprecatedSchemaAlias(openApi, "Cas2StatusUpdateDetail", "Cas2HdcStatusUpdateDetail")
     addDeprecatedSchemaAlias(openApi, "SubmitCas2Application", "Cas2HdcSubmitApplication")
     addDeprecatedSchemaAlias(openApi, "Cas2SubmittedApplication", "Cas2HdcSubmittedApplication")
     addDeprecatedSchemaAlias(openApi, "SubmittedApplicationReportRow", "Cas2HdcSubmittedApplicationReportRow")
     addDeprecatedSchemaAlias(openApi, "Cas2SubmittedApplicationSummary", "Cas2HdcSubmittedApplicationSummary")
-    addDeprecatedSchemaAlias(openApi, "Cas2TimelineEvent", "Cas2HdcTimelineEvent")
     addDeprecatedSchemaAlias(openApi, "UnsubmittedApplicationsReportRow", "Cas2HdcUnsubmittedApplicationsReportRow")
     addDeprecatedSchemaAlias(openApi, "UpdateCas2Application", "Cas2HdcUpdateApplication")
     addDeprecatedSchemaAlias(openApi, "UpdateCas2Assessment", "Cas2HdcUpdateAssessment")


### PR DESCRIPTION
**Changes:**
- Removed unnecessary schema aliases.
- Renamed CAS2 domain event endpoint handler methods.