### PR TITLE
FM-728 add cas2 mappings to cas2v2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2Controller.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/Cas2v2Controller.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 @Retention(AnnotationRetention.RUNTIME)
 @RestController
 @RequestMapping(
-  "\${api.base-path:}/cas2v2",
+  value = ["\${api.base-path:}/cas2v2", "\${api.base-path:}/cas2"],
   produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
 )
 internal annotation class Cas2v2Controller

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/external/Cas2v2ExternalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/controller/external/Cas2v2ExternalController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 @Retention(AnnotationRetention.RUNTIME)
 @RestController
 @RequestMapping(
-  "\${api.base-path:}/cas2v2/external",
+  value = ["\${api.base-path:}/cas2v2/external", "\${api.base-path:}/cas2/external"],
   produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
 )
 internal annotation class Cas2v2ExternalController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -93,6 +93,21 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize("/cas2v2/applications/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize("/cas2v2/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
 
+        authorize(HttpMethod.PUT, "/cas2/assessments/**", hasAuthority("ROLE_CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2/assessments/**", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_ADMIN", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.POST, "/cas2/assessments/*/status-updates", hasAuthority("ROLE_CAS2_ASSESSOR"))
+        authorize(HttpMethod.POST, "/cas2/assessments/*/notes", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_ADMIN"))
+        authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasAnyAuthority("ROLE_CAS2_ASSESSOR"))
+        authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.GET, "/cas2/reports/**", hasAuthority("ROLE_CAS2_MI"))
+        authorize(HttpMethod.GET, "/cas2/people/*/oasys/**", hasAnyAuthority(Cas2v2Role.COURT_BAIL_REFERRER, Cas2v2Role.PRISON_BAIL_REFERRER))
+        authorize(HttpMethod.GET, "/cas2/people/search-by-crn/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.GET, "/cas2/people/search-by-noms/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+        authorize(HttpMethod.GET, "/cas2/external/**", hasRole("APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE"))
+        authorize("/cas2/applications/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+        authorize("/cas2/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
+
         authorize(HttpMethod.GET, "/cas3-api.yml", permitAll)
         authorize(HttpMethod.GET, "/subject-access-request", hasAnyRole("SAR_DATA_ACCESS"))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -150,27 +150,6 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
         if (pathItem.patch != null) pathItem.patch.operationId = prefix + pathItem.patch.operationId
         if (pathItem.delete != null) pathItem.delete.operationId = prefix + pathItem.delete.operationId
       }
-
-    addDeprecatedSchemaAlias(openApi, "Cas2Application", "Cas2HdcApplication")
-    addDeprecatedSchemaAlias(openApi, "Cas2ApplicationNote", "Cas2HdcApplicationNote")
-    addDeprecatedSchemaAlias(openApi, "Cas2ApplicationStatus", "Cas2HdcApplicationStatus")
-    addDeprecatedSchemaAlias(openApi, "Cas2ApplicationStatusDetail", "Cas2HdcApplicationStatusDetail")
-    addDeprecatedSchemaAlias(openApi, "ApplicationStatusUpdatesReportRow", "Cas2HdcApplicationStatusUpdatesReportRow")
-    addDeprecatedSchemaAlias(openApi, "Cas2ApplicationSummary", "Cas2HdcApplicationSummary")
-    addDeprecatedSchemaAlias(openApi, "Cas2Assessment", "Cas2HdcAssessment")
-    addDeprecatedSchemaAlias(openApi, "Cas2AssessmentStatusUpdate", "Cas2HdcAssessmentStatusUpdate")
-    addDeprecatedSchemaAlias(openApi, "LatestCas2StatusUpdate", "Cas2HdcLatestStatusUpdate")
-    addDeprecatedSchemaAlias(openApi, "NewCas2ApplicationNote", "Cas2HdcNewApplicationNote")
-    addDeprecatedSchemaAlias(openApi, "Cas2ReportName", "Cas2HdcReportName")
-    addDeprecatedSchemaAlias(openApi, "Cas2StatusUpdate", "Cas2HdcStatusUpdate")
-    addDeprecatedSchemaAlias(openApi, "Cas2StatusUpdateDetail", "Cas2HdcStatusUpdateDetail")
-    addDeprecatedSchemaAlias(openApi, "SubmitCas2Application", "Cas2HdcSubmitApplication")
-    addDeprecatedSchemaAlias(openApi, "Cas2SubmittedApplication", "Cas2HdcSubmittedApplication")
-    addDeprecatedSchemaAlias(openApi, "SubmittedApplicationReportRow", "Cas2HdcSubmittedApplicationReportRow")
-    addDeprecatedSchemaAlias(openApi, "Cas2SubmittedApplicationSummary", "Cas2HdcSubmittedApplicationSummary")
-    addDeprecatedSchemaAlias(openApi, "UnsubmittedApplicationsReportRow", "Cas2HdcUnsubmittedApplicationsReportRow")
-    addDeprecatedSchemaAlias(openApi, "UpdateCas2Application", "Cas2HdcUpdateApplication")
-    addDeprecatedSchemaAlias(openApi, "UpdateCas2Assessment", "Cas2HdcUpdateAssessment")
   }
 
   private fun createProblemSchema(): Schema<*> = ModelConverters.getInstance()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OpenApiConfiguration.kt
@@ -58,7 +58,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas1Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS1Shared")
     .displayName("CAS1 & Shared")
-    .pathsToExclude("/**/cas2-hdc/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
+    .pathsToExclude("/**/cas2-hdc/**", "/**/cas2/**", "/**/cas2v2/**", "/**/cas3/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -92,7 +92,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas2v2(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS2v2")
     .displayName("CAS2v2")
-    .pathsToMatch("/**/cas2v2/**")
+    .pathsToMatch("/**/cas2v2/**", "/**/cas2/**")
     .pathsToExclude("/**/events/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
@@ -101,7 +101,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun cas3Shared(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("CAS3Shared")
     .displayName("CAS3 & Shared")
-    .pathsToExclude("/**/cas1/**", "/**/cas2-hdc/**", "/**/cas2v2/**", "/**/events/**", "/queue-admin/**")
+    .pathsToExclude("/**/cas1/**", "/**/cas2/**", "/**/cas2-hdc/**", "/**/cas2v2/**", "/**/events/**", "/queue-admin/**")
     .addOpenApiCustomizer(openApiCustomizer())
     .build()
 
@@ -131,6 +131,8 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
 
         val prefix = if (path.startsWith("/cas1/")) {
           "cas1-"
+        } else if (path.startsWith("/cas2/")) {
+          "cas2-"
         } else if (path.startsWith("/cas2v2/")) {
           "cas2v2-"
         } else if (path.startsWith("/cas3/")) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationAbandonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationAbandonTest.kt
@@ -64,7 +64,7 @@ class Cas2v2ApplicationAbandonTest : IntegrationTestBase() {
       )
 
       webTestClient.put()
-        .uri("/cas2v2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd/abandon")
+        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd/abandon")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -77,7 +77,7 @@ class Cas2v2ApplicationAbandonTest : IntegrationTestBase() {
     @Test
     fun `Abandon a cas2v2 application without JWT returns 401`() {
       webTestClient.put()
-        .uri("/cas2v2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6/abandon")
+        .uri("/cas2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6/abandon")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -96,7 +96,7 @@ class Cas2v2ApplicationAbandonTest : IntegrationTestBase() {
             val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, submittingUser)
 
             webTestClient.put()
-              .uri("/cas2v2/applications/${application.id}/abandon")
+              .uri("/cas2/applications/${application.id}/abandon")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ApplicationTest.kt
@@ -99,7 +99,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.post()
-        .uri("/cas2v2/applications")
+        .uri("/cas2/applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -116,7 +116,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.put()
-        .uri("/cas2v2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd")
+        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4fd")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -132,7 +132,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/applications")
+        .uri("/cas2/applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -148,7 +148,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/applications/66911cf0-75b1-4361-84bd-501b176fd4")
+        .uri("/cas2/applications/66911cf0-75b1-4361-84bd-501b176fd4")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -161,7 +161,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Get all cas2v2 applications without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/applications")
+        .uri("/cas2/applications")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -170,7 +170,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Get single cas2v2 application without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6")
+        .uri("/cas2/applications/9b785e59-b85c-4be0-b271-d9ac287684b6")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -179,7 +179,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Create new cas2v2 application without JWT returns 401`() {
       webTestClient.post()
-        .uri("/cas2v2/applications")
+        .uri("/cas2/applications")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -283,7 +283,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         }
 
         val rawResponseBody = webTestClient.get()
-          .uri("/cas2v2/applications")
+          .uri("/cas2/applications")
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.cas2v2.value)
           .exchange()
@@ -402,7 +402,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         }
 
         val rawResponseBody = webTestClient.get()
-          .uri("/cas2v2/applications")
+          .uri("/cas2/applications")
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.cas2v2.value)
           .exchange()
@@ -485,7 +485,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             }
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2v2/applications")
+              .uri("/cas2/applications")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .exchange()
@@ -539,7 +539,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         }
 
         val rawResponseBodyPage1 = webTestClient.get()
-          .uri("/cas2v2/applications?page=1")
+          .uri("/cas2/applications?page=1")
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.cas2v2.value)
           .exchange()
@@ -561,7 +561,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         Assertions.assertThat(isOrderedByCreatedAtDescending(responseBodyPage1)).isTrue()
 
         val rawResponseBodyPage2 = webTestClient.get()
-          .uri("/cas2v2/applications?page=2")
+          .uri("/cas2/applications?page=2")
           .header("Authorization", "Bearer $jwt")
           .header("X-Service-Name", ServiceName.cas2.value)
           .exchange()
@@ -593,7 +593,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
 
         webTestClient
           .get()
-          .uri("/cas2v2/applications")
+          .uri("/cas2/applications")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -615,7 +615,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         )
         webTestClient
           .get()
-          .uri("/cas2v2/applications")
+          .uri("/cas2/applications")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -634,7 +634,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         )
         webTestClient
           .get()
-          .uri("/cas2v2/applications")
+          .uri("/cas2/applications")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -796,7 +796,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `returns all cas2v2 applications for user when isSubmitted is null`() {
       val rawResponseBody = webTestClient.get()
-        .uri("/cas2v2/applications")
+        .uri("/cas2/applications")
         .header("Authorization", "Bearer $jwtForUser")
         .header("X-Service-Name", ServiceName.cas2v2.value)
         .exchange()
@@ -830,7 +830,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `returns submitted cas2v2 applications for user when isSubmitted is true`() {
       val rawResponseBody = webTestClient.get()
-        .uri("/cas2v2/applications?isSubmitted=true")
+        .uri("/cas2/applications?isSubmitted=true")
         .header("Authorization", "Bearer $jwtForUser")
         .header("X-Service-Name", ServiceName.cas2.value)
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2AssessmentTest.kt
@@ -43,7 +43,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
       @Test
       fun `updating a cas2v2 assessment without JWT returns 401`() {
         webTestClient.put()
-          .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
+          .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
           .exchange()
           .expectStatus()
           .isUnauthorized
@@ -61,7 +61,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.put()
-          .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
+          .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -80,7 +80,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.put()
-          .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
+          .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -108,7 +108,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
           val updatedAssessorName = "Anne Assessor"
 
           val rawResponseBody = webTestClient.put()
-            .uri("/cas2v2/assessments/${assessment.id}")
+            .uri("/cas2/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2v2.value)
             .bodyValue(
@@ -148,7 +148,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
       @Test
       fun `getting a cas2v2 assessment without JWT returns 401`() {
         webTestClient.get()
-          .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
+          .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
           .exchange()
           .expectStatus()
           .isUnauthorized
@@ -166,7 +166,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
+          .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -185,7 +185,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
         )
 
         webTestClient.get()
-          .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
+          .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -210,7 +210,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/cas2v2/assessments/${assessment.id}")
+            .uri("/cas2/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2v2.value)
             .exchange()
@@ -246,7 +246,7 @@ class Cas2v2AssessmentTest : IntegrationTestBase() {
           }
 
           val rawResponseBody = webTestClient.get()
-            .uri("/cas2v2/assessments/${assessment.id}")
+            .uri("/cas2/assessments/${assessment.id}")
             .header("Authorization", "Bearer $jwt")
             .header("X-Service-Name", ServiceName.cas2v2.value)
             .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2OASysTest.kt
@@ -26,13 +26,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
 
   @Nested
-  @DisplayName("GET /cas2v2/people/{crn}/oasys/metadata")
+  @DisplayName("GET /cas2/people/{crn}/oasys/metadata")
   inner class GetAssessmentMetadata {
 
     @Test
     fun `Get without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .uri("/cas2/people/CRN123/oasys/metadata")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -42,7 +42,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
     @ParameterizedTest
     fun `Get without referrer role returns 403`(role: RoleAndAuthSource) {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .uri("/cas2/people/CRN123/oasys/metadata")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -55,7 +55,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       apAndOASysMockAssessmentSummaryNotFound("CRN123")
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .uri("/cas2/people/CRN123/oasys/metadata")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -74,7 +74,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       )
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/metadata")
+        .uri("/cas2/people/CRN123/oasys/metadata")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -86,13 +86,13 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
   }
 
   @Nested
-  @DisplayName("GET /cas2v2/people/{crn}/oasys/risk-to-self")
+  @DisplayName("GET /cas2/people/{crn}/oasys/risk-to-self")
   inner class GetRiskToSelf {
 
     @Test
     fun `Get without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/risk-to-self")
+        .uri("/cas2/people/CRN123/oasys/risk-to-self")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -102,7 +102,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
     @ParameterizedTest
     fun `Get without referrer role returns 403`(role: RoleAndAuthSource) {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/risk-to-self")
+        .uri("/cas2/people/CRN123/oasys/risk-to-self")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -115,7 +115,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       apAndOASysMockRiskToTheIndividual404Call("CRN123")
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/risk-to-self")
+        .uri("/cas2/people/CRN123/oasys/risk-to-self")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -134,7 +134,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       )
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/risk-to-self")
+        .uri("/cas2/people/CRN123/oasys/risk-to-self")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -146,13 +146,13 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
   }
 
   @Nested
-  @DisplayName("GET /cas2v2/people/{crn}/oasys/rosh-summary")
+  @DisplayName("GET /cas2/people/{crn}/oasys/rosh-summary")
   inner class GetRoshSummary {
 
     @Test
     fun `Get without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .uri("/cas2/people/CRN123/oasys/rosh-summary")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -162,7 +162,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
     @ParameterizedTest
     fun `Get without referrer role returns 403`(role: RoleAndAuthSource) {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .uri("/cas2/people/CRN123/oasys/rosh-summary")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -175,7 +175,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       apAndOASysMockRoSHSummary404Call("CRN123")
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .uri("/cas2/people/CRN123/oasys/rosh-summary")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -194,7 +194,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       )
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-summary")
+        .uri("/cas2/people/CRN123/oasys/rosh-summary")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -206,13 +206,13 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
   }
 
   @Nested
-  @DisplayName("GET /cas2v2/people/{crn}/oasys/rosh-ratings")
+  @DisplayName("GET /cas2/people/{crn}/oasys/rosh-ratings")
   inner class GetRoshRatings {
 
     @Test
     fun `Get without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-ratings")
+        .uri("/cas2/people/CRN123/oasys/rosh-ratings")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -222,7 +222,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
     @ParameterizedTest
     fun `Get without referrer role returns 403`(role: RoleAndAuthSource) {
       webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-ratings")
+        .uri("/cas2/people/CRN123/oasys/rosh-ratings")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -235,7 +235,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       apAndOASysMockRoshRating404Call("CRN123")
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-ratings")
+        .uri("/cas2/people/CRN123/oasys/rosh-ratings")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()
@@ -254,7 +254,7 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
       )
 
       val result = webTestClient.get()
-        .uri("/cas2v2/people/CRN123/oasys/rosh-ratings")
+        .uri("/cas2/people/CRN123/oasys/rosh-ratings")
         .addJwtForRoleAndAuthSource(role)
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2PersonSearchTest.kt
@@ -36,7 +36,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
         @Test
         fun `Searching by NOMIS ID without a JWT returns 401`() {
           webTestClient.get()
-            .uri("/cas2v2/people/search-by-noms/nomsNumber").exchange()
+            .uri("/cas2/people/search-by-noms/nomsNumber").exchange()
             .expectStatus()
             .isUnauthorized
         }
@@ -49,7 +49,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
           )
 
           webTestClient.get()
-            .uri("/cas2v2/people/search-by-noms/nomsNumber")
+            .uri("/cas2/people/search-by-noms/nomsNumber")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -65,7 +65,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
           )
 
           webTestClient.get()
-            .uri("/cas2v2/people/search-by-noms/nomsNumber")
+            .uri("/cas2/people/search-by-noms/nomsNumber")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -78,7 +78,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
             apDeliusContextMockUnsuccessfulCaseSummaryCall(403)
 
             webTestClient.get()
-              .uri("/cas2v2/people/search-by-noms/NOMS321")
+              .uri("/cas2/people/search-by-noms/NOMS321")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -92,7 +92,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
             apDeliusContextMockUnsuccessfulCaseSummaryCall(404)
 
             webTestClient.get()
-              .uri("/cas2v2/people/search-by-noms/NOMS321")
+              .uri("/cas2/people/search-by-noms/NOMS321")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -106,7 +106,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
             apDeliusContextMockUnsuccessfulCaseSummaryCall()
 
             webTestClient.get()
-              .uri("/cas2v2/people/search-by-noms/NOMS321")
+              .uri("/cas2/people/search-by-noms/NOMS321")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -148,7 +148,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
             prisonAPIMockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
 
             webTestClient.get()
-              .uri("/cas2v2/people/search-by-noms/NOMS321")
+              .uri("/cas2/people/search-by-noms/NOMS321")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -181,7 +181,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
         @Test
         fun `Searching by CRN without a JWT returns 401`() {
           webTestClient.get()
-            .uri("/cas2v2/people/search-by-crn/CRN")
+            .uri("/cas2/people/search-by-crn/CRN")
             .exchange()
             .expectStatus()
             .isUnauthorized
@@ -195,7 +195,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
           )
 
           webTestClient.get()
-            .uri("/cas2v2/people/search?crn=CRN")
+            .uri("/cas2/people/search?crn=CRN")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -210,7 +210,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
           )
 
           webTestClient.get()
-            .uri("/cas2v2/people/search-by-crn/CRN")
+            .uri("/cas2/people/search-by-crn/CRN")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -226,7 +226,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
           )
 
           webTestClient.get()
-            .uri("/cas2v2/people/search-by-crn/CRN")
+            .uri("/cas2/people/search-by-crn/CRN")
             .header("Authorization", "Bearer $jwt")
             .exchange()
             .expectStatus()
@@ -250,7 +250,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
             )
 
             webTestClient.get()
-              .uri("/cas2v2/people/search-by-crn/CRN")
+              .uri("/cas2/people/search-by-crn/CRN")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -292,7 +292,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
               },
             ) { _, _ ->
               webTestClient.get()
-                .uri("/cas2v2/people/search-by-crn/CRN")
+                .uri("/cas2/people/search-by-crn/CRN")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -337,7 +337,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
               },
             ) { _, _ ->
               webTestClient.get()
-                .uri("/cas2v2/people/search-by-crn/CRN")
+                .uri("/cas2/people/search-by-crn/CRN")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ReferenceDataTest.kt
@@ -28,7 +28,7 @@ class Cas2v2ReferenceDataTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt()
 
     webTestClient.get()
-      .uri("/cas2v2/reference-data/application-status")
+      .uri("/cas2/reference-data/application-status")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()
@@ -46,7 +46,7 @@ class Cas2v2ReferenceDataTest : IntegrationTestBase() {
     val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt()
 
     webTestClient.get()
-      .uri("/cas2v2/reference-data/application-status")
+      .uri("/cas2/reference-data/application-status")
       .header("Authorization", "Bearer $jwt")
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ReportsTest.kt
@@ -54,7 +54,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/${reportName.value}")
+        .uri("/cas2/reports/${reportName.value}")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -74,7 +74,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
     )
     fun `Downloading cas2v2 report without JWT returns 401`(reportName: String) {
       webTestClient.get()
-        .uri("/cas2v2/reports/$reportName")
+        .uri("/cas2/reports/$reportName")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -93,7 +93,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/${reportName.value}")
+        .uri("/cas2/reports/${reportName.value}")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -178,7 +178,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/submitted-applications")
+        .uri("/cas2/reports/submitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -227,7 +227,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/submitted-applications")
+        .uri("/cas2/reports/submitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -405,7 +405,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/application-status-updates")
+        .uri("/cas2/reports/application-status-updates")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -474,7 +474,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/application-status-updates")
+        .uri("/cas2/reports/application-status-updates")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -550,7 +550,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/unsubmitted-applications")
+        .uri("/cas2/reports/unsubmitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -598,7 +598,7 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/reports/unsubmitted-applications")
+        .uri("/cas2/reports/unsubmitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2StatusUpdateTest.kt
@@ -58,7 +58,7 @@ class Cas2v2StatusUpdateTest(
       )
 
       webTestClient.post()
-        .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237/status-updates")
+        .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237/status-updates")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -71,7 +71,7 @@ class Cas2v2StatusUpdateTest(
     @Test
     fun `creating a cas2v2 status update without JWT returns 401`() {
       webTestClient.post()
-        .uri("/cas2v2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237/status-updates")
+        .uri("/cas2/assessments/de6512fc-a225-4109-b2cd-86c6307a5237/status-updates")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -103,7 +103,7 @@ class Cas2v2StatusUpdateTest(
           assertThat(realCas2StatusUpdateDetailRepository.count()).isEqualTo(0)
 
           webTestClient.post()
-            .uri("/cas2v2/assessments/$assessmentId/status-updates")
+            .uri("/cas2/assessments/$assessmentId/status-updates")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas2HdcAssessmentStatusUpdate(newStatus = "moreInfoRequested"),
@@ -141,7 +141,7 @@ class Cas2v2StatusUpdateTest(
     fun `Create cas2v2 status update returns 404 when assessment not found`() {
       givenACas2v2Assessor { _, jwt ->
         webTestClient.post()
-          .uri("/cas2v2/assessments/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
+          .uri("/cas2/assessments/66f7127a-fe03-4b66-8378-5c0b048490f8/status-updates")
           .header("Authorization", "Bearer $jwt")
           .bodyValue(
             Cas2HdcAssessmentStatusUpdate(newStatus = "moreInfoRequested"),
@@ -169,7 +169,7 @@ class Cas2v2StatusUpdateTest(
           }
 
           webTestClient.post()
-            .uri("/cas2v2/assessments/${assessment.id}/status-updates")
+            .uri("/cas2/assessments/${assessment.id}/status-updates")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas2HdcAssessmentStatusUpdate(newStatus = "invalidStatus"),
@@ -213,7 +213,7 @@ class Cas2v2StatusUpdateTest(
               every { OffsetDateTime.now() } returns now
 
               webTestClient.post()
-                .uri("/cas2v2/assessments/$assessmentId/status-updates")
+                .uri("/cas2/assessments/$assessmentId/status-updates")
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   Cas2HdcAssessmentStatusUpdate(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2SubmissionTest.kt
@@ -99,7 +99,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
       )
 
       webTestClient.post()
-        .uri("/cas2v2/submissions?applicationId=de6512fc-a225-4109-b2cd-86c6307a5237")
+        .uri("/cas2/submissions?applicationId=de6512fc-a225-4109-b2cd-86c6307a5237")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -115,7 +115,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/submissions")
+        .uri("/cas2/submissions")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -131,7 +131,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
       )
 
       webTestClient.get()
-        .uri("/cas2v2/submissions/66911cf0-75b1-4361-84bd-501b176fd4fd")
+        .uri("/cas2/submissions/66911cf0-75b1-4361-84bd-501b176fd4fd")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -144,7 +144,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
     @Test
     fun `Get all submitted applications without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/submissions")
+        .uri("/cas2/submissions")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -153,7 +153,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
     @Test
     fun `Get single submitted application without JWT returns 401`() {
       webTestClient.get()
-        .uri("/cas2v2/submissions/9b785e59-b85c-4be0-b271-d9ac287684b6")
+        .uri("/cas2/submissions/9b785e59-b85c-4be0-b271-d9ac287684b6")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -179,7 +179,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt(username)
 
       webTestClient.get()
-        .uri("/cas2v2/submissions")
+        .uri("/cas2/submissions")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -236,7 +236,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
               }
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2v2/submissions?page=1")
+              .uri("/cas2/submissions?page=1")
               .header("Authorization", "Bearer $jwt")
               .header("X-Service-Name", ServiceName.cas2.value)
               .exchange()
@@ -342,7 +342,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
       val jwt = jwtAuthHelper.createValidExternalAuthorisationCodeJwt(username)
 
       webTestClient.get()
-        .uri("/cas2v2/submissions/fea7986d-cae6-4a7a-8420-5b31376ce787")
+        .uri("/cas2/submissions/fea7986d-cae6-4a7a-8420-5b31376ce787")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -436,7 +436,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
             cas2RealStatusUpdateDetailRepository.save(statusUpdateDetail)
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2v2/submissions/${applicationEntity.id}")
+              .uri("/cas2/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -522,7 +522,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
             }
 
             webTestClient.get()
-              .uri("/cas2v2/submissions/${applicationEntity.id}")
+              .uri("/cas2/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -617,7 +617,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
             cas2RealStatusUpdateDetailRepository.save(statusUpdateDetail)
 
             val rawResponseBody = webTestClient.get()
-              .uri("/cas2v2/submissions/${applicationEntity.id}")
+              .uri("/cas2/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -678,7 +678,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
             )
 
             webTestClient.get()
-              .uri("/cas2v2/submissions/${applicationEntity.id}")
+              .uri("/cas2/submissions/${applicationEntity.id}")
               .header("Authorization", "Bearer $jwt")
               .exchange()
               .expectStatus()
@@ -763,7 +763,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
                 cas2RealStatusUpdateRepository.save(update3)
 
                 val rawResponseBody = webTestClient.get()
-                  .uri("/cas2v2/submissions/${applicationEntity.id}")
+                  .uri("/cas2/submissions/${applicationEntity.id}")
                   .header("Authorization", "Bearer $jwt")
                   .exchange()
                   .expectStatus()
@@ -813,7 +813,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
               )
 
               webTestClient.get()
-                .uri("/cas2v2/submissions/${applicationEntity.id}")
+                .uri("/cas2/submissions/${applicationEntity.id}")
                 .header("Authorization", "Bearer $jwt")
                 .exchange()
                 .expectStatus()
@@ -871,7 +871,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
           (1..10).map {
             val thread = Thread {
               webTestClient.post()
-                .uri("/cas2v2/submissions")
+                .uri("/cas2/submissions")
                 .header("Authorization", "Bearer $jwt")
                 .bodyValue(
                   SubmitCas2v2Application(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/external/Cas2v2ExternalReferralHistoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/external/Cas2v2ExternalReferralHistoryTest.kt
@@ -25,7 +25,7 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
     fun `Get all referrals when user JWT returns 403 Forbidden`() {
       givenACas2v2PomUser { _, jwt ->
         webTestClient.get()
-          .uri("/cas2v2/external/referrals/$crn")
+          .uri("/cas2/external/referrals/$crn")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -36,7 +36,7 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
     @Test
     fun `Get all referrals when no JWT returns 401 Unauthorized`() {
       webTestClient.get()
-        .uri("/cas2v2/external/referrals/$crn")
+        .uri("/cas2/external/referrals/$crn")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -126,7 +126,7 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
           )
 
           val response = webTestClient.get()
-            .uri("/cas2v2/external/referrals/$crn")
+            .uri("/cas2/external/referrals/$crn")
             .header("Authorization", "Bearer $clientCredentialsJwt")
             .exchange()
             .expectStatus()
@@ -153,7 +153,7 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
           val withdrawnApplication = createApplication(user, "Referral withdrawn", preferredAreas = "South East", referringPrisonCode = omu.prisonCode)
 
           val response = webTestClient.get()
-            .uri("/cas2v2/external/referrals/$crn")
+            .uri("/cas2/external/referrals/$crn")
             .header("Authorization", "Bearer $clientCredentialsJwt")
             .exchange()
             .expectStatus()
@@ -184,7 +184,7 @@ class Cas2v2ExternalReferralHistoryTest : IntegrationTestBase() {
           val applicationWithPrison = createApplication(user, "Active", referringPrisonCode = omu.prisonCode)
 
           val response = webTestClient.get()
-            .uri("/cas2v2/external/referrals/$crn")
+            .uri("/cas2/external/referrals/$crn")
             .header("Authorization", "Bearer $clientCredentialsJwt")
             .exchange()
             .expectStatus()


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/FM-728

Adds `/cas2` route aliases for existing CAS2v2 endpoints (and security rules) so consumers can access CAS2v2 functionality via `/cas2/**` as well as `/cas2v2/**`.

Changes:

- Update CAS2v2 controller base mappings to accept both `/cas2v2` and `/cas2` (including external routes).
- Add matching Spring Security authorization rules for `/cas2/**` endpoints (mirroring the existing `/cas2v2/**` rules).
- Update CAS2v2 integration tests to call the new `/cas2/**` paths.
- Update OpenAPI config for new cas2
- Remove CasHdc type aliases from OpenAPI config since no longer used (function left since it will be required in a subsequent PR)
