### PR TITLE
FM-737 Rename Cas2v2 controllers, annotations, and other references to Cas2.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/Cas2Constants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/Cas2Constants.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2
 
-object Cas2v2Constants {
-  object Cas2v2Role {
+object Cas2Constants {
+  object Cas2Role {
     const val ADMIN = "ROLE_CAS2_ADMIN"
     const val ASSESSOR = "ROLE_CAS2_ASSESSOR"
     const val PRISON_BAIL_REFERRER = "ROLE_CAS2_PRISON_BAIL_REFERRER"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcOffenderService
@@ -41,7 +41,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Applicat
 @Cas2Controller
 class Cas2ApplicationController(
   private val cas2ApplicationService: Cas2ApplicationService,
-  private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
+  private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
   private val jsonMapper: JsonMapper,
   private val cas2OffenderService: Cas2OffenderService,
   private val cas2HdcOffenderService: Cas2HdcOffenderService,
@@ -143,7 +143,7 @@ class Cas2ApplicationController(
 
     return ResponseEntity
       .created(URI.create("/cas2/applications/${application.id}"))
-      .body(cas2v2ApplicationsTransformer.transformJpaAndFullPersonToApi(application, personInfo))
+      .body(cas2ApplicationsTransformer.transformJpaAndFullPersonToApi(application, personInfo))
   }
 
   @Operation(description = "Update a non submitted application. An application can only be updated if it's created by the calling user, unsubmitted and not abandoned")
@@ -191,7 +191,7 @@ class Cas2ApplicationController(
     val personNamesMap = cas2HdcOffenderService.getMapOfPersonNamesAndCrns(crns)
 
     return applicationSummaries.map { application ->
-      cas2v2ApplicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.crn]!!)
+      cas2ApplicationsTransformer.transformJpaSummaryToSummary(application, personNamesMap[application.crn]!!)
     }
   }
 
@@ -206,6 +206,6 @@ class Cas2ApplicationController(
       is Cas2v2OffenderSearchResult.Success.Full -> cas2v2OffenderSearchResult.person
     }
 
-    return cas2v2ApplicationsTransformer.transformJpaAndFullPersonToApi(application, personInfo)
+    return cas2ApplicationsTransformer.transformJpaAndFullPersonToApi(application, personInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
@@ -38,8 +38,8 @@ import java.net.URI
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationSummary as ModelCas2v2ApplicationSummary
 
-@Cas2v2Controller
-class Cas2v2ApplicationController(
+@Cas2Controller
+class Cas2ApplicationController(
   private val cas2v2ApplicationService: Cas2v2ApplicationService,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
   private val jsonMapper: JsonMapper,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
@@ -18,9 +18,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2v2Appli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationSummaryEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ApplicationController.kt
@@ -17,10 +17,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Applicat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2v2Application
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationSummaryEntity
@@ -40,12 +40,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Applicat
 
 @Cas2Controller
 class Cas2ApplicationController(
-  private val cas2v2ApplicationService: Cas2v2ApplicationService,
+  private val cas2ApplicationService: Cas2ApplicationService,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
   private val jsonMapper: JsonMapper,
-  private val cas2v2OffenderService: Cas2v2OffenderService,
+  private val cas2OffenderService: Cas2OffenderService,
   private val cas2HdcOffenderService: Cas2HdcOffenderService,
-  private val userService: Cas2v2UserService,
+  private val userService: Cas2UserService,
 ) {
 
   @Operation(summary = "List all applications according to miscellaneous parameters")
@@ -73,7 +73,7 @@ class Cas2ApplicationController(
 
     val pageCriteria = PageCriteria("createdAt", SortDirection.desc, page)
 
-    val (applications, metadata) = cas2v2ApplicationService.getCas2v2Applications(
+    val (applications, metadata) = cas2ApplicationService.getCas2Applications(
       prisonCode,
       isSubmitted,
       applicationOrigin,
@@ -100,8 +100,8 @@ class Cas2ApplicationController(
   ): ResponseEntity<Cas2v2Application> {
     val user = userService.getUserForRequest()
 
-    val applicationResult = cas2v2ApplicationService
-      .getCas2v2ApplicationForUser(
+    val applicationResult = cas2ApplicationService
+      .getCas2ApplicationForUser(
         applicationId,
         user,
       )
@@ -119,14 +119,14 @@ class Cas2ApplicationController(
   ): ResponseEntity<Cas2v2Application> {
     val user = userService.getUserForRequest()
 
-    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(body.crn)) {
+    val personInfo = when (val cas2v2OffenderSearchResult = cas2OffenderService.getPersonByNomisIdOrCrn(body.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(body.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: ${body.crn}")
       is Cas2v2OffenderSearchResult.Success.Full -> cas2v2OffenderSearchResult.person
     }
 
-    val applicationResult = cas2v2ApplicationService.createCas2v2Application(
+    val applicationResult = cas2ApplicationService.createCas2Application(
       body.crn,
       user,
       body.applicationOrigin,
@@ -158,7 +158,7 @@ class Cas2ApplicationController(
 
     val serializedData = jsonMapper.writeValueAsString(body.data)
 
-    val applicationResult = cas2v2ApplicationService.updateCas2v2Application(
+    val applicationResult = cas2ApplicationService.updateCas2Application(
       applicationId = applicationId,
       data = serializedData,
       user,
@@ -178,7 +178,7 @@ class Cas2ApplicationController(
   ): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
 
-    val applicationResult = cas2v2ApplicationService.abandonCas2v2Application(applicationId, user)
+    val applicationResult = cas2ApplicationService.abandonCas2Application(applicationId, user)
     ensureEntityFromCasResultIsSuccess(applicationResult)
     return ResponseEntity.ok(Unit)
   }
@@ -199,7 +199,7 @@ class Cas2ApplicationController(
   private fun getPersonDetailAndTransform(
     application: Cas2ApplicationEntity,
   ): Cas2v2Application {
-    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(application.crn)) {
+    val personInfo = when (val cas2v2OffenderSearchResult = cas2OffenderService.getPersonByNomisIdOrCrn(application.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(application.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: ${application.crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
@@ -17,8 +17,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2StatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationNotesTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2AssessmentsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationNotesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2AssessmentsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.net.URI
@@ -28,8 +28,8 @@ import java.util.UUID
 class Cas2AssessmentsController(
   private val cas2AssessmentService: Cas2AssessmentService,
   private val cas2ApplicationNoteService: Cas2ApplicationNoteService,
-  private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
-  private val cas2v2ApplicationNotesTransformer: Cas2v2ApplicationNotesTransformer,
+  private val cas2AssessmentsTransformer: Cas2AssessmentsTransformer,
+  private val cas2ApplicationNotesTransformer: Cas2ApplicationNotesTransformer,
   private val cas2StatusUpdateService: Cas2StatusUpdateService,
   private val cas2UserService: Cas2UserService,
 ) {
@@ -41,7 +41,7 @@ class Cas2AssessmentsController(
   ): ResponseEntity<Cas2v2Assessment> {
     val assessmentResult = cas2AssessmentService.getAssessment(assessmentId)
     val cas2AssessmentEntity = extractEntityFromCasResult(assessmentResult)
-    return ResponseEntity.ok(cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity))
+    return ResponseEntity.ok(cas2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity))
   }
 
   @Operation(description = "Update an assessment. There are no constraints on who can access this endpoint")
@@ -54,7 +54,7 @@ class Cas2AssessmentsController(
 
     val cas2AssessmentEntity = extractEntityFromCasResult(assessmentResult)
     return ResponseEntity.ok(
-      cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity),
+      cas2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity),
     )
   }
 
@@ -84,7 +84,7 @@ class Cas2AssessmentsController(
     val note = extractEntityFromCasResult(noteResult)
     return ResponseEntity.created(URI.create("/cas2v2/assessments/$assessmentId/notes/${note.id}"))
       .body(
-        cas2v2ApplicationNotesTransformer.transformJpaToApi(note),
+        cas2ApplicationNotesTransformer.transformJpaToApi(note),
       )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
@@ -24,8 +24,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCa
 import java.net.URI
 import java.util.UUID
 
-@Cas2v2Controller
-class Cas2v2AssessmentsController(
+@Cas2Controller
+class Cas2AssessmentsController(
   private val cas2v2AssessmentService: Cas2v2AssessmentService,
   private val cas2v2ApplicationNoteService: Cas2v2ApplicationNoteService,
   private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2AssessmentsController.kt
@@ -13,10 +13,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2AssessmentStatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2v2ApplicationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2v2Assessment
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationNoteService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2AssessmentService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2StatusUpdateService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationNoteService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2StatusUpdateService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationNotesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2AssessmentsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
@@ -26,12 +26,12 @@ import java.util.UUID
 
 @Cas2Controller
 class Cas2AssessmentsController(
-  private val cas2v2AssessmentService: Cas2v2AssessmentService,
-  private val cas2v2ApplicationNoteService: Cas2v2ApplicationNoteService,
+  private val cas2AssessmentService: Cas2AssessmentService,
+  private val cas2ApplicationNoteService: Cas2ApplicationNoteService,
   private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
   private val cas2v2ApplicationNotesTransformer: Cas2v2ApplicationNotesTransformer,
-  private val cas2v2StatusUpdateService: Cas2v2StatusUpdateService,
-  private val cas2v2UserService: Cas2v2UserService,
+  private val cas2StatusUpdateService: Cas2StatusUpdateService,
+  private val cas2UserService: Cas2UserService,
 ) {
 
   @Operation(description = "Get an assessment. There are no constraints on assessments returned")
@@ -39,7 +39,7 @@ class Cas2AssessmentsController(
   fun assessmentsAssessmentIdGet(
     @PathVariable assessmentId: UUID,
   ): ResponseEntity<Cas2v2Assessment> {
-    val assessmentResult = cas2v2AssessmentService.getAssessment(assessmentId)
+    val assessmentResult = cas2AssessmentService.getAssessment(assessmentId)
     val cas2AssessmentEntity = extractEntityFromCasResult(assessmentResult)
     return ResponseEntity.ok(cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity))
   }
@@ -50,7 +50,7 @@ class Cas2AssessmentsController(
     @PathVariable assessmentId: UUID,
     @RequestBody updateCas2Assessment: UpdateCas2v2Assessment,
   ): ResponseEntity<Cas2v2Assessment> {
-    val assessmentResult = cas2v2AssessmentService.updateAssessment(assessmentId, updateCas2Assessment)
+    val assessmentResult = cas2AssessmentService.updateAssessment(assessmentId, updateCas2Assessment)
 
     val cas2AssessmentEntity = extractEntityFromCasResult(assessmentResult)
     return ResponseEntity.ok(
@@ -63,10 +63,10 @@ class Cas2AssessmentsController(
     @PathVariable assessmentId: UUID,
     @RequestBody cas2v2AssessmentStatusUpdate: Cas2v2AssessmentStatusUpdate,
   ): ResponseEntity<Unit> {
-    val result = cas2v2StatusUpdateService.createForAssessment(
+    val result = cas2StatusUpdateService.createForAssessment(
       assessmentId = assessmentId,
       statusUpdate = cas2v2AssessmentStatusUpdate,
-      assessor = cas2v2UserService.getUserForRequest(),
+      assessor = cas2UserService.getUserForRequest(),
     )
 
     processAuthorisationFor(result).run { processValidation(result) }
@@ -79,7 +79,7 @@ class Cas2AssessmentsController(
     @PathVariable assessmentId: UUID,
     @RequestBody body: NewCas2v2ApplicationNote,
   ): ResponseEntity<Cas2v2ApplicationNote> {
-    val noteResult = cas2v2ApplicationNoteService.createAssessmentNote(assessmentId, body)
+    val noteResult = cas2ApplicationNoteService.createAssessmentNote(assessmentId, body)
 
     val note = extractEntityFromCasResult(noteResult)
     return ResponseEntity.created(URI.create("/cas2v2/assessments/$assessmentId/notes/${note.id}"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2Controller.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2Controller.kt
@@ -11,4 +11,4 @@ import org.springframework.web.bind.annotation.RestController
   value = [ "\${api.base-path:}/cas2"],
   produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
 )
-internal annotation class Cas2v2Controller
+internal annotation class Cas2Controller

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2OASysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2OASysController.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2v2OASysAs
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2v2OAsysRiskToSelfDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2v2OAsysRoshRatingsDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2v2OAsysRoshSummaryDto
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2OASysTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2OASysTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCa
 @Cas2Controller
 class Cas2OASysController(
   val oasysService: OASysService,
-  val cas2v2OASysTransformer: Cas2v2OASysTransformer,
+  val cas2OASysTransformer: Cas2OASysTransformer,
 ) {
 
   @GetMapping("/people/{crn}/oasys/metadata")
@@ -27,7 +27,7 @@ class Cas2OASysController(
       else -> extractEntityFromCasResult(result)
     }
 
-    return ResponseEntity.ok(cas2v2OASysTransformer.toOASysAssessmentMetadataDto(assessment))
+    return ResponseEntity.ok(cas2OASysTransformer.toOASysAssessmentMetadataDto(assessment))
   }
 
   @GetMapping("/people/{crn}/oasys/risk-to-self")
@@ -39,7 +39,7 @@ class Cas2OASysController(
       else -> extractEntityFromCasResult(result)
     }
 
-    return ResponseEntity.ok(cas2v2OASysTransformer.toOASysRiskToSelfDto(risksToTheIndividual))
+    return ResponseEntity.ok(cas2OASysTransformer.toOASysRiskToSelfDto(risksToTheIndividual))
   }
 
   @GetMapping("/people/{crn}/oasys/rosh-summary")
@@ -51,7 +51,7 @@ class Cas2OASysController(
       else -> extractEntityFromCasResult(result)
     }
 
-    return ResponseEntity.ok(cas2v2OASysTransformer.toOASysRoshSummaryDto(roshSummary))
+    return ResponseEntity.ok(cas2OASysTransformer.toOASysRoshSummaryDto(roshSummary))
   }
 
   @GetMapping("/people/{crn}/oasys/rosh-ratings")
@@ -63,6 +63,6 @@ class Cas2OASysController(
       else -> extractEntityFromCasResult(result)
     }
 
-    return ResponseEntity.ok(cas2v2OASysTransformer.toOASysRoshRatingsDto(roshRatings))
+    return ResponseEntity.ok(cas2OASysTransformer.toOASysRoshRatingsDto(roshRatings))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2OASysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2OASysController.kt
@@ -12,8 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 
-@Cas2v2Controller
-class Cas2V2OASysController(
+@Cas2Controller
+class Cas2OASysController(
   val oasysService: OASysService,
   val cas2v2OASysTransformer: Cas2v2OASysTransformer,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2PeopleController.kt
@@ -4,8 +4,8 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundProblem

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2PeopleController.kt
@@ -5,14 +5,14 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.BadRequestProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundProblem
 
 @Cas2Controller
 class Cas2PeopleController(
-  private val cas2v2OffenderService: Cas2v2OffenderService,
+  private val cas2OffenderService: Cas2OffenderService,
 ) {
 
   @Suppress("ThrowsCount")
@@ -20,7 +20,7 @@ class Cas2PeopleController(
   fun searchByCrnGet(
     @PathVariable crn: String,
   ): ResponseEntity<Person> {
-    when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(crn)) {
+    when (val cas2v2OffenderSearchResult = cas2OffenderService.getPersonByNomisIdOrCrn(crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(crn, "Offender", "a CRN")
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for CRN: $crn")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
@@ -33,7 +33,7 @@ class Cas2PeopleController(
   fun searchByNomisIdGet(
     @PathVariable nomsNumber: String,
   ): ResponseEntity<Person> {
-    when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)) {
+    when (val cas2v2OffenderSearchResult = cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(nomsNumber, "Offender", "a nomsNumber (prison number)")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: $nomsNumber")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2PeopleController.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.BadReques
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundProblem
 
-@Cas2v2Controller
-class Cas2v2PeopleController(
+@Cas2Controller
+class Cas2PeopleController(
   private val cas2v2OffenderService: Cas2v2OffenderService,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReferenceDataController.kt
@@ -7,8 +7,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2Persisted
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 
-@Cas2v2Controller
-class Cas2v2ReferenceDataController(
+@Cas2Controller
+class Cas2ReferenceDataController(
   private val statusTransformer: Cas2HdcApplicationStatusTransformer,
   private val statusFinder: Cas2v2PersistedApplicationStatusFinder,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReferenceDataController.kt
@@ -4,13 +4,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 
 @Cas2Controller
 class Cas2ReferenceDataController(
   private val statusTransformer: Cas2HdcApplicationStatusTransformer,
-  private val statusFinder: Cas2v2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2PersistedApplicationStatusFinder,
 ) {
   @GetMapping("/reference-data/application-status")
   fun referenceDataApplicationStatusGet(): ResponseEntity<List<Cas2v2ApplicationStatus>> = ResponseEntity.ok(transformToApi(statusFinder.active()))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ReportNa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ReportsService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.generateXlsxStreamingResponse
 
-@Cas2v2Controller
-class Cas2v2ReportsController(private val cas2v2ReportService: Cas2v2ReportsService) {
+@Cas2Controller
+class Cas2ReportsController(private val cas2v2ReportService: Cas2v2ReportsService) {
 
   @GetMapping("/reports/{reportName}")
   fun reportsReportNameGet(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2ReportsController.kt
@@ -5,11 +5,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ReportName
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ReportsService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ReportsService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.generateXlsxStreamingResponse
 
 @Cas2Controller
-class Cas2ReportsController(private val cas2v2ReportService: Cas2v2ReportsService) {
+class Cas2ReportsController(private val cas2v2ReportService: Cas2ReportsService) {
 
   @GetMapping("/reports/{reportName}")
   fun reportsReportNameGet(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
@@ -30,8 +30,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.ensureEntityFromCas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 import java.util.UUID
 
-@Cas2v2Controller
-class Cas2v2SubmissionsController(
+@Cas2Controller
+class Cas2SubmissionsController(
   private val cas2v2ApplicationService: Cas2v2ApplicationService,
   private val cas2v2SubmissionsTransformer: Cas2v2SubmissionsTransformer,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
@@ -13,10 +13,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Submitte
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2SubmittedApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
@@ -32,12 +32,12 @@ import java.util.UUID
 
 @Cas2Controller
 class Cas2SubmissionsController(
-  private val cas2v2ApplicationService: Cas2v2ApplicationService,
+  private val cas2ApplicationService: Cas2ApplicationService,
   private val cas2v2SubmissionsTransformer: Cas2v2SubmissionsTransformer,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
-  private val cas2v2OffenderService: Cas2v2OffenderService,
+  private val cas2OffenderService: Cas2OffenderService,
   private val offenderService: Cas2HdcOffenderService,
-  private val userService: Cas2v2UserService,
+  private val userService: Cas2UserService,
 ) {
 
   @Operation(description = "Get all submitted applications, paged. There are no constraints on assessments returned")
@@ -50,7 +50,7 @@ class Cas2SubmissionsController(
     val sortDirection = SortDirection.asc
     val sortBy = "submittedAt"
 
-    val (applications, metadata) = cas2v2ApplicationService.getAllSubmittedCas2v2ApplicationsForAssessor(PageCriteria(sortBy, sortDirection, page))
+    val (applications, metadata) = cas2ApplicationService.getAllSubmittedCas2ApplicationsForAssessor(PageCriteria(sortBy, sortDirection, page))
 
     return ResponseEntity.ok().headers(
       metadata?.toHeaders(),
@@ -64,7 +64,7 @@ class Cas2SubmissionsController(
   ): ResponseEntity<Cas2v2SubmittedApplication> {
     userService.getUserForRequest()
 
-    val applicationResult = cas2v2ApplicationService.getSubmittedCas2v2ApplicationForAssessor(applicationId)
+    val applicationResult = cas2ApplicationService.getSubmittedCas2ApplicationForAssessor(applicationId)
     val application = extractEntityFromCasResult(applicationResult)
 
     return ResponseEntity.ok(getPersonDetailAndTransform(application))
@@ -77,7 +77,7 @@ class Cas2SubmissionsController(
     @RequestBody submitCas2v2Application: SubmitCas2v2Application,
   ): ResponseEntity<Unit> {
     val user = userService.getUserForRequest()
-    val submitResult = cas2v2ApplicationService.submitCas2v2Application(submitCas2v2Application, user)
+    val submitResult = cas2ApplicationService.submitCas2Application(submitCas2v2Application, user)
     ensureEntityFromCasResultIsSuccess(submitResult)
 
     return ResponseEntity(HttpStatus.OK)
@@ -99,7 +99,7 @@ class Cas2SubmissionsController(
   private fun getPersonDetailAndTransform(
     application: Cas2ApplicationEntity,
   ): Cas2v2SubmittedApplication {
-    val personInfo = when (val cas2v2OffenderSearchResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(application.crn)) {
+    val personInfo = when (val cas2v2OffenderSearchResult = cas2OffenderService.getPersonByNomisIdOrCrn(application.crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> throw NotFoundProblem(application.crn, "Offender")
       is Cas2v2OffenderSearchResult.Forbidden -> throw ForbiddenProblem()
       is Cas2v2OffenderSearchResult.Unknown -> throw cas2v2OffenderSearchResult.throwable ?: BadRequestProblem(errorDetail = "Could not retrieve person info for Prison Number: ${application.crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
@@ -14,9 +14,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Submitte
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2SubmissionsController.kt
@@ -17,8 +17,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2Applica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2SubmissionsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2SubmissionsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationSummaryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcOffenderService
@@ -33,8 +33,8 @@ import java.util.UUID
 @Cas2Controller
 class Cas2SubmissionsController(
   private val cas2ApplicationService: Cas2ApplicationService,
-  private val cas2v2SubmissionsTransformer: Cas2v2SubmissionsTransformer,
-  private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
+  private val cas2SubmissionsTransformer: Cas2SubmissionsTransformer,
+  private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
   private val cas2OffenderService: Cas2OffenderService,
   private val offenderService: Cas2HdcOffenderService,
   private val userService: Cas2UserService,
@@ -91,7 +91,7 @@ class Cas2SubmissionsController(
     val personNamesMap = offenderService.getMapOfPersonNamesAndCrns(crns)
 
     return applicationSummaries.map { application ->
-      cas2v2SubmissionsTransformer.transformJpaSummaryToApiRepresentation(application, personNamesMap[application.crn]!!)
+      cas2SubmissionsTransformer.transformJpaSummaryToApiRepresentation(application, personNamesMap[application.crn]!!)
     }
   }
 
@@ -106,6 +106,6 @@ class Cas2SubmissionsController(
       is Cas2v2OffenderSearchResult.Success.Full -> cas2v2OffenderSearchResult.person
     }
 
-    return cas2v2ApplicationsTransformer.transformJpaAndFullPersonToApiSubmitted(application, personInfo)
+    return cas2ApplicationsTransformer.transformJpaAndFullPersonToApiSubmitted(application, personInfo)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
@@ -5,8 +5,8 @@ import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2v2UserDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcUserService
 
-@Cas2v2Controller
-class Cas2v2UsersController(
+@Cas2Controller
+class Cas2UsersController(
   private val cas2HdcUserService: Cas2HdcUserService,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalController.kt
@@ -11,4 +11,4 @@ import org.springframework.web.bind.annotation.RestController
   value = [ "\${api.base-path:}/cas2/external"],
   produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE],
 )
-internal annotation class Cas2v2ExternalController
+internal annotation class Cas2ExternalController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
@@ -5,22 +5,22 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ReferralHistory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
 
 @Cas2ExternalController
 class Cas2ExternalReferralController(
-  private val cas2v2ApplicationService: Cas2v2ApplicationService,
+  private val cas2ApplicationService: Cas2ApplicationService,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
 
-) {
+  ) {
 
   @PreAuthorize("hasRole('APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE')")
   @GetMapping("/referrals/{crn}")
   fun getReferralsByCrn(
     @PathVariable crn: String,
   ): ResponseEntity<List<Cas2v2ReferralHistory>> = ResponseEntity.ok(
-    cas2v2ApplicationService.getSubmittedApplicationsByCrn(crn).map {
+    cas2ApplicationService.getSubmittedApplicationsByCrn(crn).map {
       cas2v2ApplicationsTransformer.transformJpaToCas2v2ReferralHistory(it)
     },
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Referral
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
 
-@Cas2v2ExternalController
-class Cas2v2ExternalReferralController(
+@Cas2ExternalController
+class Cas2ExternalReferralController(
   private val cas2v2ApplicationService: Cas2v2ApplicationService,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
@@ -6,12 +6,12 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ReferralHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 
 @Cas2ExternalController
 class Cas2ExternalReferralController(
   private val cas2ApplicationService: Cas2ApplicationService,
-  private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
+  private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
 
   ) {
 
@@ -21,7 +21,7 @@ class Cas2ExternalReferralController(
     @PathVariable crn: String,
   ): ResponseEntity<List<Cas2v2ReferralHistory>> = ResponseEntity.ok(
     cas2ApplicationService.getSubmittedApplicationsByCrn(crn).map {
-      cas2v2ApplicationsTransformer.transformJpaToCas2v2ReferralHistory(it)
+      cas2ApplicationsTransformer.transformJpaToCas2ReferralHistory(it)
     },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/external/Cas2ExternalReferralController.kt
@@ -13,7 +13,7 @@ class Cas2ExternalReferralController(
   private val cas2ApplicationService: Cas2ApplicationService,
   private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
 
-  ) {
+) {
 
   @PreAuthorize("hasRole('APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE')")
   @GetMapping("/referrals/{crn}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOri
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentEntity
@@ -36,7 +36,7 @@ class Cas2ApplicationsSeedJob(
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val assessmentRepository: Cas2AssessmentRepository,
   private val statusFinder: Cas2PersistedApplicationStatusFinder,
-  private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
+  private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
 ) : SeedJob<Cas2ApplicationSeedCsvRow>(
   requiredHeaders = setOf("id", "nomsNumber", "crn", "state", "createdBy", "createdAt", "applicationOrigin", "bailHearingDate", "submittedAt", "statusUpdates", "location"),
 ) {
@@ -49,7 +49,7 @@ class Cas2ApplicationsSeedJob(
     state = columns["state"]!!.trim(),
     createdBy = columns["createdBy"]!!.trim(),
     createdAt = OffsetDateTime.parse(columns["createdAt"]),
-    applicationOrigin = cas2v2ApplicationsTransformer.applicationOriginFromText(columns["applicationOrigin"]!!.trim()),
+    applicationOrigin = cas2ApplicationsTransformer.applicationOriginFromText(columns["applicationOrigin"]!!.trim()),
     bailHearingDate = OffsetDateTime.parse(columns["bailHearingDate"]),
     submittedAt = parseDateIfNotNull(emptyToNull(columns["submittedAt"])),
     statusUpdates = columns["statusUpdates"]!!.trim(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
@@ -35,7 +35,7 @@ class Cas2ApplicationsSeedJob(
   private val cas2UserRepository: Cas2UserRepository,
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val assessmentRepository: Cas2AssessmentRepository,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2HdcPersistedApplicationStatusFinder,
   private val cas2ApplicationsTransformer: Cas2ApplicationsTransformer,
 ) : SeedJob<Cas2ApplicationSeedCsvRow>(
   requiredHeaders = setOf("id", "nomsNumber", "crn", "state", "createdBy", "createdAt", "applicationOrigin", "bailHearingDate", "submittedAt", "statusUpdates", "location"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
@@ -19,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2S
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedColumns
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.insertHdcDates

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2ApplicationsSeedJob.kt
@@ -30,19 +30,19 @@ import java.util.UUID
 
 @Component
 @SuppressWarnings("LongParameterList")
-class Cas2v2ApplicationsSeedJob(
+class Cas2ApplicationsSeedJob(
   private val repository: Cas2ApplicationRepository,
   private val cas2UserRepository: Cas2UserRepository,
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val assessmentRepository: Cas2AssessmentRepository,
   private val statusFinder: Cas2PersistedApplicationStatusFinder,
   private val cas2v2ApplicationsTransformer: Cas2v2ApplicationsTransformer,
-) : SeedJob<Cas2v2ApplicationSeedCsvRow>(
+) : SeedJob<Cas2ApplicationSeedCsvRow>(
   requiredHeaders = setOf("id", "nomsNumber", "crn", "state", "createdBy", "createdAt", "applicationOrigin", "bailHearingDate", "submittedAt", "statusUpdates", "location"),
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun deserializeRow(columns: Map<String, String>) = Cas2v2ApplicationSeedCsvRow(
+  override fun deserializeRow(columns: Map<String, String>) = Cas2ApplicationSeedCsvRow(
     id = UUID.fromString(columns["id"]!!.trim()),
     nomsNumber = columns["nomsNumber"]!!.trim(),
     crn = columns["crn"]!!.trim(),
@@ -59,7 +59,7 @@ class Cas2v2ApplicationsSeedJob(
   )
 
   @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
-  override fun processRow(row: Cas2v2ApplicationSeedCsvRow) {
+  override fun processRow(row: Cas2ApplicationSeedCsvRow) {
     log.info("Setting up Application id ${row.id}")
     if (repository.findById(row.id).isPresent) {
       return log.info("Skipping ${row.id}: already seeded")
@@ -74,7 +74,7 @@ class Cas2v2ApplicationsSeedJob(
     }
   }
 
-  private fun createApplication(row: Cas2v2ApplicationSeedCsvRow, cas2UserEntity: Cas2UserEntity) {
+  private fun createApplication(row: Cas2ApplicationSeedCsvRow, cas2UserEntity: Cas2UserEntity) {
     val application = repository.save(
       Cas2ApplicationEntity(
         id = row.id,
@@ -101,7 +101,7 @@ class Cas2v2ApplicationsSeedJob(
     }
   }
 
-  private fun applyFirstClassFields(application: Cas2ApplicationEntity, row: Cas2v2ApplicationSeedCsvRow) {
+  private fun applyFirstClassFields(application: Cas2ApplicationEntity, row: Cas2ApplicationSeedCsvRow) {
     repository.saveAndFlush(
       application.apply {
         referringPrisonCode = row.referringPrisonCode
@@ -182,7 +182,7 @@ class Cas2v2ApplicationsSeedJob(
   private fun parseDateIfNotNull(date: String?) = date?.let { OffsetDateTime.parse(it) }
 }
 
-data class Cas2v2ApplicationSeedCsvRow(
+data class Cas2ApplicationSeedCsvRow(
   val id: UUID,
   val nomsNumber: String,
   val crn: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2StatusUpdateService
@@ -48,7 +48,7 @@ class Cas2StartupScript(
   private val cas2assessmentRepository: Cas2AssessmentRepository,
   private val cas2ApplicationService: Cas2ApplicationService,
   private val cas2StatusUpdateService: Cas2StatusUpdateService,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2HdcPersistedApplicationStatusFinder,
 ) {
   fun script() {
     seedLogger.info("Running Start up Script for CAS2v2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOri
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2StatusUpdateService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2StatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentEntity
@@ -46,8 +46,8 @@ class Cas2StartupScript(
   private val cas2applicationRepository: Cas2ApplicationRepository,
   private val cas2statusUpdateRepository: Cas2StatusUpdateRepository,
   private val cas2assessmentRepository: Cas2AssessmentRepository,
-  private val cas2v2applicationService: Cas2v2ApplicationService,
-  private val cas2v2statusUpdateService: Cas2v2StatusUpdateService,
+  private val cas2ApplicationService: Cas2ApplicationService,
+  private val cas2StatusUpdateService: Cas2StatusUpdateService,
   private val statusFinder: Cas2PersistedApplicationStatusFinder,
 ) {
   fun script() {
@@ -89,7 +89,7 @@ class Cas2StartupScript(
 
     if (listOf("SUBMITTED", "IN_REVIEW").contains(state)) {
       val appWithPromotedProperties = applyFirstClassProperties(application)
-      cas2v2applicationService.createCas2ApplicationSubmittedEvent(appWithPromotedProperties)
+      cas2ApplicationService.createCas2ApplicationSubmittedEvent(appWithPromotedProperties)
       createAssessment(application)
     }
 
@@ -129,7 +129,7 @@ class Cas2StartupScript(
     )
     update.apply { this.createdAt = application.submittedAt!!.plusDays(idx + 1.toLong()) }
     cas2statusUpdateRepository.save(update)
-    cas2v2statusUpdateService.createStatusUpdatedDomainEvent(update)
+    cas2StatusUpdateService.createStatusUpdatedDomainEvent(update)
   }
 
   private fun findStatusAtPosition(idx: Int): Cas2PersistedApplicationStatus = statusFinder.active()[idx]

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
@@ -39,7 +39,7 @@ const val MOST_UPDATES = 6
 const val MINUTES_PER_DAY = 60 * 24
 
 @Component
-class Cas2v2StartupScript(
+class Cas2StartupScript(
   private val seedLogger: SeedLogger,
   private val seedConfig: SeedConfig,
   private val cas2UserRepository: Cas2UserRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2StartupScript.kt
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2StatusUpdateService
@@ -19,6 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2S
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.insertHdcDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2UsersSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/seed/Cas2UsersSeedJob.kt
@@ -13,9 +13,9 @@ import java.util.UUID
 import kotlin.random.Random
 
 @Component
-class Cas2v2UsersSeedJob(
+class Cas2UsersSeedJob(
   private val cas2UserRepository: Cas2UserRepository,
-) : SeedJob<Cas2v2UserSeedCsvRow>(
+) : SeedJob<Cas2UserSeedCsvRow>(
   requiredHeaders = setOf(
     "username",
     "email",
@@ -33,7 +33,7 @@ class Cas2v2UsersSeedJob(
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun deserializeRow(columns: Map<String, String>) = Cas2v2UserSeedCsvRow(
+  override fun deserializeRow(columns: Map<String, String>) = Cas2UserSeedCsvRow(
     username = columns["username"]!!.trim().uppercase(),
     email = columns["email"]!!.trim(),
     name = columns["name"]!!.trim(),
@@ -50,7 +50,7 @@ class Cas2v2UsersSeedJob(
   )
 
   @SuppressWarnings("TooGenericExceptionThrown", "TooGenericExceptionCaught")
-  override fun processRow(row: Cas2v2UserSeedCsvRow) {
+  override fun processRow(row: Cas2UserSeedCsvRow) {
     log.info("Setting up ${row.username}")
 
     val users = cas2UserRepository.findAll()
@@ -69,7 +69,7 @@ class Cas2v2UsersSeedJob(
   }
 
   @SuppressWarnings("MagicNumber")
-  private fun createCas2User(row: Cas2v2UserSeedCsvRow) {
+  private fun createCas2User(row: Cas2UserSeedCsvRow) {
     cas2UserRepository.save(
       Cas2UserEntity(
         id = UUID.randomUUID(),
@@ -99,7 +99,7 @@ class Cas2v2UsersSeedJob(
   }
 }
 
-data class Cas2v2UserSeedCsvRow(
+data class Cas2UserSeedCsvRow(
   val username: String,
   val email: String,
   val name: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
@@ -25,12 +25,12 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
-class Cas2v2ApplicationNoteService(
+class Cas2ApplicationNoteService(
   private val cas2ApplicationRepository: Cas2ApplicationRepository,
   private val cas2AssessmentRepository: Cas2AssessmentRepository,
   private val cas2ApplicationNoteRepository: Cas2ApplicationNoteRepository,
-  private val userService: Cas2v2UserService,
-  private val userAccessService: Cas2v2UserAccessService,
+  private val userService: Cas2UserService,
+  private val userAccessService: Cas2UserAccessService,
   private val emailNotificationService: EmailNotificationService,
   private val notifyConfig: NotifyConfig,
   @Value("\${url-templates.frontend.cas2v2.application-overview}") private val applicationUrlTemplate: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewCas2v2ApplicationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.util.Cas2v2ApplicationUtils
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.util.Cas2ApplicationUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationNoteEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationNoteRepository
@@ -81,7 +81,7 @@ class Cas2ApplicationNoteService(
   ) {
     if (application.createdByUser.email != null) {
       val applicationOrigin = application.applicationOrigin
-      val applicationType = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin)
+      val applicationType = Cas2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin)
 
       val templateId = when (applicationOrigin) {
         ApplicationOrigin.courtBail -> Cas2NotifyTemplates.CAS2_V2_NOTE_ADDED_FOR_REFERRER_COURT_BAIL
@@ -112,7 +112,7 @@ class Cas2ApplicationNoteService(
     savedNote: Cas2ApplicationNoteEntity,
   ) {
     val applicationOrigin = application.applicationOrigin
-    val applicationType = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin)
+    val applicationType = Cas2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin)
 
     val templateId = when (applicationOrigin) {
       ApplicationOrigin.courtBail -> Cas2NotifyTemplates.CAS2_V2_NOTE_ADDED_FOR_ASSESSOR_COURT_BAIL

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -43,15 +43,15 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @Service("Cas2v2ApplicationService")
-class Cas2v2ApplicationService(
+class Cas2ApplicationService(
   private val cas2ApplicationRepository: Cas2ApplicationRepository,
   private val cas2LockableApplicationRepository: Cas2LockableApplicationRepository,
   private val cas2ApplicationSummaryRepository: Cas2ApplicationSummaryRepository,
-  private val cas2v2OffenderService: Cas2v2OffenderService,
-  private val cas2v2UserAccessService: Cas2v2UserAccessService,
+  private val cas2OffenderService: Cas2OffenderService,
+  private val cas2UserAccessService: Cas2UserAccessService,
   private val domainEventService: Cas2DomainEventService,
   private val emailNotificationService: EmailNotificationService,
-  private val cas2v2AssessmentService: Cas2v2AssessmentService,
+  private val cas2AssessmentService: Cas2AssessmentService,
   private val notifyConfig: NotifyConfig,
   private val jsonMapper: JsonMapper,
   private val sentryService: SentryService,
@@ -59,7 +59,7 @@ class Cas2v2ApplicationService(
   @Value("\${url-templates.frontend.cas2v2.submitted-application-overview}") private val submittedApplicationUrlTemplate: String,
 ) {
 
-  fun getCas2v2Applications(
+  fun getCas2Applications(
     prisonCode: String?,
     isSubmitted: Boolean?,
     applicationOrigin: ApplicationOrigin?,
@@ -99,7 +99,7 @@ class Cas2v2ApplicationService(
     return Pair(response.content, metadata)
   }
 
-  fun getAllSubmittedCas2v2ApplicationsForAssessor(pageCriteria: PageCriteria<String>): Pair<List<Cas2ApplicationSummaryEntity>, PaginationMetadata?> {
+  fun getAllSubmittedCas2ApplicationsForAssessor(pageCriteria: PageCriteria<String>): Pair<List<Cas2ApplicationSummaryEntity>, PaginationMetadata?> {
     val pageable = getPageableOrAllPages(pageCriteria)
 
     val response = cas2ApplicationSummaryRepository.findByServiceOriginAndSubmittedAtIsNotNull(Cas2ServiceOrigin.BAIL.toString(), pageable)
@@ -109,7 +109,7 @@ class Cas2v2ApplicationService(
     return Pair(response.content, metadata)
   }
 
-  fun getSubmittedCas2v2ApplicationForAssessor(applicationId: UUID): CasResult<Cas2ApplicationEntity> {
+  fun getSubmittedCas2ApplicationForAssessor(applicationId: UUID): CasResult<Cas2ApplicationEntity> {
     val applicationEntity = cas2ApplicationRepository.findByIdAndServiceOriginAndSubmittedAtIsNotNull(applicationId, Cas2ServiceOrigin.BAIL)
       ?: return CasResult.NotFound("Cas2ApplicationEntity", applicationId.toString())
 
@@ -118,7 +118,7 @@ class Cas2v2ApplicationService(
     )
   }
 
-  fun getCas2v2ApplicationForUser(applicationId: UUID, user: Cas2UserEntity): CasResult<Cas2ApplicationEntity> {
+  fun getCas2ApplicationForUser(applicationId: UUID, user: Cas2UserEntity): CasResult<Cas2ApplicationEntity> {
     val applicationEntity = cas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)
       ?: return CasResult.NotFound("Cas2ApplicationEntity", applicationId.toString())
 
@@ -126,7 +126,7 @@ class Cas2v2ApplicationService(
       return CasResult.NotFound("Cas2ApplicationEntity", applicationId.toString())
     }
 
-    val canAccess = cas2v2UserAccessService.userCanViewCas2v2Application(user, applicationEntity)
+    val canAccess = cas2UserAccessService.userCanViewCas2Application(user, applicationEntity)
 
     return if (canAccess) {
       CasResult.Success(applicationEntity)
@@ -138,13 +138,13 @@ class Cas2v2ApplicationService(
   fun getSubmittedApplicationsByCrn(crn: String): List<Cas2ApplicationEntity> = cas2ApplicationRepository.findAllByCrnAndSubmittedAtIsNotNullAndAssessmentIdIsNotNull(crn)
 
   @SuppressWarnings("TooGenericExceptionThrown")
-  fun createCas2v2Application(
+  fun createCas2Application(
     crn: String,
     user: Cas2UserEntity,
     applicationOrigin: ApplicationOrigin = ApplicationOrigin.homeDetentionCurfew,
     bailHearingDate: LocalDate? = null,
   ) = validated {
-    val offenderDetails = when (val offenderDetailsResult = cas2v2OffenderService.getPersonByNomisIdOrCrn(crn)) {
+    val offenderDetails = when (val offenderDetailsResult = cas2OffenderService.getPersonByNomisIdOrCrn(crn)) {
       is Cas2v2OffenderSearchResult.NotFound -> return "$.crn" hasSingleValidationError "doesNotExist"
       is Cas2v2OffenderSearchResult.Forbidden -> return "$.crn" hasSingleValidationError "userPermission"
       is Cas2v2OffenderSearchResult.Unknown -> return "$.crn" hasSingleValidationError "unknown"
@@ -180,7 +180,7 @@ class Cas2v2ApplicationService(
   }
 
   @SuppressWarnings("ReturnCount")
-  fun updateCas2v2Application(
+  fun updateCas2Application(
     applicationId: UUID,
     data: String?,
     user: Cas2UserEntity,
@@ -215,7 +215,7 @@ class Cas2v2ApplicationService(
   }
 
   @SuppressWarnings("ReturnCount")
-  fun abandonCas2v2Application(applicationId: UUID, user: Cas2UserEntity): CasResult<Cas2ApplicationEntity> {
+  fun abandonCas2Application(applicationId: UUID, user: Cas2UserEntity): CasResult<Cas2ApplicationEntity> {
     val application = cas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)
       ?: return CasResult.NotFound("Cas2ApplicationEntity", applicationId.toString())
 
@@ -243,7 +243,7 @@ class Cas2v2ApplicationService(
 
   @SuppressWarnings("ReturnCount", "TooGenericExceptionThrown")
   @Transactional
-  fun submitCas2v2Application(
+  fun submitCas2Application(
     submitCas2v2Application: SubmitCas2v2Application,
     user: Cas2UserEntity,
   ): CasResult<Cas2ApplicationEntity> {
@@ -360,12 +360,12 @@ class Cas2v2ApplicationService(
   }
 
   fun createAssessment(application: Cas2ApplicationEntity) {
-    cas2v2AssessmentService.createCas2v2Assessment(application)
+    cas2AssessmentService.createCas2Assessment(application)
   }
 
   @SuppressWarnings("ThrowsCount")
   private fun retrievePrisonCode(application: Cas2ApplicationEntity): String {
-    val inmateDetailResult = cas2v2OffenderService.getInmateDetailByNomsNumber(
+    val inmateDetailResult = cas2OffenderService.getInmateDetailByNomsNumber(
       crn = application.crn,
       nomsNumber = application.nomsNumber.toString(),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -42,7 +42,7 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
-@Service("Cas2v2ApplicationService")
+@Service
 class Cas2ApplicationService(
   private val cas2ApplicationRepository: Cas2ApplicationRepository,
   private val cas2LockableApplicationRepository: Cas2LockableApplicationRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2AssessmentService.kt
@@ -12,12 +12,12 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service("Cas2v2AssessmentService")
-class Cas2v2AssessmentService(
+class Cas2AssessmentService(
   private val cas2AssessmentRepository: Cas2AssessmentRepository,
 ) {
 
   @Transactional
-  fun createCas2v2Assessment(cas2ApplicationEntity: Cas2ApplicationEntity): Cas2AssessmentEntity = cas2AssessmentRepository.save(
+  fun createCas2Assessment(cas2ApplicationEntity: Cas2ApplicationEntity): Cas2AssessmentEntity = cas2AssessmentRepository.save(
     Cas2AssessmentEntity(
       id = UUID.randomUUID(),
       createdAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2AssessmentService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import java.time.OffsetDateTime
 import java.util.UUID
 
-@Service("Cas2v2AssessmentService")
+@Service
 class Cas2AssessmentService(
   private val cas2AssessmentRepository: Cas2AssessmentRepository,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.Authorisa
 class Cas2OffenderService(
   private val prisonsApiClient: PrisonsApiClient,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
-  private val cas2v2PersonTransformer: Cas2v2PersonTransformer,
+  private val cas2PersonTransformer: Cas2PersonTransformer,
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -53,7 +53,7 @@ class Cas2OffenderService(
     return when (caseSummary.currentRestriction) {
       false -> Cas2v2OffenderSearchResult.Success.Full(
         nomisIdOrCrn = nomisIdOrCrn,
-        person = cas2v2PersonTransformer.transformCaseSummaryToFullPerson(caseSummary),
+        person = cas2PersonTransformer.transformCaseSummaryToFullPerson(caseSummary),
       )
 
       else -> Cas2v2OffenderSearchResult.Forbidden(nomisIdOrCrn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2OffenderService.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.Authorisa
 @Suppress(
   "ReturnCount",
 )
-class Cas2v2OffenderService(
+class Cas2OffenderService(
   private val prisonsApiClient: PrisonsApiClient,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val cas2v2PersonTransformer: Cas2v2PersonTransformer,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2PersistedApplicationStatusFinder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2PersistedApplicationStatusFinder.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2Applicati
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 
 @Component
-class Cas2v2PersistedApplicationStatusFinder(
+class Cas2PersistedApplicationStatusFinder(
   private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2v2),
 ) {
   fun active(): List<Cas2PersistedApplicationStatus> = statusList.filter { it.isActive }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ReportsService.kt
@@ -14,7 +14,7 @@ import java.io.OutputStream
 import java.time.LocalDate
 
 @Service
-class Cas2v2ReportsService(
+class Cas2ReportsService(
   private val submittedApplicationReportRepository: Cas2SubmittedApplicationReportRepository,
   private val applicationStatusUpdatesReportRepository: Cas2ApplicationStatusUpdatesReportRepository,
   private val unsubmittedApplicationsReportRepository: Cas2UnsubmittedApplicationsReportRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
@@ -35,7 +35,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHo
 import java.time.OffsetDateTime
 import java.util.UUID
 
-@Service("Cas2v2StatusUpdateService")
+@Service
 class Cas2StatusUpdateService(
   private val cas2AssessmentRepository: Cas2AssessmentRepository,
   private val cas2StatusUpdateRepository: Cas2StatusUpdateRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.util.Cas2v2ApplicationUtils
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.util.Cas2ApplicationUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateDetailEntity
@@ -162,7 +162,7 @@ class Cas2StatusUpdateService(
   private fun sendEmailStatusUpdated(user: Cas2UserEntity, application: Cas2ApplicationEntity, status: Cas2StatusUpdateEntity) {
     if (application.createdByUser.email != null) {
       val applicationOrigin = application.applicationOrigin
-      val applicationType = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin)
+      val applicationType = Cas2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin)
 
       val templateId = when (applicationOrigin) {
         ApplicationOrigin.courtBail -> Cas2NotifyTemplates.CAS2_V2_APPLICATION_STATUS_UPDATED_COURT_BAIL

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
@@ -36,13 +36,13 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service("Cas2v2StatusUpdateService")
-class Cas2v2StatusUpdateService(
+class Cas2StatusUpdateService(
   private val cas2AssessmentRepository: Cas2AssessmentRepository,
   private val cas2StatusUpdateRepository: Cas2StatusUpdateRepository,
   private val cas2StatusUpdateDetailRepository: Cas2StatusUpdateDetailRepository,
   private val domainEventService: Cas2DomainEventService,
   private val emailNotificationService: EmailNotificationService,
-  private val cas2v2PersistedApplicationStatusFinder: Cas2v2PersistedApplicationStatusFinder,
+  private val cas2PersistedApplicationStatusFinder: Cas2PersistedApplicationStatusFinder,
   private val statusTransformer: Cas2HdcApplicationStatusTransformer,
   @Value("\${url-templates.frontend.cas2v2.application}") private val applicationUrlTemplate: String,
   @Value("\${url-templates.frontend.cas2v2.application-overview}") private val applicationOverviewUrlTemplate: String,
@@ -108,7 +108,7 @@ class Cas2v2StatusUpdateService(
     return CasResult.Success(createdStatusUpdate)
   }
 
-  private fun findActiveStatusByName(statusName: String): Cas2PersistedApplicationStatus? = cas2v2PersistedApplicationStatusFinder.active()
+  private fun findActiveStatusByName(statusName: String): Cas2PersistedApplicationStatus? = cas2PersistedApplicationStatusFinder.active()
     .find { status -> status.name == statusName }
 
   fun createStatusUpdatedDomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserAccessService.kt
@@ -8,16 +8,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2U
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
 
 @Service("Cas2v2UserAccessService")
-class Cas2v2UserAccessService(
-  private val cas2v2UserService: Cas2v2UserService,
+class Cas2UserAccessService(
+  private val cas2UserService: Cas2UserService,
 ) {
-  fun userCanViewCas2v2Application(
+  fun userCanViewCas2Application(
     user: Cas2UserEntity,
     application: Cas2ApplicationEntity,
   ): Boolean {
     val isPrisonBailReferral = application.applicationOrigin == ApplicationOrigin.prisonBail &&
       application.submittedAt != null &&
-      cas2v2UserService.userForRequestHasRole(
+      cas2UserService.userForRequestHasRole(
         listOf(SimpleGrantedAuthority("ROLE_CAS2_PRISON_BAIL_REFERRER")),
       )
 
@@ -37,7 +37,7 @@ class Cas2v2UserAccessService(
   fun userCanAddNote(user: Cas2UserEntity, application: Cas2ApplicationEntity): Boolean {
     if (
       application.applicationOrigin == ApplicationOrigin.prisonBail &&
-      cas2v2UserService.userForRequestHasRole(
+      cas2UserService.userForRequestHasRole(
         listOf(
           SimpleGrantedAuthority("ROLE_CAS2_PRISON_BAIL_REFERRER"),
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserAccessService.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2A
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
 
-@Service("Cas2v2UserAccessService")
+@Service
 class Cas2UserAccessService(
   private val cas2UserService: Cas2UserService,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import java.util.UUID
 
 @Service
-class Cas2v2UserService(
+class Cas2UserService(
   private val httpAuthService: HttpAuthService,
   private val cas2UserRepository: Cas2UserRepository,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationNotesTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationNotesTransformer.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Applicat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationNoteEntity
 
 @Component
-class Cas2v2ApplicationNotesTransformer {
+class Cas2ApplicationNotesTransformer {
 
   fun transformJpaToApi(
     jpa: Cas2ApplicationNoteEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationsTransformer.kt
@@ -19,13 +19,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransf
 import java.util.UUID
 
 @Component
-class Cas2v2ApplicationsTransformer(
+class Cas2ApplicationsTransformer(
   private val jsonMapper: JsonMapper,
   private val personTransformer: PersonTransformer,
-  private val cas2v2UserTransformer: Cas2v2UserTransformer,
-  private val statusUpdateTransformer: Cas2v2StatusUpdateTransformer,
-  private val timelineEventsTransformer: Cas2v2TimelineEventsTransformer,
-  private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
+  private val cas2UserTransformer: Cas2UserTransformer,
+  private val statusUpdateTransformer: Cas2StatusUpdateTransformer,
+  private val timelineEventsTransformer: Cas2TimelineEventsTransformer,
+  private val cas2AssessmentsTransformer: Cas2AssessmentsTransformer,
   private val offenderManagementUnitRepository: OffenderManagementUnitRepository,
 ) {
 
@@ -34,7 +34,7 @@ class Cas2v2ApplicationsTransformer(
   fun transformJpaAndFullPersonToApi(jpa: Cas2ApplicationEntity, fullPerson: Person) = Cas2v2Application(
     id = jpa.id,
     person = fullPerson,
-    createdBy = cas2v2UserTransformer.transformJpaToApi(jpa.createdByUser),
+    createdBy = cas2UserTransformer.transformJpaToApi(jpa.createdByUser),
     createdAt = jpa.createdAt.toInstant(),
     submittedAt = jpa.submittedAt?.toInstant(),
     data = if (jpa.data != null) jsonMapper.readTree(jpa.data) else null,
@@ -42,7 +42,7 @@ class Cas2v2ApplicationsTransformer(
     status = getStatus(jpa),
     type = "CAS2V2",
     telephoneNumber = jpa.telephoneNumber,
-    assessment = if (jpa.assessment != null) cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
+    assessment = if (jpa.assessment != null) cas2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!) else null,
     timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
     applicationOrigin = jpa.applicationOrigin,
     cohort = jpa.cohort?.apiType,
@@ -51,12 +51,12 @@ class Cas2v2ApplicationsTransformer(
   fun transformJpaAndFullPersonToApiSubmitted(jpa: Cas2ApplicationEntity, fullPerson: Person): Cas2v2SubmittedApplication = Cas2v2SubmittedApplication(
     id = jpa.id,
     person = fullPerson,
-    submittedBy = Cas2v2UserTransformer().transformJpaToApi(jpa.createdByUser),
+    submittedBy = Cas2UserTransformer().transformJpaToApi(jpa.createdByUser),
     createdAt = jpa.createdAt.toInstant(),
     submittedAt = jpa.submittedAt?.toInstant(),
     document = if (jpa.document != null) jsonMapper.readTree(jpa.document) else null,
     telephoneNumber = jpa.telephoneNumber,
-    assessment = cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!),
+    assessment = cas2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!),
     timelineEvents = timelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
     applicationOrigin = jpa.applicationOrigin,
   )
@@ -89,7 +89,7 @@ class Cas2v2ApplicationsTransformer(
     else -> ApplicationOrigin.homeDetentionCurfew
   }
 
-  fun transformJpaToCas2v2ReferralHistory(
+  fun transformJpaToCas2ReferralHistory(
     jpa: Cas2ApplicationEntity,
   ): Cas2v2ReferralHistory {
     val latestStatusUpdate = jpa.statusUpdates?.firstOrNull()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2AssessmentsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2AssessmentsTransformer.kt
@@ -5,8 +5,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessme
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentEntity
 
 @Component
-class Cas2v2AssessmentsTransformer(
-  private val statusUpdateTransformer: Cas2v2StatusUpdateTransformer,
+class Cas2AssessmentsTransformer(
+  private val statusUpdateTransformer: Cas2StatusUpdateTransformer,
 ) {
   fun transformJpaToApiRepresentation(
     jpaAssessment: Cas2AssessmentEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OASysAssessmentInfoTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OASysAssessmentInfoTransformer.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2v2OASysAs
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
 
 @Service
-class Cas2v2OASysAssessmentInfoTransformer {
+class Cas2OASysAssessmentInfoTransformer {
 
   fun toAssessmentMetadata(assessmentInfo: AssessmentInfo?) = assessmentInfo?.let {
     Cas2v2OASysAssessmentMetadataDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OASysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OASysTransformer.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
 
 @Service
-class Cas2v2OASysTransformer {
+class Cas2OASysTransformer {
 
   fun toOASysAssessmentMetadataDto(summary: OASysAssessmentSummary?) = Cas2v2OASysAssessmentMetadataDto(
     hasApplicableAssessment = summary != null,
@@ -21,19 +21,19 @@ class Cas2v2OASysTransformer {
   )
 
   fun toOASysRiskToSelfDto(risksToTheIndividual: RisksToTheIndividual?) = Cas2v2OAsysRiskToSelfDto(
-    metadata = Cas2v2OASysAssessmentInfoTransformer().toAssessmentMetadata(risksToTheIndividual),
+    metadata = Cas2OASysAssessmentInfoTransformer().toAssessmentMetadata(risksToTheIndividual),
     analysisSuicideSelfharm = risksToTheIndividual?.riskToTheIndividual?.analysisSuicideSelfharm,
     analysisVulnerabilities = risksToTheIndividual?.riskToTheIndividual?.analysisVulnerabilities,
   )
 
   fun toOASysRoshSummaryDto(roshSummary: RoshSummary?) = Cas2v2OAsysRoshSummaryDto(
-    metadata = Cas2v2OASysAssessmentInfoTransformer().toAssessmentMetadata(roshSummary),
+    metadata = Cas2OASysAssessmentInfoTransformer().toAssessmentMetadata(roshSummary),
     whoIsAtRisk = roshSummary?.roshSummary?.whoIsAtRisk,
     natureOfRisk = roshSummary?.roshSummary?.natureOfRisk,
   )
 
   fun toOASysRoshRatingsDto(roshRatings: RoshRatings?) = Cas2v2OAsysRoshRatingsDto(
-    metadata = Cas2v2OASysAssessmentInfoTransformer().toAssessmentMetadata(roshRatings),
+    metadata = Cas2OASysAssessmentInfoTransformer().toAssessmentMetadata(roshRatings),
     overallRisk = Cas2V2OASysRiskLevel.forValue(roshRatings?.rosh?.determineOverallRiskLevel()?.name),
     riskToChildren = Cas2V2OASysRiskLevel.forValue(roshRatings?.rosh?.riskChildrenCommunity?.name),
     riskToPublic = Cas2V2OASysRiskLevel.forValue(roshRatings?.rosh?.riskPublicCommunity?.name),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2PersonTransformer.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummary
 
 @Component
-class Cas2v2PersonTransformer {
+class Cas2PersonTransformer {
 
   fun transformCaseSummaryToFullPerson(caseSummary: CaseSummary): FullPerson = FullPerson(
     name = "${caseSummary.name.forename} ${caseSummary.name.surname}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2StatusUpdateTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2StatusUpdateTransformer.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2S
 import java.util.UUID
 
 @Component
-class Cas2v2StatusUpdateTransformer(
-  private val cas2v2UserTransformer: Cas2v2UserTransformer,
+class Cas2StatusUpdateTransformer(
+  private val cas2UserTransformer: Cas2UserTransformer,
 ) {
 
   fun transformJpaToApi(
@@ -21,7 +21,7 @@ class Cas2v2StatusUpdateTransformer(
     name = jpa.status().name,
     label = jpa.label,
     description = jpa.description,
-    updatedBy = cas2v2UserTransformer.transformJpaToApi(jpa.assessor),
+    updatedBy = cas2UserTransformer.transformJpaToApi(jpa.assessor),
     updatedAt = jpa.createdAt.toInstant(),
     statusUpdateDetails = jpa.statusUpdateDetails?.map { detail -> transformStatusUpdateDetailsJpaToApi(detail) },
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2SubmissionsTransformer.kt
@@ -11,12 +11,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransf
 import java.util.UUID
 
 @Component
-class Cas2v2SubmissionsTransformer(
+class Cas2SubmissionsTransformer(
   private val jsonMapper: JsonMapper,
   private val personTransformer: PersonTransformer,
-  private val cas2v2UserTransformer: Cas2v2UserTransformer,
-  private val cas2v2TimelineEventsTransformer: Cas2v2TimelineEventsTransformer,
-  private val cas2v2AssessmentsTransformer: Cas2v2AssessmentsTransformer,
+  private val cas2UserTransformer: Cas2UserTransformer,
+  private val cas2TimelineEventsTransformer: Cas2TimelineEventsTransformer,
+  private val cas2AssessmentsTransformer: Cas2AssessmentsTransformer,
 ) {
 
   fun transformJpaToApiRepresentation(
@@ -26,14 +26,14 @@ class Cas2v2SubmissionsTransformer(
   ): Cas2v2SubmittedApplication = Cas2v2SubmittedApplication(
     id = jpa.id,
     person = personTransformer.transformModelToPersonApi(personInfo),
-    submittedBy = cas2v2UserTransformer.transformJpaToApi(jpa.createdByUser),
+    submittedBy = cas2UserTransformer.transformJpaToApi(jpa.createdByUser),
     createdAt = jpa.createdAt.toInstant(),
     submittedAt = jpa.submittedAt?.toInstant(),
     document = if (jpa.document != null) jsonMapper.readTree(jpa.document) else null,
     telephoneNumber = jpa.telephoneNumber,
     applicationOrigin = jpa.applicationOrigin,
-    timelineEvents = cas2v2TimelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
-    assessment = cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!),
+    timelineEvents = cas2TimelineEventsTransformer.transformApplicationToTimelineEvents(jpa),
+    assessment = cas2AssessmentsTransformer.transformJpaToApiRepresentation(jpa.assessment!!),
   )
 
   fun transformJpaSummaryToApiRepresentation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2TimelineEventsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2TimelineEventsTransformer.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2TimelineE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 
 @Component
-class Cas2v2TimelineEventsTransformer {
+class Cas2TimelineEventsTransformer {
 
   fun transformApplicationToTimelineEvents(jpa: Cas2ApplicationEntity): List<Cas2TimelineEvent> {
     val timelineEvents: MutableList<Cas2TimelineEvent> = mutableListOf()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2UserTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2UserTransformer.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 
 @Component
-class Cas2v2UserTransformer {
+class Cas2UserTransformer {
 
   fun transformJpaToApi(userEntity: Cas2UserEntity): Cas2v2User = Cas2v2User(
     id = userEntity.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/util/Cas2ApplicationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/util/Cas2ApplicationUtils.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Constant
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Constants.CAS2_PRISON_BAIL_APPLICATION_TYPE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Constants.HDC_APPLICATION_TYPE
 
-class Cas2v2ApplicationUtils {
+class Cas2ApplicationUtils {
 
   fun getApplicationTypeFromApplicationOrigin(applicationOrigin: ApplicationOrigin): String {
     val applicationType = when (applicationOrigin) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/controller/Cas2HdcReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/controller/Cas2HdcReferenceDataController.kt
@@ -3,14 +3,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 
 @Cas2HdcController
 class Cas2HdcReferenceDataController(
   private val statusTransformer: Cas2HdcApplicationStatusTransformer,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2HdcPersistedApplicationStatusFinder,
 ) {
   @GetMapping("/reference-data/application-status")
   fun referenceDataApplicationStatusGet(): ResponseEntity<List<Cas2HdcApplicationStatus>> = ResponseEntity.ok(transformToApi(statusFinder.active()))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/controller/Cas2HdcReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/controller/Cas2HdcReferenceDataController.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 
 @Cas2HdcController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcApplicationsSeedJob.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
@@ -33,7 +33,7 @@ class Cas2HdcApplicationsSeedJob(
   private val cas2UserRepository: Cas2UserRepository,
   private val statusUpdateRepository: Cas2StatusUpdateRepository,
   private val assessmentRepository: Cas2AssessmentRepository,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2HdcPersistedApplicationStatusFinder,
 ) : SeedJob<Cas2HdcApplicationSeedCsvRow>(
   requiredHeaders = setOf("id", "nomsNumber", "crn", "state", "createdBy", "createdAt", "submittedAt", "statusUpdates", "location"),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcApplicationsSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcApplicationsSeedJob.kt
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
@@ -18,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2S
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.insertHdcDates
 import java.io.IOException

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcStartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcStartupScript.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
@@ -47,7 +47,7 @@ class Cas2HdcStartupScript(
   private val assessmentRepository: Cas2AssessmentRepository,
   private val applicationService: Cas2HdcApplicationService,
   private val cas2HdcStatusUpdateService: Cas2HdcStatusUpdateService,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2HdcPersistedApplicationStatusFinder,
 ) {
   fun script() {
     seedLogger.info("Running Start up Script for CAS2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcStartupScript.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jobs/seed/Cas2HdcStartupScript.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component
 import org.springframework.util.FileCopyUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
@@ -17,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2U
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcStatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.insertHdcDates

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateDetailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateDetailEntity.kt
@@ -32,9 +32,13 @@ data class Cas2StatusUpdateDetailEntity(
 
   var createdAt: OffsetDateTime = OffsetDateTime.now(),
 ) {
+  companion object {
+    private val statusFinder = Cas2HdcPersistedApplicationStatusFinder()
+  }
+
   override fun toString() = "Cas2StatusDetailEntity: $id"
 
-  fun statusDetail(statusId: UUID, detailId: UUID): Cas2PersistedApplicationStatusDetail = Cas2HdcPersistedApplicationStatusFinder().getById(statusId).statusDetails
+  fun statusDetail(statusId: UUID, detailId: UUID): Cas2PersistedApplicationStatusDetail = statusFinder.getById(statusId).statusDetails
     ?.find { detail -> detail.id == detailId }
     ?: error("Status detail with id $detailId not found")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateDetailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateDetailEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -34,7 +34,7 @@ data class Cas2StatusUpdateDetailEntity(
 ) {
   override fun toString() = "Cas2StatusDetailEntity: $id"
 
-  fun statusDetail(statusId: UUID, detailId: UUID): Cas2PersistedApplicationStatusDetail = Cas2PersistedApplicationStatusFinder().getById(statusId).statusDetails
+  fun statusDetail(statusId: UUID, detailId: UUID): Cas2PersistedApplicationStatusDetail = Cas2HdcPersistedApplicationStatusFinder().getById(statusId).statusDetails
     ?.find { detail -> detail.id == detailId }
     ?: error("Status detail with id $detailId not found")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateEntity.kt
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -61,5 +61,5 @@ data class Cas2StatusUpdateEntity(
 ) {
   override fun toString() = "Cas2StatusEntity: $id"
 
-  fun status(): Cas2PersistedApplicationStatus = Cas2PersistedApplicationStatusFinder().getById(statusId)
+  fun status(): Cas2PersistedApplicationStatus = Cas2HdcPersistedApplicationStatusFinder().getById(statusId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/StatusUpdateEntity.kt
@@ -59,7 +59,11 @@ data class Cas2StatusUpdateEntity(
   val statusUpdateDetails: List<Cas2StatusUpdateDetailEntity>? = null,
   var createdAt: OffsetDateTime = OffsetDateTime.now(),
 ) {
+  companion object {
+    private val statusFinder = Cas2HdcPersistedApplicationStatusFinder()
+  }
+
   override fun toString() = "Cas2StatusEntity: $id"
 
-  fun status(): Cas2PersistedApplicationStatus = Cas2HdcPersistedApplicationStatusFinder().getById(statusId)
+  fun status(): Cas2PersistedApplicationStatus = statusFinder.getById(statusId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcPersistedApplicationStatusFinder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcPersistedApplicationStatusFinder.kt
@@ -1,12 +1,14 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationStatusSeeding
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import java.util.UUID
 
 @Component
-class Cas2PersistedApplicationStatusFinder(
-  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2),
+class Cas2HdcPersistedApplicationStatusFinder(
+    private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2),
 ) {
   fun all(): List<Cas2PersistedApplicationStatus> = statusList
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcPersistedApplicationStatusFinder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcPersistedApplicationStatusFinder.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 @Component
 class Cas2HdcPersistedApplicationStatusFinder(
-    private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2),
+  private val statusList: List<Cas2PersistedApplicationStatus> = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2),
 ) {
   fun all(): List<Cas2PersistedApplicationStatus> = statusList
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcStatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcStatusUpdateService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ex
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcAssessmentStatusUpdate
@@ -50,7 +49,7 @@ class Cas2HdcStatusUpdateService(
   private val statusUpdateDetailRepository: Cas2StatusUpdateDetailRepository,
   private val domainEventService: Cas2DomainEventService,
   private val emailNotificationService: EmailNotificationService,
-  private val statusFinder: Cas2PersistedApplicationStatusFinder,
+  private val statusFinder: Cas2HdcPersistedApplicationStatusFinder,
   private val statusTransformer: Cas2HdcApplicationStatusTransformer,
   private val cas2HdcEmailService: Cas2HdcEmailService,
   @Value("\${url-templates.frontend.cas2.application}") private val applicationUrlTemplate: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/seed/SeedOnStartupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/seed/SeedOnStartupService.kt
@@ -7,7 +7,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1StartupScript
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2v2StartupScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2StartupScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcStartupScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.SeedConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EnvironmentService
@@ -20,7 +20,7 @@ class SeedOnStartupService(
   private val seedConfig: SeedConfig,
   private val cas1StartupScript: Cas1StartupScript,
   private val cas2HdcStartupScript: Cas2HdcStartupScript,
-  private val cas2v2StartupScript: Cas2v2StartupScript,
+  private val cas2StartupScript: Cas2StartupScript,
   private val seedService: SeedService,
   private val seedLogger: SeedLogger,
   private val environmentService: EnvironmentService,
@@ -89,7 +89,7 @@ class SeedOnStartupService(
     }
 
     if (startupConfig.script.cas2v2Enabled) {
-      cas2v2StartupScript.script()
+      cas2StartupScript.script()
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/seed/SeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/seed/SeedService.kt
@@ -34,8 +34,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdatePrem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UpdateSpaceBookingSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1WithdrawPlacementRequestSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2v2ApplicationsSeedJob
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2v2UsersSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2ApplicationsSeedJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2UsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcApplicationsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcExternalUsersSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcNomisUserEmailSeedJob
@@ -86,8 +86,8 @@ class SeedService(
         SeedFileType.nomisUsers -> getBean(Cas2HdcNomisUsersSeedJob::class)
         SeedFileType.externalUsers -> getBean(Cas2HdcExternalUsersSeedJob::class)
         SeedFileType.cas2Applications -> getBean(Cas2HdcApplicationsSeedJob::class)
-        SeedFileType.cas2v2Applications -> getBean(Cas2v2ApplicationsSeedJob::class)
-        SeedFileType.cas2v2Users -> getBean(Cas2v2UsersSeedJob::class)
+        SeedFileType.cas2v2Applications -> getBean(Cas2ApplicationsSeedJob::class)
+        SeedFileType.cas2v2Users -> getBean(Cas2UsersSeedJob::class)
         SeedFileType.cas2Users -> getBean(Cas2HdcUsersSeedJob::class)
         SeedFileType.approvedPremisesUsers -> getBean(Cas1UsersSeedJob::class)
         SeedFileType.temporaryAccommodationUsers -> getBean(Cas3UsersSeedJob::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -31,7 +31,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.Cas2v2Constants.Cas2v2Role
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.Cas2Constants.Cas2Role
 import java.time.Duration
 import java.util.Base64
 
@@ -86,7 +86,7 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasAnyAuthority("ROLE_CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyAuthority("ROLE_CAS2_ASSESSOR", "ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2/reports/**", hasAuthority("ROLE_CAS2_MI"))
-        authorize(HttpMethod.GET, "/cas2/people/*/oasys/**", hasAnyAuthority(Cas2v2Role.COURT_BAIL_REFERRER, Cas2v2Role.PRISON_BAIL_REFERRER))
+        authorize(HttpMethod.GET, "/cas2/people/*/oasys/**", hasAnyAuthority(Cas2Role.COURT_BAIL_REFERRER, Cas2Role.PRISON_BAIL_REFERRER))
         authorize(HttpMethod.GET, "/cas2/people/search-by-crn/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2/people/search-by-noms/**", hasAnyAuthority("ROLE_CAS2_COURT_BAIL_REFERRER", "ROLE_CAS2_PRISON_BAIL_REFERRER"))
         authorize(HttpMethod.GET, "/cas2/external/**", hasRole("APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/LaoStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/LaoStrategy.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcOffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -53,7 +53,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoR
  *
  * We _could_ tighten this up for Delius users
  *
- * Implemented in [Cas2v2OffenderService]
+ * Implemented in [Cas2OffenderService]
  *
  * # CAS3
  *

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2IntegrationTestBase.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.Cas2v2Constants.Cas2v2Role
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.Cas2Constants.Cas2Role
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.hmpps.kotlin.auth.AuthSource
 
@@ -24,7 +24,7 @@ class Cas2v2IntegrationTestBase : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    fun cas2v2NonReferrerRoles(): List<Arguments> = listOf(Cas2v2Role.ADMIN, Cas2v2Role.ASSESSOR, Cas2v2Role.MI)
+    fun cas2v2NonReferrerRoles(): List<Arguments> = listOf(Cas2Role.ADMIN, Cas2Role.ASSESSOR, Cas2Role.MI)
       .flatMap {
         listOf(
           Arguments.of(RoleAndAuthSource(it, AuthSource.DELIUS)),
@@ -33,7 +33,7 @@ class Cas2v2IntegrationTestBase : IntegrationTestBase() {
       }
 
     @JvmStatic
-    fun cas2v2ReferrerRoles(): List<Arguments> = listOf(Cas2v2Role.COURT_BAIL_REFERRER, Cas2v2Role.PRISON_BAIL_REFERRER)
+    fun cas2v2ReferrerRoles(): List<Arguments> = listOf(Cas2Role.COURT_BAIL_REFERRER, Cas2Role.PRISON_BAIL_REFERRER)
       .flatMap {
         listOf(
           Arguments.of(RoleAndAuthSource(it, AuthSource.DELIUS)),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ReferenceDataTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 
@@ -14,7 +14,7 @@ class Cas2v2ReferenceDataTest : IntegrationTestBase() {
   lateinit var statusTransformer: Cas2HdcApplicationStatusTransformer
 
   @Autowired
-  lateinit var cas2v2statusFinder: Cas2v2PersistedApplicationStatusFinder
+  lateinit var cas2v2statusFinder: uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2PersistedApplicationStatusFinder
 
   @Autowired
   lateinit var cas2statusFinder: Cas2PersistedApplicationStatusFinder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ReferenceDataTest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 
@@ -14,10 +14,10 @@ class Cas2v2ReferenceDataTest : IntegrationTestBase() {
   lateinit var statusTransformer: Cas2HdcApplicationStatusTransformer
 
   @Autowired
-  lateinit var cas2v2statusFinder: uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2PersistedApplicationStatusFinder
+  lateinit var cas2v2statusFinder: Cas2PersistedApplicationStatusFinder
 
   @Autowired
-  lateinit var cas2statusFinder: Cas2PersistedApplicationStatusFinder
+  lateinit var cas2statusFinder: Cas2HdcPersistedApplicationStatusFinder
 
   @Test
   fun `All available application status options are returned`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ReportsTest.kt
@@ -20,9 +20,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration.givens.
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration.givens.givenASubmittedCas2HdcApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration.givens.givenAnUnsubmittedCas2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.integration.givens.givenAnUnsubmittedCas2HdcApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ReportsService.ApplicationStatusUpdatesReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ReportsService.SubmittedApplicationReportRow
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ReportsService.UnsubmittedApplicationsReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ReportsService.ApplicationStatusUpdatesReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ReportsService.SubmittedApplicationReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ReportsService.UnsubmittedApplicationsReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcReportName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.events.Cas2ApplicationStatusUpdatedEventDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.events.Cas2ApplicationSubmittedEventDetailsFactory

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2SubmissionTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Submitte
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentRepository
@@ -58,7 +58,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
   lateinit var cas2RealStatusUpdateDetailRepository: Cas2StatusUpdateDetailRepository
 
   @Autowired
-  lateinit var userTransformer: Cas2v2UserTransformer
+  lateinit var userTransformer: Cas2UserTransformer
 
   val schema = """
        {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2ApplicationServiceTest.kt
@@ -29,12 +29,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2AssessmentService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2ApplicationServiceTest.kt
@@ -30,11 +30,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SortDirection
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitCas2v2Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2ApplicationService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
@@ -69,24 +69,24 @@ class Cas2v2ApplicationServiceTest {
   private val mockCas2ApplicationRepository = mockk<Cas2ApplicationRepository>()
   private val mockCas2LockableApplicationRepository = mockk<Cas2LockableApplicationRepository>()
   private val mockCas2ApplicationSummaryRepository = mockk<Cas2ApplicationSummaryRepository>()
-  private val mockCas2v2OffenderService = mockk<Cas2v2OffenderService>()
-  private val mockCas2v2UserAccessService = mockk<Cas2v2UserAccessService>()
+  private val mockCas2OffenderService = mockk<Cas2OffenderService>()
+  private val mockCas2UserAccessService = mockk<Cas2UserAccessService>()
   private val mockDomainEventService = mockk<Cas2DomainEventService>()
   private val mockEmailNotificationService = mockk<EmailNotificationService>()
-  private val mockCas2v2AssessmentService = mockk<Cas2v2AssessmentService>()
+  private val mockCas2AssessmentService = mockk<Cas2AssessmentService>()
   private val mockJsonMapper = mockk<JsonMapper>()
   private val mockNotifyConfig = mockk<NotifyConfig>()
   private val mockSentryService = mockk<SentryService>()
 
-  private val cas2v2ApplicationService = Cas2v2ApplicationService(
+  private val cas2ApplicationService = Cas2ApplicationService(
     mockCas2ApplicationRepository,
     mockCas2LockableApplicationRepository,
     mockCas2ApplicationSummaryRepository,
-    mockCas2v2OffenderService,
-    mockCas2v2UserAccessService,
+    mockCas2OffenderService,
+    mockCas2UserAccessService,
     mockDomainEventService,
     mockEmailNotificationService,
-    mockCas2v2AssessmentService,
+    mockCas2AssessmentService,
     mockNotifyConfig,
     mockJsonMapper,
     mockSentryService,
@@ -139,7 +139,7 @@ class Cas2v2ApplicationServiceTest {
         )
       } returns page
 
-      val (applicationSummaries, metadata) = cas2v2ApplicationService.getAllSubmittedCas2v2ApplicationsForAssessor(pageCriteria)
+      val (applicationSummaries, metadata) = cas2ApplicationService.getAllSubmittedCas2ApplicationsForAssessor(pageCriteria)
 
       assertThat(applicationSummaries).isEqualTo(listOf(cas2v2ApplicationSummary))
       assertThat(metadata?.currentPage).isEqualTo(3)
@@ -180,7 +180,7 @@ class Cas2v2ApplicationServiceTest {
       every { page.totalPages } returns 10
       every { page.totalElements } returns 100
 
-      val (applicationSummaries, _) = cas2v2ApplicationService.getCas2v2Applications(
+      val (applicationSummaries, _) = cas2ApplicationService.getCas2Applications(
         prisonCode,
         isSubmitted,
         null,
@@ -240,7 +240,7 @@ class Cas2v2ApplicationServiceTest {
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns null
 
-      assertThat(cas2v2ApplicationService.getCas2v2ApplicationForUser(applicationId, user) is CasResult.NotFound).isTrue
+      assertThat(cas2ApplicationService.getCas2ApplicationForUser(applicationId, user) is CasResult.NotFound).isTrue
     }
 
     @Test
@@ -261,7 +261,7 @@ class Cas2v2ApplicationServiceTest {
           .withAbandonedAt(OffsetDateTime.now())
           .produce()
 
-      assertThat(cas2v2ApplicationService.getCas2v2ApplicationForUser(applicationId, user) is CasResult.NotFound).isTrue
+      assertThat(cas2ApplicationService.getCas2ApplicationForUser(applicationId, user) is CasResult.NotFound).isTrue
     }
 
     @Test
@@ -281,9 +281,9 @@ class Cas2v2ApplicationServiceTest {
           .withServiceOrigin(Cas2ServiceOrigin.BAIL)
           .produce()
 
-      every { mockCas2v2UserAccessService.userCanViewCas2v2Application(any(), any()) } returns false
+      every { mockCas2UserAccessService.userCanViewCas2Application(any(), any()) } returns false
 
-      assertThat(cas2v2ApplicationService.getCas2v2ApplicationForUser(applicationId, user) is CasResult.Unauthorised).isTrue
+      assertThat(cas2ApplicationService.getCas2ApplicationForUser(applicationId, user) is CasResult.Unauthorised).isTrue
     }
 
     @Test
@@ -304,9 +304,9 @@ class Cas2v2ApplicationServiceTest {
         .produce()
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(any(), Cas2ServiceOrigin.BAIL) } returns cas2ApplicationEntity
-      every { mockCas2v2UserAccessService.userCanViewCas2v2Application(any(), any()) } returns true
+      every { mockCas2UserAccessService.userCanViewCas2Application(any(), any()) } returns true
 
-      val result = cas2v2ApplicationService.getCas2v2ApplicationForUser(applicationId, userEntity)
+      val result = cas2ApplicationService.getCas2ApplicationForUser(applicationId, userEntity)
 
       assertThat(result is CasResult.Success).isTrue
       val entity = extractEntityFromCasResult(result)
@@ -328,11 +328,11 @@ class Cas2v2ApplicationServiceTest {
       val crn = "CRN345"
       val username = "SOME_PERSON"
 
-      every { mockCas2v2OffenderService.getPersonByNomisIdOrCrn(any()) } returns Cas2v2OffenderSearchResult.NotFound(crn)
+      every { mockCas2OffenderService.getPersonByNomisIdOrCrn(any()) } returns Cas2v2OffenderSearchResult.NotFound(crn)
 
       val user = userWithUsername(username)
 
-      val result = cas2v2ApplicationService.createCas2v2Application(crn, user)
+      val result = cas2ApplicationService.createCas2Application(crn, user)
 
       assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
       result as ValidatableActionResult.FieldValidationError
@@ -344,11 +344,11 @@ class Cas2v2ApplicationServiceTest {
       val crn = "CRN345"
       val username = "SOME PERSON"
 
-      every { mockCas2v2OffenderService.getPersonByNomisIdOrCrn(any()) } returns Cas2v2OffenderSearchResult.Forbidden(crn)
+      every { mockCas2OffenderService.getPersonByNomisIdOrCrn(any()) } returns Cas2v2OffenderSearchResult.Forbidden(crn)
 
       val user = userWithUsername(username)
 
-      val result = cas2v2ApplicationService.createCas2v2Application(crn, user)
+      val result = cas2ApplicationService.createCas2Application(crn, user)
 
       assertThat(result is ValidatableActionResult.FieldValidationError).isTrue
       result as ValidatableActionResult.FieldValidationError
@@ -363,7 +363,7 @@ class Cas2v2ApplicationServiceTest {
 
       val user = userWithUsername(username)
 
-      every { mockCas2v2OffenderService.getPersonByNomisIdOrCrn(crn) } returns Cas2v2OffenderSearchResult.Success.Full(
+      every { mockCas2OffenderService.getPersonByNomisIdOrCrn(crn) } returns Cas2v2OffenderSearchResult.Success.Full(
         crn,
         FullPerson(
           name = "",
@@ -382,7 +382,7 @@ class Cas2v2ApplicationServiceTest {
           Cas2ApplicationEntity
       }
 
-      val result = cas2v2ApplicationService.createCas2v2Application(crn, user, ApplicationOrigin.prisonBail, bailHearingDate)
+      val result = cas2ApplicationService.createCas2Application(crn, user, ApplicationOrigin.prisonBail, bailHearingDate)
 
       assertThat(result is ValidatableActionResult.Success).isTrue
       result as ValidatableActionResult.Success
@@ -406,7 +406,7 @@ class Cas2v2ApplicationServiceTest {
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns null
 
       assertThat(
-        cas2v2ApplicationService.updateCas2v2Application(
+        cas2ApplicationService.updateCas2Application(
           applicationId = applicationId,
           data = "{}",
           user = user,
@@ -434,7 +434,7 @@ class Cas2v2ApplicationServiceTest {
         cas2v2Application
 
       assertThat(
-        cas2v2ApplicationService.updateCas2v2Application(
+        cas2ApplicationService.updateCas2Application(
           applicationId = applicationId,
           data = "{}",
           user = user,
@@ -458,7 +458,7 @@ class Cas2v2ApplicationServiceTest {
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns
         cas2v2Application
 
-      val result = cas2v2ApplicationService.updateCas2v2Application(
+      val result = cas2ApplicationService.updateCas2Application(
         applicationId = applicationId,
         data = "{}",
         user = user,
@@ -484,7 +484,7 @@ class Cas2v2ApplicationServiceTest {
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns cas2v2Application
 
-      val result = cas2v2ApplicationService.updateCas2v2Application(
+      val result = cas2ApplicationService.updateCas2Application(
         applicationId = applicationId,
         data = "{}",
         user = user,
@@ -522,7 +522,7 @@ class Cas2v2ApplicationServiceTest {
           as Cas2ApplicationEntity
       }
 
-      val result = cas2v2ApplicationService.updateCas2v2Application(
+      val result = cas2ApplicationService.updateCas2Application(
         applicationId = applicationId,
         data = updatedData,
         user = user,
@@ -574,7 +574,7 @@ class Cas2v2ApplicationServiceTest {
           as Cas2ApplicationEntity
       }
 
-      val result = cas2v2ApplicationService.updateCas2v2Application(
+      val result = cas2ApplicationService.updateCas2Application(
         applicationId = applicationId,
         data = updatedData,
         user = user,
@@ -607,7 +607,7 @@ class Cas2v2ApplicationServiceTest {
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns null
 
       assertThat(
-        cas2v2ApplicationService.abandonCas2v2Application(
+        cas2ApplicationService.abandonCas2Application(
           applicationId = applicationId,
           user = user,
         ) is CasResult.NotFound,
@@ -632,7 +632,7 @@ class Cas2v2ApplicationServiceTest {
         application
 
       assertThat(
-        cas2v2ApplicationService.abandonCas2v2Application(
+        cas2ApplicationService.abandonCas2Application(
           applicationId = applicationId,
           user = user,
         ) is CasResult.Unauthorised,
@@ -653,7 +653,7 @@ class Cas2v2ApplicationServiceTest {
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns
         application
 
-      val result = cas2v2ApplicationService.abandonCas2v2Application(
+      val result = cas2ApplicationService.abandonCas2Application(
         applicationId = applicationId,
         user = user,
       )
@@ -677,7 +677,7 @@ class Cas2v2ApplicationServiceTest {
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns
         application
 
-      val result = cas2v2ApplicationService.abandonCas2v2Application(
+      val result = cas2ApplicationService.abandonCas2Application(
         applicationId = applicationId,
         user = user,
       )
@@ -710,7 +710,7 @@ class Cas2v2ApplicationServiceTest {
         it.invocation.args[0] as Cas2ApplicationEntity
       }
 
-      val result = cas2v2ApplicationService.abandonCas2v2Application(
+      val result = cas2ApplicationService.abandonCas2Application(
         applicationId = applicationId,
         user = user,
       )
@@ -756,7 +756,7 @@ class Cas2v2ApplicationServiceTest {
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns null
 
-      assertThat(cas2v2ApplicationService.submitCas2v2Application(submitCas2v2Application, user) is CasResult.NotFound).isTrue
+      assertThat(cas2ApplicationService.submitCas2Application(submitCas2v2Application, user) is CasResult.NotFound).isTrue
 
       assertEmailAndAssessmentsWereNotCreated()
     }
@@ -776,7 +776,7 @@ class Cas2v2ApplicationServiceTest {
 
       every { mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL) } returns cas2v2Application
 
-      assertThat(cas2v2ApplicationService.submitCas2v2Application(submitCas2v2Application, user) is CasResult.Unauthorised).isTrue
+      assertThat(cas2ApplicationService.submitCas2Application(submitCas2v2Application, user) is CasResult.Unauthorised).isTrue
 
       assertEmailAndAssessmentsWereNotCreated()
     }
@@ -795,7 +795,7 @@ class Cas2v2ApplicationServiceTest {
         mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)
       } returns cas2v2Application
 
-      val result = cas2v2ApplicationService.submitCas2v2Application(submitCas2v2Application, user)
+      val result = cas2ApplicationService.submitCas2Application(submitCas2v2Application, user)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue
       val validatableActionResult = result as CasResult.GeneralValidationError
@@ -819,7 +819,7 @@ class Cas2v2ApplicationServiceTest {
         mockCas2ApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)
       } returns cas2v2Application
 
-      val result = cas2v2ApplicationService.submitCas2v2Application(submitCas2v2Application, user)
+      val result = cas2ApplicationService.submitCas2Application(submitCas2v2Application, user)
 
       assertThat(result is CasResult.GeneralValidationError).isTrue
       val validatableActionResult = result as CasResult.GeneralValidationError
@@ -831,7 +831,7 @@ class Cas2v2ApplicationServiceTest {
 
     private fun assertEmailAndAssessmentsWereNotCreated() {
       verify(exactly = 0) { mockEmailNotificationService.sendEmail(any(), any(), any()) }
-      verify(exactly = 0) { mockCas2v2AssessmentService.createCas2v2Assessment(any()) }
+      verify(exactly = 0) { mockCas2AssessmentService.createCas2Assessment(any()) }
     }
 
     @Test
@@ -860,7 +860,7 @@ class Cas2v2ApplicationServiceTest {
         .produce()
 
       every {
-        mockCas2v2OffenderService.getInmateDetailByNomsNumber(
+        mockCas2OffenderService.getInmateDetailByNomsNumber(
           cas2v2Application.crn,
           cas2v2Application.nomsNumber.toString(),
         )
@@ -875,7 +875,7 @@ class Cas2v2ApplicationServiceTest {
           as Cas2ApplicationEntity
       }
 
-      every { mockCas2v2OffenderService.getPersonByNomisIdOrCrn(cas2v2Application.crn) } returns Cas2v2OffenderSearchResult.Success.Full(
+      every { mockCas2OffenderService.getPersonByNomisIdOrCrn(cas2v2Application.crn) } returns Cas2v2OffenderSearchResult.Success.Full(
         cas2v2Application.crn,
         FullPerson(
           name = "",
@@ -888,9 +888,9 @@ class Cas2v2ApplicationServiceTest {
         ),
       )
 
-      every { mockCas2v2AssessmentService.createCas2v2Assessment(any()) } returns any()
+      every { mockCas2AssessmentService.createCas2Assessment(any()) } returns any()
 
-      val result = cas2v2ApplicationService.submitCas2v2Application(submitCas2v2Application, user)
+      val result = cas2ApplicationService.submitCas2Application(submitCas2v2Application, user)
 
       assertThat(result is CasResult.Success).isTrue
       result as CasResult.Success
@@ -938,7 +938,7 @@ class Cas2v2ApplicationServiceTest {
         )
       }
 
-      verify(exactly = 1) { mockCas2v2AssessmentService.createCas2v2Assessment(persistedApplication) }
+      verify(exactly = 1) { mockCas2AssessmentService.createCas2Assessment(persistedApplication) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2AssessmentServiceTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateCas2v2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2AssessmentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentEntity
@@ -21,7 +21,7 @@ class Cas2v2AssessmentServiceTest {
 
   private val mockCas2AssessmentRepository = mockk<Cas2AssessmentRepository>()
 
-  private val cas2v2AssessmentService = Cas2v2AssessmentService(
+  private val cas2AssessmentService = Cas2AssessmentService(
     mockCas2AssessmentRepository,
   )
 
@@ -49,7 +49,7 @@ class Cas2v2AssessmentServiceTest {
           assessEntity
         }
 
-      val result = cas2v2AssessmentService.createCas2v2Assessment(
+      val result = cas2AssessmentService.createCas2Assessment(
         cas2v2Application,
       )
       Assertions.assertThat(result).isEqualTo(assessEntity)
@@ -97,7 +97,7 @@ class Cas2v2AssessmentServiceTest {
           assessEntity
         }
 
-      val result = cas2v2AssessmentService.updateAssessment(
+      val result = cas2AssessmentService.updateAssessment(
         assessmentId = assessmentId,
         newAssessment = newAssessmentData,
       )
@@ -131,7 +131,7 @@ class Cas2v2AssessmentServiceTest {
           null
         }
 
-      val result = cas2v2AssessmentService.updateAssessment(
+      val result = cas2AssessmentService.updateAssessment(
         assessmentId = assessmentId,
         newAssessment = newAssessmentData,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2OffenderServiceTest.kt
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2OffenderServiceTest.kt
@@ -10,7 +10,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult.Failure.StatusCode
@@ -30,12 +30,12 @@ class Cas2v2OffenderServiceTest {
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockOffenderDetailsDataSource = mockk<OffenderDetailsDataSource>()
 
-  private val cas2v2PersonTransformer = Cas2v2PersonTransformer()
+  private val cas2PersonTransformer = Cas2PersonTransformer()
 
   private val cas2OffenderService = Cas2OffenderService(
     mockPrisonsApiClient,
     mockApDeliusContextApiClient,
-    cas2v2PersonTransformer,
+    cas2PersonTransformer,
   )
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2OffenderServiceTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderSearchResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -32,7 +32,7 @@ class Cas2v2OffenderServiceTest {
 
   private val cas2v2PersonTransformer = Cas2v2PersonTransformer()
 
-  private val cas2v2OffenderService = Cas2v2OffenderService(
+  private val cas2OffenderService = Cas2OffenderService(
     mockPrisonsApiClient,
     mockApDeliusContextApiClient,
     cas2v2PersonTransformer,
@@ -47,7 +47,7 @@ class Cas2v2OffenderServiceTest {
       every { mockApDeliusContextApiClient.getCaseSummaries(listOf(nomsNumber)) } returns
         StatusCode(HttpMethod.POST, "/case-summaries", HttpStatus.NOT_FOUND, null)
 
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.NotFound).isTrue
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.NotFound).isTrue
     }
 
     @Test
@@ -55,7 +55,7 @@ class Cas2v2OffenderServiceTest {
       every { mockApDeliusContextApiClient.getCaseSummaries(listOf(nomsNumber)) } returns
         ClientResult.Success(HttpStatus.OK, CaseSummaries(emptyList()))
 
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.NotFound).isTrue
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.NotFound).isTrue
     }
 
     @Test
@@ -84,7 +84,7 @@ class Cas2v2OffenderServiceTest {
         body = inmateDetail,
       )
 
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.Success).isTrue
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.Success).isTrue
     }
 
     @Test
@@ -92,7 +92,7 @@ class Cas2v2OffenderServiceTest {
       every { mockApDeliusContextApiClient.getCaseSummaries(listOf(nomsNumber)) } returns
         StatusCode(HttpMethod.POST, "/case-summaries", HttpStatus.INTERNAL_SERVER_ERROR, null)
 
-      val result = cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)
+      val result = cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)
 
       assertThat(result is Cas2v2OffenderSearchResult.Unknown).isTrue
       result as Cas2v2OffenderSearchResult.Unknown
@@ -125,7 +125,7 @@ class Cas2v2OffenderServiceTest {
         body = inmateDetail,
       )
 
-      val result = cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)
+      val result = cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)
 
       assertThat(result is Cas2v2OffenderSearchResult.Success.Full).isTrue
       result as Cas2v2OffenderSearchResult.Success.Full
@@ -148,7 +148,7 @@ class Cas2v2OffenderServiceTest {
         null,
       )
 
-      val result = cas2v2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
+      val result = cas2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
       assertThat(result is AuthorisableActionResult.NotFound).isTrue
     }
@@ -165,7 +165,7 @@ class Cas2v2OffenderServiceTest {
         null,
       )
 
-      val result = cas2v2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
+      val result = cas2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
       assertThat(result is AuthorisableActionResult.NotFound).isTrue
     }
@@ -182,7 +182,7 @@ class Cas2v2OffenderServiceTest {
         null,
       )
 
-      val result = cas2v2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
+      val result = cas2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
       assertThat(result is AuthorisableActionResult.Unauthorised).isTrue
     }
@@ -207,7 +207,7 @@ class Cas2v2OffenderServiceTest {
         ),
       )
 
-      val result = cas2v2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
+      val result = cas2OffenderService.getInmateDetailByNomsNumber(crn, nomsNumber)
 
       assertThat(result is AuthorisableActionResult.Success)
       result as AuthorisableActionResult.Success
@@ -271,12 +271,12 @@ class Cas2v2OffenderServiceTest {
 
     @Test
     fun `Check searching by crn cannot view an offender with a currentRestriction`() {
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(crn) is Cas2v2OffenderSearchResult.Forbidden).isTrue
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(crn) is Cas2v2OffenderSearchResult.Forbidden).isTrue
     }
 
     @Test
     fun `Check searching by nomis cannot view an offender with a currentRestriction`() {
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.Forbidden).isTrue
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber) is Cas2v2OffenderSearchResult.Forbidden).isTrue
     }
   }
 
@@ -326,12 +326,12 @@ class Cas2v2OffenderServiceTest {
 
     @Test
     fun `Check searching by crn can view an offender with a currentExclusion`() {
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(crn)).isInstanceOf(Cas2v2OffenderSearchResult.Success.Full::class.java)
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(crn)).isInstanceOf(Cas2v2OffenderSearchResult.Success.Full::class.java)
     }
 
     @Test
     fun `Check searching by nomis can view an offender with a currentExclusion`() {
-      assertThat(cas2v2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)).isInstanceOf(Cas2v2OffenderSearchResult.Success.Full::class.java)
+      assertThat(cas2OffenderService.getPersonByNomisIdOrCrn(nomsNumber)).isInstanceOf(Cas2v2OffenderSearchResult.Success.Full::class.java)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2UserAccessServiceTest.kt
@@ -9,20 +9,20 @@ import org.junit.jupiter.api.Test
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2UserAccessService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2v2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserAccessService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
 import java.time.OffsetDateTime
 
 class Cas2v2UserAccessServiceTest {
 
-  val mockkCas2v2UserService = mockk<Cas2v2UserService>()
+  val mockkCas2UserService = mockk<Cas2UserService>()
 
   @Nested
   inner class UserCanViewApplication {
 
-    private val cas2v2UserAccessService = Cas2v2UserAccessService(mockkCas2v2UserService)
+    private val cas2UserAccessService = Cas2UserAccessService(mockkCas2UserService)
 
     @Nested
     inner class WhenApplicationCreatedByUser {
@@ -37,7 +37,7 @@ class Cas2v2UserAccessServiceTest {
           .withServiceOrigin(Cas2ServiceOrigin.BAIL)
           .produce()
 
-        assertThat(cas2v2UserAccessService.userCanViewCas2v2Application(user, application)).isTrue
+        assertThat(cas2UserAccessService.userCanViewCas2Application(user, application)).isTrue
       }
     }
 
@@ -60,7 +60,7 @@ class Cas2v2UserAccessServiceTest {
             .withCreatedByUser(anotherUser)
             .produce()
 
-          assertThat(cas2v2UserAccessService.userCanViewCas2v2Application(user, cas2v2Application)).isFalse
+          assertThat(cas2UserAccessService.userCanViewCas2Application(user, cas2v2Application)).isFalse
         }
       }
 
@@ -84,7 +84,7 @@ class Cas2v2UserAccessServiceTest {
             .withServiceOrigin(Cas2ServiceOrigin.BAIL)
             .produce()
 
-          assertThat(cas2v2UserAccessService.userCanViewCas2v2Application(user, cas2v2Application)).isFalse
+          assertThat(cas2UserAccessService.userCanViewCas2Application(user, cas2v2Application)).isFalse
         }
 
         @Nested
@@ -107,7 +107,7 @@ class Cas2v2UserAccessServiceTest {
               .produce()
 
             assertThat(
-              cas2v2UserAccessService.userCanViewCas2v2Application(
+              cas2UserAccessService.userCanViewCas2Application(
                 userWithNoPrison,
                 cas2v2Application,
               ),
@@ -136,7 +136,7 @@ class Cas2v2UserAccessServiceTest {
             .withServiceOrigin(Cas2ServiceOrigin.BAIL)
             .produce()
 
-          assertThat(cas2v2UserAccessService.userCanViewCas2v2Application(user, cas2v2Application)).isTrue
+          assertThat(cas2UserAccessService.userCanViewCas2Application(user, cas2v2Application)).isTrue
         }
 
         @Test
@@ -148,7 +148,7 @@ class Cas2v2UserAccessServiceTest {
             .withServiceOrigin(Cas2ServiceOrigin.BAIL)
             .produce()
 
-          assertThat(cas2v2UserAccessService.userCanViewCas2v2Application(user, cas2v2Application)).isTrue
+          assertThat(cas2UserAccessService.userCanViewCas2Application(user, cas2v2Application)).isTrue
         }
       }
 
@@ -182,7 +182,7 @@ class Cas2v2UserAccessServiceTest {
             @BeforeEach
             fun setup() {
               every {
-                mockkCas2v2UserService.userForRequestHasRole(
+                mockkCas2UserService.userForRequestHasRole(
                   listOf(SimpleGrantedAuthority("ROLE_CAS2_PRISON_BAIL_REFERRER")),
                 )
               } returns true
@@ -191,7 +191,7 @@ class Cas2v2UserAccessServiceTest {
             @Test
             fun `access submitted prison bail applications`() {
               assertThat(
-                cas2v2UserAccessService.userCanViewCas2v2Application(
+                cas2UserAccessService.userCanViewCas2Application(
                   referrerTwo,
                   submittedPrisonApplication,
                 ),
@@ -201,7 +201,7 @@ class Cas2v2UserAccessServiceTest {
             @Test
             fun `cannot access unsubmitted prison bail applications`() {
               assertThat(
-                cas2v2UserAccessService.userCanViewCas2v2Application(
+                cas2UserAccessService.userCanViewCas2Application(
                   referrerTwo,
                   unsubmittedPrisonApplication,
                 ),
@@ -210,8 +210,8 @@ class Cas2v2UserAccessServiceTest {
 
             @Test
             fun `access a note to any application that is of origin prisonBail`() {
-              assertThat(cas2v2UserAccessService.userCanAddNote(referrerTwo, submittedPrisonApplication)).isTrue
-              assertThat(cas2v2UserAccessService.userCanAddNote(referrerTwo, unsubmittedPrisonApplication)).isTrue
+              assertThat(cas2UserAccessService.userCanAddNote(referrerTwo, submittedPrisonApplication)).isTrue
+              assertThat(cas2UserAccessService.userCanAddNote(referrerTwo, unsubmittedPrisonApplication)).isTrue
             }
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2ApplicationNotesTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2ApplicationNotesTransformerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2ApplicationNote
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationNotesTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationNotesTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
@@ -24,7 +24,7 @@ class Cas2v2ApplicationNotesTransformerTest {
     .withSubmittedAt(OffsetDateTime.now())
     .produce()
 
-  private val cas2v2ApplicationNotesTransformer = Cas2v2ApplicationNotesTransformer()
+  private val cas2ApplicationNotesTransformer = Cas2ApplicationNotesTransformer()
 
   @Nested
   inner class WithExternalUser {
@@ -55,7 +55,7 @@ class Cas2v2ApplicationNotesTransformerTest {
         body = jpaEntity.body,
       )
 
-      val transformation = cas2v2ApplicationNotesTransformer.transformJpaToApi(jpaEntity)
+      val transformation = cas2ApplicationNotesTransformer.transformJpaToApi(jpaEntity)
 
       Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
     }
@@ -88,7 +88,7 @@ class Cas2v2ApplicationNotesTransformerTest {
         body = jpaEntity.body,
       )
 
-      val transformation = cas2v2ApplicationNotesTransformer.transformJpaToApi(jpaEntity)
+      val transformation = cas2ApplicationNotesTransformer.transformJpaToApi(jpaEntity)
 
       Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -16,11 +16,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.LatestCas2v2St
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2TimelineEvent
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2ApplicationsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2AssessmentsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2StatusUpdateTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2TimelineEventsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2ApplicationsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2AssessmentsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2StatusUpdateTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2TimelineEventsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
@@ -35,20 +35,20 @@ import java.util.UUID
 
 class Cas2v2ApplicationTransformerTest {
   private val mockPersonTransformer = mockk<PersonTransformer>()
-  private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
-  private val mockCas2v2StatusUpdateTransformer = mockk<Cas2v2StatusUpdateTransformer>()
-  private val mockCas2v2TimelineEventsTransformer = mockk<Cas2v2TimelineEventsTransformer>()
-  private val mockCas2v2AssessmentsTransformer = mockk<Cas2v2AssessmentsTransformer>()
+  private val mockCas2UserTransformer = mockk<Cas2UserTransformer>()
+  private val mockCas2StatusUpdateTransformer = mockk<Cas2StatusUpdateTransformer>()
+  private val mockCas2TimelineEventsTransformer = mockk<Cas2TimelineEventsTransformer>()
+  private val mockCas2AssessmentsTransformer = mockk<Cas2AssessmentsTransformer>()
   private val mockOffenderManagementUnitRepository = mockk<OffenderManagementUnitRepository>()
   private val objectMapper = JsonMapperFactory.createJackson3JsonMapper()
 
-  private val cas2v2ApplicationsTransformer = Cas2v2ApplicationsTransformer(
+  private val cas2ApplicationsTransformer = Cas2ApplicationsTransformer(
     objectMapper,
     mockPersonTransformer,
-    mockCas2v2UserTransformer,
-    mockCas2v2StatusUpdateTransformer,
-    mockCas2v2TimelineEventsTransformer,
-    mockCas2v2AssessmentsTransformer,
+    mockCas2UserTransformer,
+    mockCas2StatusUpdateTransformer,
+    mockCas2TimelineEventsTransformer,
+    mockCas2AssessmentsTransformer,
     mockOffenderManagementUnitRepository,
   )
 
@@ -66,16 +66,16 @@ class Cas2v2ApplicationTransformerTest {
   @BeforeEach
   fun setup() {
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
-    every { mockCas2v2UserTransformer.transformJpaToApi(any()) } returns Cas2v2User(
+    every { mockCas2UserTransformer.transformJpaToApi(any()) } returns Cas2v2User(
       id = user.id,
       name = user.name,
       username = user.username,
       authSource = Cas2v2User.AuthSource.nomis,
       isActive = user.isActive,
     )
-    every { mockCas2v2StatusUpdateTransformer.transformJpaToApi(any()) } returns mockk<Cas2v2StatusUpdate>()
-    every { mockCas2v2StatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns mockk<LatestCas2v2StatusUpdate>()
-    every { mockCas2v2TimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf()
+    every { mockCas2StatusUpdateTransformer.transformJpaToApi(any()) } returns mockk<Cas2v2StatusUpdate>()
+    every { mockCas2StatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns mockk<LatestCas2v2StatusUpdate>()
+    every { mockCas2TimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf()
   }
 
   @Nested
@@ -90,7 +90,7 @@ class Cas2v2ApplicationTransformerTest {
         .withCohort(Cas2Cohort.PRISON_BAIL)
         .produce()
 
-      val result = cas2v2ApplicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result).hasOnlyFields(
         "id",
@@ -121,7 +121,7 @@ class Cas2v2ApplicationTransformerTest {
     @Test
     fun `transformJpaToApi transforms a submitted CAS2v2 application correctly without status updates`() {
       val assessment = Cas2v2Assessment(id = UUID.fromString("3adc18ec-3d0d-4d0f-8b31-6f08e2591c35"))
-      every { mockCas2v2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns assessment
+      every { mockCas2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns assessment
 
       val application = submittedCas2ApplicationFactory
         .withAssessment(
@@ -130,7 +130,7 @@ class Cas2v2ApplicationTransformerTest {
             .produce(),
         ).produce()
 
-      val result = cas2v2ApplicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.status).isEqualTo(ApplicationStatus.submitted)
@@ -150,7 +150,7 @@ class Cas2v2ApplicationTransformerTest {
         id = UUID.fromString("6e631a8c-a013-4bb4-812c-886c8fc25354"),
         statusUpdates = listOf(mockStatusUpdate),
       )
-      every { mockCas2v2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns mockAssessment
+      every { mockCas2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns mockAssessment
 
       val application = submittedCas2ApplicationFactory.withAssessment(
         Cas2AssessmentEntityFactory()
@@ -158,7 +158,7 @@ class Cas2v2ApplicationTransformerTest {
           .produce(),
       ).produce()
 
-      val result = cas2v2ApplicationsTransformer.transformJpaToApi(application, mockk())
+      val result = cas2ApplicationsTransformer.transformJpaToApi(application, mockk())
 
       assertThat(result.id).isEqualTo(application.id)
       assertThat(result.assessment!!.statusUpdates).hasSize(1).containsExactly(mockStatusUpdate)
@@ -188,9 +188,9 @@ class Cas2v2ApplicationTransformerTest {
         assignmentDate = null,
       )
 
-      every { mockCas2v2StatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns null
+      every { mockCas2StatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns null
 
-      val result = cas2v2ApplicationsTransformer.transformJpaSummaryToSummary(
+      val result = cas2ApplicationsTransformer.transformJpaSummaryToSummary(
         application,
         "firstName surname",
       )
@@ -225,12 +225,12 @@ class Cas2v2ApplicationTransformerTest {
         assignmentDate = null,
       )
 
-      every { mockCas2v2StatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns LatestCas2v2StatusUpdate(
+      every { mockCas2StatusUpdateTransformer.transformJpaSummaryToLatestStatusUpdateApi(any()) } returns LatestCas2v2StatusUpdate(
         statusId = UUID.fromString(application.latestStatusUpdateStatusId),
         label = application.latestStatusUpdateLabel!!,
       )
 
-      val result = cas2v2ApplicationsTransformer.transformJpaSummaryToSummary(
+      val result = cas2ApplicationsTransformer.transformJpaSummaryToSummary(
         application,
         "firstName surname",
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2AssessmentsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2AssessmentsTransformerTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2StatusUpdate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2AssessmentsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2StatusUpdateTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2AssessmentsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2StatusUpdateTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateEntity
 
@@ -20,14 +20,14 @@ class Cas2v2AssessmentsTransformerTest {
     .withStatusUpdates(mutableListOf(mockCas2StatusUpdateEntity, mockCas2StatusUpdateEntity))
     .withServiceOrigin(Cas2ServiceOrigin.BAIL)
     .produce()
-  private val mockCas2v2StatusUpdateTransformer = mockk<Cas2v2StatusUpdateTransformer>()
+  private val mockCas2StatusUpdateTransformer = mockk<Cas2StatusUpdateTransformer>()
   private val mockStatusUpdateApi = mockk<Cas2v2StatusUpdate>()
-  private val cas2v2AssessmentsTransformer = Cas2v2AssessmentsTransformer(mockCas2v2StatusUpdateTransformer)
+  private val cas2AssessmentsTransformer = Cas2AssessmentsTransformer(mockCas2StatusUpdateTransformer)
 
   @Test
   fun `transforms a cas2v2Assessment entity`() {
-    every { mockCas2v2StatusUpdateTransformer.transformJpaToApi(mockCas2StatusUpdateEntity) } returns mockStatusUpdateApi
-    val transformation = cas2v2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity)
+    every { mockCas2StatusUpdateTransformer.transformJpaToApi(mockCas2StatusUpdateEntity) } returns mockStatusUpdateApi
+    val transformation = cas2AssessmentsTransformer.transformJpaToApiRepresentation(cas2AssessmentEntity)
 
     Assertions.assertThat(transformation).isEqualTo(
       Cas2v2Assessment(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2OASysTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2OASysTransformerTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2V2OASysRiskLevel
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2OASysTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2OASysTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
@@ -14,7 +14,7 @@ import java.time.OffsetDateTime
 
 class Cas2v2OASysTransformerTest {
 
-  private val transformer = Cas2v2OASysTransformer()
+  private val transformer = Cas2OASysTransformer()
 
   @Nested
   inner class ToOASysMetadataDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2PersonTransformerTest.kt
@@ -5,14 +5,14 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FullPerson
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2PersonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Name
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProfileFactory
 
 class Cas2v2PersonTransformerTest {
 
-  private val cas2v2PersonTransformer = Cas2v2PersonTransformer()
+  private val cas2PersonTransformer = Cas2PersonTransformer()
 
   private val crn = "crn123"
   private val nomsNumber = "noms123"
@@ -29,7 +29,7 @@ class Cas2v2PersonTransformerTest {
       )
       .produce()
 
-    val fullPerson: FullPerson = cas2v2PersonTransformer.transformCaseSummaryToFullPerson(caseSummary)
+    val fullPerson: FullPerson = cas2PersonTransformer.transformCaseSummaryToFullPerson(caseSummary)
     assertThat(fullPerson.crn).isEqualTo(caseSummary.crn)
     assertThat(fullPerson.nomsNumber).isEqualTo(caseSummary.nomsId)
     assertThat(fullPerson.status).isEqualTo(PersonStatus.unknown)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2StatusUpdateTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2StatusUpdateTransformerTest.kt
@@ -11,8 +11,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2StatusUpdateTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2StatusUpdateTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2StatusUpdateDetailEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2StatusUpdateEntityFactory
@@ -32,12 +32,12 @@ class Cas2v2StatusUpdateTransformerTest {
     .produce()
 
   private val mockCas2v2UserApi = mockk<Cas2v2User>()
-  private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
-  private val cas2v2StatusUpdateTransformer = Cas2v2StatusUpdateTransformer(mockCas2v2UserTransformer)
+  private val mockCas2UserTransformer = mockk<Cas2UserTransformer>()
+  private val cas2StatusUpdateTransformer = Cas2StatusUpdateTransformer(mockCas2UserTransformer)
 
   @BeforeEach
   fun setup() {
-    every { mockCas2v2UserTransformer.transformJpaToApi(any()) } returns mockCas2v2UserApi
+    every { mockCas2UserTransformer.transformJpaToApi(any()) } returns mockCas2v2UserApi
   }
 
   @Test
@@ -62,7 +62,7 @@ class Cas2v2StatusUpdateTransformerTest {
       statusUpdateDetails = null,
     )
 
-    val transformation = cas2v2StatusUpdateTransformer.transformJpaToApi(jpaEntity)
+    val transformation = cas2StatusUpdateTransformer.transformJpaToApi(jpaEntity)
 
     Assertions.assertThat(transformation).isEqualTo(expectedRepresentation)
   }
@@ -86,7 +86,7 @@ class Cas2v2StatusUpdateTransformerTest {
       .withStatusDetailId(UUID.fromString("3df29b1b-e2fc-4df7-b4b8-0527cd9e3a6f"))
       .withStatusUpdate(mockStatusUpdate)
       .produce()
-    val transformation = cas2v2StatusUpdateTransformer.transformStatusUpdateDetailsJpaToApi(updateDetail)
+    val transformation = cas2StatusUpdateTransformer.transformStatusUpdateDetailsJpaToApi(updateDetail)
 
     Assertions.assertThat(transformation).isEqualTo(cas2v2StatusUpdateDetail)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2SubmissionsTransformerTest.kt
@@ -13,10 +13,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2v2User
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2TimelineEvent
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2AssessmentsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2SubmissionsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2TimelineEventsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2UserTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2AssessmentsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2SubmissionsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2TimelineEventsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2UserTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
@@ -31,18 +31,18 @@ import java.util.UUID
 class Cas2v2SubmissionsTransformerTest {
 
   private val mockPersonTransformer = mockk<PersonTransformer>()
-  private val mockCas2v2UserTransformer = mockk<Cas2v2UserTransformer>()
-  private val mockCas2v2TimelineEventsTransformer = mockk<Cas2v2TimelineEventsTransformer>()
-  private val mockCas2v2AssessmentsTransformer = mockk<Cas2v2AssessmentsTransformer>()
+  private val mockCas2UserTransformer = mockk<Cas2UserTransformer>()
+  private val mockCas2TimelineEventsTransformer = mockk<Cas2TimelineEventsTransformer>()
+  private val mockCas2AssessmentsTransformer = mockk<Cas2AssessmentsTransformer>()
 
   private val jsonMapper = JsonMapperFactory.createJackson3JsonMapper()
 
-  private val applicationTransformer = Cas2v2SubmissionsTransformer(
+  private val applicationTransformer = Cas2SubmissionsTransformer(
     jsonMapper,
     mockPersonTransformer,
-    mockCas2v2UserTransformer,
-    mockCas2v2TimelineEventsTransformer,
-    mockCas2v2AssessmentsTransformer,
+    mockCas2UserTransformer,
+    mockCas2TimelineEventsTransformer,
+    mockCas2AssessmentsTransformer,
   )
 
   private val user = Cas2UserEntityFactory()
@@ -71,9 +71,9 @@ class Cas2v2SubmissionsTransformerTest {
   @BeforeEach
   fun setup() {
     every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
-    every { mockCas2v2UserTransformer.transformJpaToApi(any()) } returns mockCas2v2User
-    every { mockCas2v2TimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf(mockk<Cas2TimelineEvent>())
-    every { mockCas2v2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns mockAssessment
+    every { mockCas2UserTransformer.transformJpaToApi(any()) } returns mockCas2v2User
+    every { mockCas2TimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf(mockk<Cas2TimelineEvent>())
+    every { mockCas2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns mockAssessment
   }
 
   @Nested
@@ -89,7 +89,7 @@ class Cas2v2SubmissionsTransformerTest {
 
       val jpaEntity = submittedCas2ApplicationFactory.withAssessment(assessmentEntity).produce()
 
-      every { mockCas2v2AssessmentsTransformer.transformJpaToApiRepresentation(assessmentEntity) } returns mockAssessment
+      every { mockCas2AssessmentsTransformer.transformJpaToApiRepresentation(assessmentEntity) } returns mockAssessment
 
       val transformation = applicationTransformer.transformJpaToApiRepresentation(jpaEntity, mockk())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2TimelineEventsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2TimelineEventsTransformerTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.TimelineEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2TimelineEvent
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2v2TimelineEventsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.transformer.Cas2TimelineEventsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2StatusUpdateEntityFactory
@@ -31,7 +31,7 @@ class Cas2v2TimelineEventsTransformerTest {
     .withServiceOrigin(Cas2ServiceOrigin.BAIL)
     .withSubmittedAt(OffsetDateTime.now())
 
-  private val timelineEventTransformer = Cas2v2TimelineEventsTransformer()
+  private val timelineEventTransformer = Cas2TimelineEventsTransformer()
 
   @Nested
   inner class WhenThereAreTimelineEvents {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/util/Cas2v2ApplicationUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/util/Cas2v2ApplicationUtilsTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.unit.util
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.util.Cas2v2ApplicationUtils
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.util.Cas2ApplicationUtils
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Constants.CAS2_COURT_BAIL_APPLICATION_TYPE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Constants.CAS2_PRISON_BAIL_APPLICATION_TYPE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Constants.HDC_APPLICATION_TYPE
@@ -13,13 +13,13 @@ class Cas2v2ApplicationUtilsTest {
   @Test
   fun `in Cas2v2ApplicationUtils getApplicationTypeFromApplicationOrigin returns correct applicationType`() {
     val applicationOrigin1 = ApplicationOrigin.courtBail
-    val applicationType1 = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin1)
+    val applicationType1 = Cas2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin1)
 
     val applicationOrigin2 = ApplicationOrigin.prisonBail
-    val applicationType2 = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin2)
+    val applicationType2 = Cas2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin2)
 
     val applicationOrigin3 = ApplicationOrigin.homeDetentionCurfew
-    val applicationType3 = Cas2v2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin3)
+    val applicationType3 = Cas2ApplicationUtils().getApplicationTypeFromApplicationOrigin(applicationOrigin3)
 
     assertThat(applicationType1).isEqualTo(CAS2_COURT_BAIL_APPLICATION_TYPE)
     assertThat(applicationType2).isEqualTo(CAS2_PRISON_BAIL_APPLICATION_TYPE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2ReferenceDataTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.integration
 
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 
@@ -12,7 +12,7 @@ class Cas2ReferenceDataTest : IntegrationTestBase() {
   lateinit var statusTransformer: Cas2HdcApplicationStatusTransformer
 
   @Autowired
-  lateinit var statusFinder: Cas2PersistedApplicationStatusFinder
+  lateinit var statusFinder: Cas2HdcPersistedApplicationStatusFinder
 
   @Test
   fun `All available application status options are returned`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/model/reference/Cas2PersistedApplicationStatusFinderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/model/reference/Cas2PersistedApplicationStatusFinderTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import java.util.UUID
 
 class Cas2PersistedApplicationStatusFinderTest {
@@ -20,7 +20,7 @@ class Cas2PersistedApplicationStatusFinderTest {
   inner class All {
     @Test
     fun `returns all statuses`() {
-      val finder = Cas2PersistedApplicationStatusFinder(statusList())
+      val finder = Cas2HdcPersistedApplicationStatusFinder(statusList())
 
       assertThat(finder.all().map { it.name }).isEqualTo(
         listOf(
@@ -36,7 +36,7 @@ class Cas2PersistedApplicationStatusFinderTest {
   inner class Active {
     @Test
     fun `returns only the ACTIVE statuses`() {
-      val finder = Cas2PersistedApplicationStatusFinder(statusList())
+      val finder = Cas2HdcPersistedApplicationStatusFinder(statusList())
 
       assertThat(finder.active().map { it.name }).isEqualTo(
         listOf(
@@ -51,7 +51,7 @@ class Cas2PersistedApplicationStatusFinderTest {
   inner class GetById {
     @Test
     fun `returns the matching status regardless of _isActive_ flag`() {
-      val finder = Cas2PersistedApplicationStatusFinder(statusList())
+      val finder = Cas2HdcPersistedApplicationStatusFinder(statusList())
 
       assertThat(
         finder.getById(UUID.fromString("f5cd423b-08eb-4efb-96ff-5cc6bb073905")).name,
@@ -68,7 +68,7 @@ class Cas2PersistedApplicationStatusFinderTest {
 
     @Test
     fun `throws an exception if the matching status is not found`() {
-      val finder = Cas2PersistedApplicationStatusFinder(statusList())
+      val finder = Cas2HdcPersistedApplicationStatusFinder(statusList())
 
       val exception = assertThrows<RuntimeException> {
         finder.getById(UUID.fromString("9887f81e-1a81-49b8-b0a6-5a17b3c9d7d1"))
@@ -85,7 +85,7 @@ class Cas2PersistedApplicationStatusFinderTest {
     @Test
     fun `Requests for CAS2 service returns only CAS2 detail updates`() {
       val statusList = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
-      val finder = Cas2PersistedApplicationStatusFinder(statusList)
+      val finder = Cas2HdcPersistedApplicationStatusFinder(statusList)
 
       val statuses = finder.all()
 
@@ -128,7 +128,7 @@ class Cas2PersistedApplicationStatusFinderTest {
     @Test
     fun `Requests for CAS2v2 service returns only CAS2v2 detail updates`() {
       val statusList = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2v2)
-      val finder = Cas2PersistedApplicationStatusFinder(statusList)
+      val finder = Cas2HdcPersistedApplicationStatusFinder(statusList)
 
       val statuses = finder.all()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/StatusUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/StatusUpdateServiceTest.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ex
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcAssessmentStatusUpdate
@@ -32,6 +31,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2S
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcStatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.transformer.Cas2HdcApplicationStatusTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/StatusUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/StatusUpdateServiceTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ex
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusDetail
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2DomainEventService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcAssessmentStatusUpdate
@@ -67,7 +67,7 @@ class StatusUpdateServiceTest {
     .produce()
   private val applicationId = application.id
   val assessment = Cas2AssessmentEntityFactory().withApplication(application).produce()
-  private val mockStatusFinder = mockk<Cas2PersistedApplicationStatusFinder>()
+  private val mockStatusFinder = mockk<Cas2HdcPersistedApplicationStatusFinder>()
   private val applicationUrlTemplate = "http://example.com/application-status-updated/#eventId"
   private val applicationOverviewUrlTemplate = "http://example.com/application/#id/overview"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/jobs/seed/SeedOnStartupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/jobs/seed/SeedOnStartupServiceTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SeedFileType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.ApprovedPremisesRoomsSeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1SeedPremisesFromCsvJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.seed.Cas1StartupScript
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2v2StartupScript
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.seed.Cas2StartupScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcStartupScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedLogger
@@ -43,7 +43,7 @@ class SeedOnStartupServiceTest {
   private val mockSeedLogger = mockk<SeedLogger>()
   private val mockCas1StartupScript = mockk<Cas1StartupScript>()
   private val mockCas2HdcStartupScript = mockk<Cas2HdcStartupScript>()
-  private val mockCas2v2StartupScript = mockk<Cas2v2StartupScript>()
+  private val mockCas2StartupScript = mockk<Cas2StartupScript>()
   private val mockSeedService = mockk<SeedService>()
   private val mockEnvironmentService = mockk<EnvironmentService>()
   private val mockSentryService = mockk<SentryService>()
@@ -54,7 +54,7 @@ class SeedOnStartupServiceTest {
     seedConfig,
     mockCas1StartupScript,
     mockCas2HdcStartupScript,
-    mockCas2v2StartupScript,
+    mockCas2StartupScript,
     mockSeedService,
     mockSeedLogger,
     mockEnvironmentService,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StartupScriptConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StartupScriptConfigTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcStartupScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
@@ -17,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2S
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcStatusUpdateService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.SeedLogger
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.seed.insertHdcDates

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StartupScriptConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/StartupScriptConfigTest.kt
@@ -6,7 +6,7 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2PersistedApplicationStatusFinder
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcPersistedApplicationStatusFinder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jobs.seed.Cas2HdcStartupScript
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
@@ -43,7 +43,7 @@ class StartupScriptConfigTest {
 
   private val mockApplicationService = mockk<Cas2HdcApplicationService>()
   private val mockCas2HdcStatusUpdateService = mockk<Cas2HdcStatusUpdateService>()
-  private val statusFinder = Cas2PersistedApplicationStatusFinder()
+  private val statusFinder = Cas2HdcPersistedApplicationStatusFinder()
 
   private val seedConfig = SeedConfig()
 


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-737

- Rename Cas2v2 controllers, annotations, and references to Cas2
- Rename Cas2v2 seed jobs, scripts, and references to Cas2.
- Rename Cas2v2 services, tests, and references to Cas2.
- Rename Cas2v2 transformers, tests, and references to Cas2.
- Remove strings from service annotations.
- Rename Cas2v2 utility class and references to Cas2.
- Rename Cas2v2 constants, tests, and security configuration references to Cas2
- Rename Cas2PersistedApplicationStatusFinder to Cas2HdcPersistedApplicationStatusFinder and update references.
- detekt and linting fixes.
- Refactor to reuse Cas2HdcPersistedApplicationStatusFinder instance in entity classes