### PR TITLE
FM-734 allow null NOMS number for un-submitted applications report.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/dto/Cas2HdcUnsubmittedApplicationsReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/dto/Cas2HdcUnsubmittedApplicationsReportRow.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOri
 class Cas2HdcUnsubmittedApplicationsReportRow(
   val applicationId: String,
   val personCrn: String,
-  val personNoms: String,
+  val personNoms: String?,
   val startedAt: String,
   val startedBy: String,
   val applicationOrigin: ApplicationOrigin = ApplicationOrigin.homeDetentionCurfew,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/Cas2UnsubmittedApplicationsReport.kt
@@ -34,7 +34,7 @@ interface Cas2UnsubmittedApplicationReportQueryRow {
   fun getApplicationId(): String
   fun getApplicationOrigin(): ApplicationOrigin
   fun getCohort(): Cas2Cohort?
-  fun getPersonNoms(): String
+  fun getPersonNoms(): String?
   fun getPersonCrn(): String
   fun getStartedBy(): String
   fun getStartedAt(): String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/service/Cas2v2ReportsService.kt
@@ -102,7 +102,7 @@ class Cas2v2ReportsService(
     val eventId: String,
     val applicationId: String,
     val personCrn: String,
-    val personNoms: String?,
+    val personNoms: String,
     val referringPrisonCode: String?,
     val preferredAreas: String?,
     val hdcEligibilityDate: LocalDate?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/factory/Cas2ApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/factory/Cas2ApplicationEntityFactory.kt
@@ -32,7 +32,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
   private var abandonedAt: Yielded<OffsetDateTime?> = { null }
   private var statusUpdates: Yielded<MutableList<Cas2StatusUpdateEntity>> = { mutableListOf() }
   private var eventNumber: Yielded<String> = { randomInt(1, 9).toString() }
-  private var nomsNumber: Yielded<String> = { randomStringUpperCase(6) }
+  private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var telephoneNumber: Yielded<String?> = { randomNumberChars(12) }
   private var notes: Yielded<MutableList<Cas2ApplicationNoteEntity>> = { mutableListOf() }
   private var assessment: Yielded<Cas2AssessmentEntity?> = { null }
@@ -54,7 +54,7 @@ class Cas2ApplicationEntityFactory : Factory<Cas2ApplicationEntity> {
     this.crn = { crn }
   }
 
-  fun withNomsNumber(nomsNumber: String) = apply {
+  fun withNomsNumber(nomsNumber: String?) = apply {
     this.nomsNumber = { nomsNumber }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/Cas2v2ReportsTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StatusDetail
@@ -519,7 +518,8 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       val newer = Instant.now().minusDays(100)
       val tooOld = Instant.now().minusDays(366)
 
-      val applicableApplication = givenAnUnsubmittedCas2Application(createdAt = newer.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+      val applicableApplicationNomsNotNull = givenAnUnsubmittedCas2Application(createdAt = newer.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
+      val applicableApplicationNomsNull = givenAnUnsubmittedCas2Application(createdAt = newer.plusSeconds(1).atOffset(ZoneOffset.ofHoursMinutes(0, 0)), noms = null)
 
       // HDC application, which should not feature in report
       givenAnUnsubmittedCas2HdcApplication(createdAt = old.atOffset(ZoneOffset.ofHoursMinutes(0, 0)))
@@ -530,39 +530,49 @@ class Cas2v2ReportsTest : IntegrationTestBase() {
       // submitted application, which should not feature in report
       givenASubmittedCas2Application(createdAt = Instant.now().atOffset(ZoneOffset.ofHoursMinutes(0, 0)).minusDays(51))
 
-      val expectedDataFrame = listOf(
-        UnsubmittedApplicationsReportRow(
-          applicationId = applicableApplication.id.toString(),
-          personCrn = applicableApplication.crn,
-          applicationOrigin = applicableApplication.applicationOrigin,
-          personNoms = applicableApplication.nomsNumber.toString(),
-          startedAt = applicableApplication.createdAt.toString().split(".").first(),
-          startedBy = applicableApplication.createdByUser.username,
-          cohort = "Prison Bail",
-        ),
-      )
-        .toDataFrame()
-
       val jwt = jwtAuthHelper.createClientCredentialsJwt(
         username = "username",
         authSource = "nomis",
         roles = listOf("ROLE_CAS2_MI"),
       )
 
-      webTestClient.get()
+      val responseBody = webTestClient.get()
         .uri("/cas2/reports/unsubmitted-applications")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
         .isOk
         .expectBody()
-        .consumeWith {
-          val actual = DataFrame
-            .readExcel(it.responseBody!!.inputStream())
-            .convertTo<UnsubmittedApplicationsReportRow>(ExcessiveColumns.Remove)
+        .returnResult()
+        .responseBody!!
 
-          assertThat(actual).isEqualTo(expectedDataFrame)
-        }
+      val actual = DataFrame
+        .readExcel(responseBody.inputStream())
+        .convertTo<UnsubmittedApplicationsReportRow>(ExcessiveColumns.Remove)
+
+      assertThat(actual).isEqualTo(
+        listOf(
+          UnsubmittedApplicationsReportRow(
+            applicationId = applicableApplicationNomsNull.id.toString(),
+            personCrn = applicableApplicationNomsNull.crn,
+            applicationOrigin = applicableApplicationNomsNull.applicationOrigin,
+            personNoms = null,
+            startedAt = applicableApplicationNomsNull.createdAt.toString().split(".").first(),
+            startedBy = applicableApplicationNomsNull.createdByUser.username,
+            cohort = "Prison Bail",
+          ),
+          UnsubmittedApplicationsReportRow(
+            applicationId = applicableApplicationNomsNotNull.id.toString(),
+            personCrn = applicableApplicationNomsNotNull.crn,
+            applicationOrigin = applicableApplicationNomsNotNull.applicationOrigin,
+            personNoms = applicableApplicationNomsNotNull.nomsNumber,
+            startedAt = applicableApplicationNomsNotNull.createdAt.toString().split(".").first(),
+            startedBy = applicableApplicationNomsNotNull.createdByUser.username,
+            cohort = "Prison Bail",
+          ),
+        )
+          .toDataFrame(),
+      )
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/givens/GivenACas2Application.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/givens/GivenACas2Application.kt
@@ -29,7 +29,7 @@ fun IntegrationTestBase.givenAnUnsubmittedCas2Application(
   applicationOrigin: ApplicationOrigin = ApplicationOrigin.prisonBail,
   cohort: Cas2Cohort = Cas2Cohort.PRISON_BAIL,
   crn: String = "CRN_1",
-  noms: String = "NOMS_1",
+  noms: String? = "NOMS_1",
   createdAt: OffsetDateTime = OffsetDateTime.now(),
 ) = cas2ApplicationEntityFactory.produceAndPersist {
   withCreatedByUser(


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-734

This change is only required for un-submitted applications because for these applications the NOMS number in the reports comes from the application.  For submitted and status update reports, the NOMS number comes from the event associated with application submission or application status update, in both of these circumstances the NOMS strings will not be null, even if the offender doesn't have a NOMS number in Delius.

See the [ticket](https://dsdmoj.atlassian.net/browse/FM-734), related [comment](https://dsdmoj.atlassian.net/browse/FM-734?focusedCommentId=792218) and original Slack [message](https://dsdmoj.atlassian.net/browse/FM-734#:~:text=Slack%20from%20a-,message,-.) for more context.