### PR TITLE
FM-724 Remove deprecated `SubmitPlacementApplication.placementType`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SubmitPlacementApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/SubmitPlacementApplication.kt
@@ -7,16 +7,12 @@ data class SubmitPlacementApplication(
 
   @Schema(required = true)
   val translatedDocument: Any,
-
-  @Schema(deprecated = true, description = "Please use release type instead")
-  val placementType: PlacementType?,
-
   @Schema(deprecated = true, description = "Please use requestedPlacementPeriods instead")
   val placementDates: List<PlacementDates>?,
 
   val requestedPlacementPeriods: List<Cas1RequestedPlacementPeriod>?,
 
-  val releaseType: ReleaseTypeOption?,
+  val releaseType: ReleaseTypeOption,
   val sentenceType: SentenceTypeOption?,
   val situationType: SituationOption?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
@@ -35,7 +35,6 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision as ApiPlacementApplicationDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType as ApiPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision as JpaPlacementApplicationDecision
 
 @Service
@@ -339,10 +338,6 @@ class Cas1PlacementApplicationService(
       return CasResult.GeneralValidationError("Please provide at least one of placement dates or requested placement periods.")
     }
 
-    if (submitPlacementApplication.placementType == null && submitPlacementApplication.releaseType == null) {
-      return CasResult.GeneralValidationError("Please provide at least one of placementType or releaseType.")
-    }
-
     val translatedDocument = jsonMapper.writeValueAsString(submitPlacementApplication.translatedDocument)
 
     val cas1RequestedPlacementPeriod = deriveRequestedPlacementPeriods(submitPlacementApplication)!!
@@ -372,7 +367,7 @@ class Cas1PlacementApplicationService(
       allocatedAt = now
       placementType = placementTypeValue
       submissionGroupId = UUID.randomUUID()
-      releaseType = submitPlacementApplication.releaseType?.let { Cas1ReleaseType.fromApiType(it) }
+      releaseType = submitPlacementApplication.releaseType.let { Cas1ReleaseType.fromApiType(it) }
       sentenceType = submitPlacementApplication.sentenceType?.toString()
       situation = submitPlacementApplication.situationType?.toString()
     }
@@ -415,8 +410,6 @@ class Cas1PlacementApplicationService(
 
   private fun getPlacementTypeForApplication(submitPlacementApplication: SubmitPlacementApplication): PlacementType {
     val placementTypeValue = when {
-      submitPlacementApplication.placementType != null -> getPlacementType(submitPlacementApplication.placementType)
-
       submitPlacementApplication.releaseType == ReleaseTypeOption.paroleDirectedLicence -> PlacementType.RELEASE_FOLLOWING_DECISION
       submitPlacementApplication.releaseType == ReleaseTypeOption.rotl -> PlacementType.ROTL
       else -> PlacementType.ADDITIONAL_PLACEMENT
@@ -503,12 +496,6 @@ class Cas1PlacementApplicationService(
     )
 
     return CasResult.Success(savedApplication)
-  }
-
-  private fun getPlacementType(apiPlacementType: ApiPlacementType): PlacementType = when (apiPlacementType) {
-    ApiPlacementType.additionalPlacement -> PlacementType.ADDITIONAL_PLACEMENT
-    ApiPlacementType.rotl -> PlacementType.ROTL
-    ApiPlacementType.releaseFollowingDecision -> PlacementType.RELEASE_FOLLOWING_DECISION
   }
 
   private fun <T> getApplicationForUpdateOrSubmit(id: UUID): Either<CasResult<T>, PlacementApplicationEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1PlacementApplicationService.kt
@@ -61,7 +61,7 @@ class Cas1PlacementApplicationService(
   fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
     user: UserEntity,
-  ) = validatedCasResult<PlacementApplicationEntity> {
+  ): CasResult<PlacementApplicationEntity> = validatedCasResult {
     val assessment = application.getLatestAssessment()
 
     if (assessment?.decision !== AssessmentDecision.ACCEPTED) {
@@ -165,8 +165,8 @@ class Cas1PlacementApplicationService(
           reallocatedAt = null,
           dueAt = null,
           releaseType = application.releaseType,
-          sentenceType = application.sentenceType?.toString(),
-          situation = application.situation?.toString(),
+          sentenceType = application.sentenceType,
+          situation = application.situation,
         ),
       ),
     )
@@ -347,7 +347,7 @@ class Cas1PlacementApplicationService(
 
     val cas1RequestedPlacementPeriod = deriveRequestedPlacementPeriods(submitPlacementApplication)!!
 
-    var placementTypeValue = getPlacementTypeForApplication(submitPlacementApplication)
+    val placementTypeValue = getPlacementTypeForApplication(submitPlacementApplication)
 
     val placementApplicationAuthorisationResult = getApplicationForUpdateOrSubmit<List<PlacementApplicationEntity>>(id)
 
@@ -414,7 +414,7 @@ class Cas1PlacementApplicationService(
   }
 
   private fun getPlacementTypeForApplication(submitPlacementApplication: SubmitPlacementApplication): PlacementType {
-    var placementTypeValue = when {
+    val placementTypeValue = when {
       submitPlacementApplication.placementType != null -> getPlacementType(submitPlacementApplication.placementType)
 
       submitPlacementApplication.releaseType == ReleaseTypeOption.paroleDirectedLicence -> PlacementType.RELEASE_FOLLOWING_DECISION

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementMatchingOutcomesV2ReportTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -487,7 +486,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       placementApplicationId = createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 6),
@@ -537,7 +536,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH - 1, 31),
@@ -565,7 +564,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH + 1, 2),
@@ -739,7 +738,7 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
 
   private fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
-    placementType: PlacementType,
+    releaseType: ReleaseTypeOption,
     placementDates: List<PlacementDates>,
   ): UUID {
     val creatorJwt = givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER)).second
@@ -767,10 +766,9 @@ class Cas1PlacementMatchingOutcomesV2ReportTest : InitialiseDatabasePerClassTest
       placementApplicationId = placementApplicationId,
       body = SubmitPlacementApplication(
         translatedDocument = mapOf("key" to "value"),
-        placementType = placementType,
         placementDates = placementDates,
         requestedPlacementPeriods = emptyList(),
-        releaseType = ReleaseTypeOption.licence,
+        releaseType = releaseType,
         sentenceType = null,
         situationType = null,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1PlacementReportTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -278,7 +277,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.additionalPlacement,
+        releaseType = ReleaseTypeOption.notApplicable,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 5),
@@ -351,7 +350,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 15),
@@ -434,7 +433,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 15),
@@ -507,7 +506,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(REPORT_YEAR, REPORT_MONTH, 15),
@@ -583,7 +582,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = outOfRangeArrivalDate,
@@ -607,7 +606,7 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
   private fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
-    placementType: PlacementType,
+    releaseType: ReleaseTypeOption,
     placementDates: List<PlacementDates>,
   ) {
     val creatorJwt = givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER)).second
@@ -635,10 +634,9 @@ class Cas1PlacementReportTest : InitialiseDatabasePerClassTestBase() {
       placementApplicationId = placementApplicationId,
       body = SubmitPlacementApplication(
         translatedDocument = mapOf("key" to "value"),
-        placementType = placementType,
         placementDates = placementDates,
         requestedPlacementPeriods = emptyList(),
-        releaseType = ReleaseTypeOption.licence,
+        releaseType = releaseType,
         sentenceType = null,
         situationType = null,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementCriteria
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementRequirements
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
@@ -81,17 +80,17 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
   val standardRFPSubmittedAfterReportingPeriod = StandardRFPSubmittedAfterReportingPeriod()
 
   val placementAppRotlAcceptedManager = PlacementAppAssessedManager(
-    type = PlacementType.rotl,
+    releaseType = ReleaseTypeOption.rotl,
     submittedAt = LocalDateTime.of(2021, 3, 22, 9, 49, 0),
     withdraw = false,
   )
   val placementAppAdditionalAcceptedManager = PlacementAppAssessedManager(
-    type = PlacementType.additionalPlacement,
+    releaseType = ReleaseTypeOption.notApplicable,
     submittedAt = LocalDateTime.of(2021, 3, 23, 9, 49, 0),
     withdraw = false,
   )
   val placementAppParoleAcceptedAndWithdrawnManager = PlacementAppAssessedManager(
-    type = PlacementType.releaseFollowingDecision,
+    releaseType = ReleaseTypeOption.paroleDirectedLicence,
     submittedAt = LocalDateTime.of(2021, 3, 24, 9, 49, 0),
     withdraw = true,
   )
@@ -448,7 +447,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
   }
 
   inner class PlacementAppAssessedManager(
-    val type: PlacementType,
+    val releaseType: ReleaseTypeOption,
     val submittedAt: LocalDateTime,
     val withdraw: Boolean = false,
   ) {
@@ -457,7 +456,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
     fun createRequestForPlacement() {
       application = createAndSubmitApplication(
-        crn = "${type}PlacementAppAssessed",
+        crn = "${releaseType}PlacementAppAssessed",
         submittedAt = LocalDateTime.of(2021, 2, 28, 23, 59, 59),
         arrivalDateOnApplication = null,
         durationOnApplication = 7,
@@ -475,7 +474,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       )
       createPlacementApplication(
         application = application,
-        placementType = type,
+        releaseType = releaseType,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(2029, 1, 1),
@@ -502,10 +501,10 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
     fun assertRow(row: RequestForPlacementReportRow) {
       assertThat(row.request_for_placement_id).isEqualTo(placementApplicationId.toString())
       assertThat(row.request_for_placement_type).isEqualTo(
-        when (type) {
-          PlacementType.rotl -> "ROTL"
-          PlacementType.releaseFollowingDecision -> "RELEASE_FOLLOWING_DECISION"
-          PlacementType.additionalPlacement -> "ADDITIONAL_PLACEMENT"
+        when (releaseType) {
+          ReleaseTypeOption.rotl -> "ROTL"
+          ReleaseTypeOption.paroleDirectedLicence -> "RELEASE_FOLLOWING_DECISION"
+          else -> "ADDITIONAL_PLACEMENT"
         },
       )
       assertThat(row.requested_arrival_date).isEqualTo("2029-01-01")
@@ -521,8 +520,8 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
         assertThat(row.request_for_placement_withdrawal_date).isNull()
         assertThat(row.request_for_placement_withdrawal_reason).isNull()
       }
-      assertThat(row.crn).isEqualTo("${type}PlacementAppAssessed")
-      assertThat(row.release_type).isEqualTo("awaitingSentence")
+      assertThat(row.crn).isEqualTo("${releaseType}PlacementAppAssessed")
+      assertThat(row.release_type).isEqualTo(releaseType.name)
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
     }
   }
@@ -551,7 +550,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       )
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(2029, 1, 1),
@@ -580,7 +579,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_withdrawal_date).isNull()
       assertThat(row.request_for_placement_withdrawal_reason).isNull()
       assertThat(row.crn).isEqualTo("PlacementAppRejected")
-      assertThat(row.release_type).isEqualTo("awaitingSentence")
+      assertThat(row.release_type).isEqualTo("rotl")
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
     }
   }
@@ -606,7 +605,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       )
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(2029, 1, 1),
@@ -640,7 +639,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       )
       createPlacementApplication(
         application = application,
-        placementType = PlacementType.rotl,
+        releaseType = ReleaseTypeOption.rotl,
         placementDates = listOf(
           PlacementDates(
             expectedArrival = LocalDate.of(2029, 1, 1),
@@ -848,7 +847,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
 
   private fun createPlacementApplication(
     application: ApprovedPremisesApplicationEntity,
-    placementType: PlacementType,
+    releaseType: ReleaseTypeOption,
     placementDates: List<PlacementDates>,
     paroleDecisionDate: LocalDate,
     submittedAt: LocalDateTime,
@@ -886,10 +885,9 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       placementApplicationId = placementApplicationId,
       body = SubmitPlacementApplication(
         translatedDocument = mapOf("key" to "value"),
-        placementType = placementType,
         placementDates = placementDates,
         requestedPlacementPeriods = emptyList(),
-        releaseType = ReleaseTypeOption.inCommunity,
+        releaseType = releaseType,
         sentenceType = SentenceTypeOption.bailPlacement,
         situationType = SituationOption.awaitingSentence,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PlacementApplicationsTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementAppli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
@@ -543,7 +542,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
         .bodyValue(
           SubmitPlacementApplication(
             translatedDocument = mapOf("thingId" to 123),
-            placementType = PlacementType.additionalPlacement,
             placementDates = listOf(
               PlacementDates(
                 expectedArrival = LocalDate.now(),
@@ -574,7 +572,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
-                placementType = PlacementType.additionalPlacement,
                 placementDates = listOf(
                   PlacementDates(
                     expectedArrival = LocalDate.now(),
@@ -611,7 +608,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
-                placementType = PlacementType.additionalPlacement,
                 placementDates = listOf(
                   PlacementDates(
                     expectedArrival = LocalDate.now(),
@@ -648,7 +644,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
-                placementType = PlacementType.additionalPlacement,
                 placementDates = listOf(
                   PlacementDates(
                     expectedArrival = LocalDate.now(),
@@ -681,7 +676,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
-                placementType = PlacementType.additionalPlacement,
                 placementDates = listOf(
                   PlacementDates(
                     expectedArrival = LocalDate.now(),
@@ -716,7 +710,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
             .bodyValue(
               SubmitPlacementApplication(
                 translatedDocument = mapOf("thingId" to 123),
-                placementType = PlacementType.additionalPlacement,
                 placementDates = emptyList(),
                 requestedPlacementPeriods = emptyList(),
                 releaseType = ReleaseTypeOption.licence,
@@ -759,7 +752,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
               .bodyValue(
                 SubmitPlacementApplication(
                   translatedDocument = mapOf("thingId" to 123),
-                  placementType = PlacementType.additionalPlacement,
                   placementDates = emptyList(),
                   requestedPlacementPeriods = cas1RequestedPlacementPeriod,
                   releaseType = ReleaseTypeOption.licence,
@@ -839,7 +831,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
               .bodyValue(
                 SubmitPlacementApplication(
                   translatedDocument = mapOf("thingId" to 123),
-                  placementType = PlacementType.additionalPlacement,
                   placementDates = placementDates,
                   requestedPlacementPeriods = emptyList(),
                   releaseType = ReleaseTypeOption.licence,
@@ -936,7 +927,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
               .bodyValue(
                 SubmitPlacementApplication(
                   translatedDocument = mapOf("thingId" to 123),
-                  placementType = PlacementType.additionalPlacement,
                   placementDates = placementDates,
                   requestedPlacementPeriods = emptyList(),
                   releaseType = ReleaseTypeOption.licence,
@@ -1037,7 +1027,6 @@ class PlacementApplicationsTest : IntegrationTestBase() {
               .bodyValue(
                 SubmitPlacementApplication(
                   translatedDocument = mapOf("thingId" to 123),
-                  placementType = PlacementType.additionalPlacement,
                   placementDates = null,
                   requestedPlacementPeriods = requestedPlacementPeriod,
                   releaseType = ReleaseTypeOption.licence,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1PlacementApplicationServiceTest.kt
@@ -19,7 +19,6 @@ import org.springframework.data.repository.findByIdOrNull
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementApplicationDecisionEnvelope
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
@@ -264,7 +263,6 @@ class Cas1PlacementApplicationServiceTest {
 
       val submitPlacementApplication = SubmitPlacementApplication(
         translatedDocument = "translatedDocument",
-        placementType = PlacementType.releaseFollowingDecision,
         placementDates = emptyList(),
         requestedPlacementPeriods = null,
         releaseType = ReleaseTypeOption.licence,
@@ -280,36 +278,6 @@ class Cas1PlacementApplicationServiceTest {
 
       assertThat(result is CasResult.GeneralValidationError).isTrue
       assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Please provide at least one of placement dates or requested placement periods.")
-    }
-
-    @Test
-    fun `Submitting an application returns validation error if no placement type or release type present`() {
-      every { placementApplicationRepository.findByIdOrNull(placementApplication.id) } returns placementApplication
-
-      val submitPlacementApplication = SubmitPlacementApplication(
-        translatedDocument = "translatedDocument",
-        placementType = null,
-        placementDates = emptyList(),
-        requestedPlacementPeriods = listOf(
-          Cas1RequestedPlacementPeriod(
-            arrival = LocalDate.of(2024, 4, 1),
-            duration = 5,
-            arrivalFlexible = null,
-          ),
-        ),
-        releaseType = null,
-        sentenceType = null,
-        situationType = null,
-      )
-
-      val result = cas1PlacementApplicationService.submitApplication(
-        placementApplication.id,
-        submitPlacementApplication,
-
-      )
-
-      assertThat(result is CasResult.GeneralValidationError).isTrue
-      assertThat((result as CasResult.GeneralValidationError).message).isEqualTo("Please provide at least one of placementType or releaseType.")
     }
 
     @ParameterizedTest
@@ -338,7 +306,6 @@ class Cas1PlacementApplicationServiceTest {
 
       val submitPlacementApplication = SubmitPlacementApplication(
         translatedDocument = "translatedDocument",
-        placementType = null,
         placementDates = emptyList(),
         requestedPlacementPeriods = listOf(
           Cas1RequestedPlacementPeriod(
@@ -387,7 +354,6 @@ class Cas1PlacementApplicationServiceTest {
 
       val submitPlacementApplication = SubmitPlacementApplication(
         translatedDocument = "translatedDocument",
-        placementType = PlacementType.releaseFollowingDecision,
         placementDates = emptyList(),
         requestedPlacementPeriods = listOf(
           Cas1RequestedPlacementPeriod(
@@ -427,7 +393,6 @@ class Cas1PlacementApplicationServiceTest {
 
       val submitPlacementApplication = SubmitPlacementApplication(
         translatedDocument = "translatedDocument",
-        placementType = PlacementType.releaseFollowingDecision,
         placementDates = emptyList(),
         requestedPlacementPeriods = listOf(
           Cas1RequestedPlacementPeriod(
@@ -479,7 +444,6 @@ class Cas1PlacementApplicationServiceTest {
 
       val submitPlacementApplication = SubmitPlacementApplication(
         translatedDocument = "translatedDocument",
-        placementType = PlacementType.releaseFollowingDecision,
         placementDates = emptyList(),
         requestedPlacementPeriods = listOf(
           Cas1RequestedPlacementPeriod(


### PR DESCRIPTION
This has been long replaced by `releaseType` and `sentenceType`. The UI is no longer populating this value.

Removing this allows us to make releaseType mandatory, removing the need for some validation on this field.