### PR TITLE
bug/SAS-693-cas1-suitable-placement-status-null-fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -42,7 +42,13 @@ class Cas1RequestForPlacementService(
   private fun toRequestForPlacement(placementApplication: PlacementApplicationEntity, user: UserEntity?) = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
     placementApplication,
     user?.let { cas1WithdrawableService.isDirectlyWithdrawable(placementApplication, user) } ?: false,
-  )
+  ).apply {
+    placementApplication.placementRequest?.let { placementRequest ->
+      placements = cas1SpaceBookingRepository
+        .findByPlacementRequestId(placementRequest.id)
+        .map { cas1SpaceBookingTransformer.transformToCas1SpaceBookingShortSummary(it) }
+    }
+  }
 
   private fun toRequestForPlacement(placementRequest: PlacementRequestEntity, user: UserEntity?): RequestForPlacement = requestForPlacementTransformer
     .transformPlacementRequestEntityToApi(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -42,21 +42,19 @@ class Cas1RequestForPlacementService(
   private fun toRequestForPlacement(placementApplication: PlacementApplicationEntity, user: UserEntity?) = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
     placementApplication,
     user?.let { cas1WithdrawableService.isDirectlyWithdrawable(placementApplication, user) } ?: false,
-  ).apply {
-    placementApplication.placementRequest?.let { placementRequest ->
-      placements = cas1SpaceBookingRepository
-        .findByPlacementRequestId(placementRequest.id)
-        .map { cas1SpaceBookingTransformer.transformToCas1SpaceBookingShortSummary(it) }
-    }
-  }
+  ).withPlacementsFrom(placementApplication.placementRequest)
 
   private fun toRequestForPlacement(placementRequest: PlacementRequestEntity, user: UserEntity?): RequestForPlacement = requestForPlacementTransformer
     .transformPlacementRequestEntityToApi(
       placementRequest,
       user?.let { cas1WithdrawableService.isDirectlyWithdrawable(placementRequest, user) } ?: false,
-    ).apply {
+    ).withPlacementsFrom(placementRequest)
+
+  private fun RequestForPlacement.withPlacementsFrom(placementRequest: PlacementRequestEntity?) = apply {
+    placementRequest?.let { pr ->
       placements = cas1SpaceBookingRepository
-        .findByPlacementRequestId(placementRequest.id)
+        .findByPlacementRequestId(pr.id)
         .map { cas1SpaceBookingTransformer.transformToCas1SpaceBookingShortSummary(it) }
     }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas1SpaceBookingShortSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplica
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationService
@@ -135,6 +137,67 @@ class Cas1RequestForPlacementServiceTest {
       placementApplications.forEach {
         verify(exactly = 1) { requestForPlacementTransformer.transformPlacementApplicationEntityToApi(it, true) }
       }
+    }
+
+    @Test
+    fun `Populates placements for a placement application from its linked placement request bookings`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withSubmittedAt(OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+        .produce()
+
+      val placementRequirements = PlacementRequirementsEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .produce()
+
+      val linkedPlacementRequest = PlacementRequestEntityFactory()
+        .withApplication(application)
+        .withAssessment(assessment)
+        .withPlacementRequirements(placementRequirements)
+        .produce()
+
+      val placementApplication = PlacementApplicationEntityFactory()
+        .withDefaults()
+        .withApplication(application)
+        .withPlacementRequest(linkedPlacementRequest)
+        .produce()
+
+      val spaceBooking = mockk<Cas1SpaceBookingEntity>()
+      val shortSummary = mockk<Cas1SpaceBookingShortSummary>()
+
+      every { applicationService.getApplication(application.id) } returns application
+
+      every {
+        cas1PlacementApplicationService.getAllSubmittedNonReallocatedApplications(application.id)
+      } returns listOf(placementApplication)
+
+      every {
+        placementRequestService.getPlacementRequestForInitialApplicationDates(application.id)
+      } returns listOf()
+
+      every { cas1WithdrawableService.isDirectlyWithdrawable(placementApplication, user) } returns true
+
+      every {
+        cas1SpaceBookingRepository.findByPlacementRequestId(linkedPlacementRequest.id)
+      } returns listOf(spaceBooking)
+
+      every {
+        cas1SpaceBookingTransformer.transformToCas1SpaceBookingShortSummary(spaceBooking)
+      } returns shortSummary
+
+      val result = cas1RequestForPlacementService.getRequestsForPlacementByApplication(application.id, user)
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it).hasSize(1)
+        assertThat(it.single().placements).containsExactly(shortSummary)
+      }
+
+      verify(exactly = 1) { cas1SpaceBookingRepository.findByPlacementRequestId(linkedPlacementRequest.id) }
     }
 
     @Test


### PR DESCRIPTION
This PR fixes null `placementStatus` for placements booked via manual placement applications

SAS Background
SAS is calling `GET /cas1/external/cases/{crn}/applications/suitable` during rules engine eligibility checks and is only treating a placement as valid when the `placementStatus` is populated (for example is upcoming). We have a CRN in preprod where this endpoint is returning `requestForPlacementStatus = placement_booked` and `placementStatus = null` - meaning SAS is showing the individual as `NOT_ELIGIBLE` for CAS1 - instead of `PLACEMENT_BOOKED`.  

It looks to me like this is caused by placements not being populated in the other `Cas1RequestForPlacementService.toRequestForPlacement` function so the booking was being dropped

  Changes
  - populate placements in the other `Cas1RequestForPlacementService.toRequestForPlacement` branch to load space bookings from the linked placement request (same behaviour as the existing branch which is working)
  - Added a unit test covering a manual placement application whose linked placement request has a booking

Ticket: https://dsdmoj.atlassian.net/browse/SAS-693