### PR TITLE
Always report integration tests on failure

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -148,6 +148,7 @@ jobs:
             build/reports/tests
 
       - name: publish test report
+        if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: Integration Test Report


### PR DESCRIPTION
A recent change to integration testing config accidentally removed the `if: always()` option