### PR TITLE
Log problem responses locally

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/RequestResponseLoggingFilter.kt
@@ -105,7 +105,7 @@ class RequestResponseLoggingFilter(
   ) {
     log.info("Response Headers {}", responseWrapper.headerNames.map { "$it:  ${responseWrapper.getHeaders(it)}" })
     val contentType = responseWrapper.contentType
-    if (contentType == "application/json") {
+    if (contentType == "application/json" || contentType == "application/problem+json") {
       log.info("Response Body {}", String(responseWrapper.contentAsByteArray))
     } else {
       log.info("Response Body not logged as content type is $contentType")


### PR DESCRIPTION
Before this commit the request/response logger we use in local environments would not log problem responses