### PR TITLE
Upgrade hmpps spring boot

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,5 +10,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IOOPENTELEMETRY-17280222:
+    - '*':
+        reason: Suppression for baggage limits issue as we use header size limits
+        expires: 2026-07-11T00:00:00.000Z
+        created: 2026-06-11T07:38:00.250Z
 patch: {}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.3.1"
-  kotlin("plugin.spring") version "2.3.21"
-  kotlin("plugin.jpa") version "2.3.21"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.4.0"
+  kotlin("plugin.spring") version "2.4.0"
+  kotlin("plugin.jpa") version "2.4.0"
   id("dev.detekt") version "2.0.0-alpha.3"
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -16,12 +16,12 @@ class ClientCachingOAuth2AuthorizedClientService(
 ) : OAuth2AuthorizedClientService {
   private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
 
-  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+  override fun <T : OAuth2AuthorizedClient> loadAuthorizedClient(
     clientRegistrationId: String,
     principalName: String,
   ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
     @Suppress("UNCHECKED_CAST")
-    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T?
   }
 
   override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -228,30 +228,28 @@ class LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository:
   private val backingImplementation = InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository)
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
-    clientRegistrationId: String?,
-    principalName: String?,
-  ): T = backingImplementation.loadAuthorizedClient<T>(clientRegistrationId, principalName)
+  override fun <T : OAuth2AuthorizedClient> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = backingImplementation.loadAuthorizedClient(clientRegistrationId, principalName)
 
-  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient?, principal: Authentication?) {
-    val tokenValue = authorizedClient?.accessToken?.tokenValue
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    val tokenValue = authorizedClient.accessToken.tokenValue
 
-    if (tokenValue != null) {
-      try {
-        val tokenBodyBase64 = tokenValue.split(".")[1]
-        val tokenBodyRaw = Base64.getDecoder().decode(tokenBodyBase64)
-        val info = jsonMapper.readValue(tokenBodyRaw, JwtLogInfo::class.java)
-        log.info("Retrieved a client_credentials JWT for service->service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")
-      } catch (exception: Exception) {
-        // Deliberately not logging exception message
-        log.error("Unable to get token info to log, exception of type: ${exception::class.java.name}")
-      }
+    try {
+      val tokenBodyBase64 = tokenValue.split(".")[1]
+      val tokenBodyRaw = Base64.getDecoder().decode(tokenBodyBase64)
+      val info = jsonMapper.readValue(tokenBodyRaw, JwtLogInfo::class.java)
+      log.info("Retrieved a client_credentials JWT for service->service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")
+    } catch (exception: Exception) {
+      // Deliberately not logging exception message
+      log.error("Unable to get token info to log, exception of type: ${exception::class.java.name}")
     }
 
     backingImplementation.saveAuthorizedClient(authorizedClient, principal)
   }
 
-  override fun removeAuthorizedClient(clientRegistrationId: String?, principalName: String?) = backingImplementation.removeAuthorizedClient(clientRegistrationId, principalName)
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) = backingImplementation.removeAuthorizedClient(clientRegistrationId, principalName)
 }
 
 @Configuration

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -240,7 +240,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons returns 200 with correct body`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     val departureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = jsonMapper.writeValueAsString(
@@ -261,7 +261,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons for only approved premises returns 200 with correct body`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     departureReasonEntityFactory.produceAndPersistMultiple(10)
 
@@ -316,7 +316,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons returns only active departure reasons by default`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     val departureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10) {
       withIsActive(true)
@@ -345,7 +345,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons returns both active and inactive departure reasons when 'includeInactive' query is true`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     val activeDepartureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10) {
       withIsActive(true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
@@ -373,7 +373,7 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
 
     @Test
     fun success() {
-      departureReasonRepository.deleteAll()
+      departureReasonRepository.deleteAllRecursively()
 
       val compareByDepartureReasonNameAsc = compareBy(String.CASE_INSENSITIVE_ORDER, DepartureReasonEntity::name)
       val compareByDepartureReasonNameDesc = compareByDescending(String.CASE_INSENSITIVE_ORDER, DepartureReasonEntity::name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DepartureReasonTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DepartureReasonTestRepository.kt
@@ -1,9 +1,29 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
+import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import java.util.UUID
 
 @Repository
-interface DepartureReasonTestRepository : JpaRepository<DepartureReasonEntity, UUID>
+interface DepartureReasonTestRepository : JpaRepository<DepartureReasonEntity, UUID> {
+  @Modifying
+  @Query(
+    value = """
+    WITH RECURSIVE tree AS (
+      SELECT id FROM departure_reasons
+      UNION
+      SELECT d.id
+      FROM departure_reasons d
+      JOIN tree t ON d.parent_reason_id = t.id
+    )
+    DELETE FROM departure_reasons WHERE id IN (SELECT id FROM tree)
+  """,
+    nativeQuery = true,
+  )
+  @Transactional
+  fun deleteAllRecursively()
+}


### PR DESCRIPTION
This required some tweaks to our OAuth2 config classes as the spring boot interfaces no longer support nullable values

This also upgraded hibernate from 7.2.12 to 7.4.1.Final. This caused some change in behaviour wrt. deleteall() with FKs that referenced entries in the same table.