### PR TITLE
FM-746 Rename "release_type" columns for CAS1 reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/reporting/Cas1ApplicationV2ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/reporting/Cas1ApplicationV2ReportRepository.kt
@@ -31,7 +31,7 @@ SELECT DISTINCT ON (application.submitted_at, application.id)
   CASE 
     WHEN submission_event.data -> 'eventDetails' ->> 'releaseType' = 'inCommunity' THEN apa.situation
     ELSE submission_event.data -> 'eventDetails' ->> 'releaseType'
-  END AS release_type,
+  END AS application_release_type,
   ap_area.name AS application_origin_cru,
   submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'ldu' ->> 'name' AS referral_ldu,
   submission_event.data -> 'eventDetails' -> 'submittedBy' -> 'region' ->> 'name' AS referral_region,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/reporting/Cas1RequestForPlacementReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/reporting/Cas1RequestForPlacementReportRepository.kt
@@ -54,7 +54,7 @@ class Cas1RequestForPlacementReportRepository(
     CASE 
       WHEN apa.release_type = 'inCommunity' THEN apa.situation
       ELSE apa.release_type
-    END AS release_type,
+    END AS placement_release_type,
     raw_applications_report.*
     
   FROM placement_applications_placeholder pap
@@ -112,7 +112,7 @@ UNION ALL
     CASE
       WHEN pa.release_type = 'inCommunity' THEN pa.situation
       ELSE pa.release_type
-    END AS release_type,
+    END AS placement_release_type,
     raw_applications_report.*
     
   FROM

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1ApplicationV2ReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1ApplicationV2ReportTest.kt
@@ -337,7 +337,7 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.offence_id).isEqualTo("offenceId1")
       assertThat(row.premises_type).isEqualTo("NORMAL")
       assertThat(row.sentence_type).isEqualTo("nonStatutory")
-      assertThat(row.release_type).isEqualTo("licence")
+      assertThat(row.application_release_type).isEqualTo("licence")
       assertThat(row.application_origin_cru).isEqualTo("apArea1")
       assertThat(row.referral_ldu).isEqualTo("ldu1")
       assertThat(row.referral_region).isEqualTo("refRegion1")
@@ -507,7 +507,7 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.offence_id).isEqualTo("offenceId3")
       assertThat(row.premises_type).isEqualTo("PIPE")
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
-      assertThat(row.release_type).isEqualTo("bailAssessment")
+      assertThat(row.application_release_type).isEqualTo("bailAssessment")
       assertThat(row.application_origin_cru).isEqualTo("apArea3")
       assertThat(row.referral_ldu).isEqualTo("ldu3")
       assertThat(row.referral_region).isEqualTo("refRegion3")
@@ -616,7 +616,7 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.offence_id).isEqualTo("offenceId2")
       assertThat(row.premises_type).isEqualTo("ESAP")
       assertThat(row.sentence_type).isEqualTo("ipp")
-      assertThat(row.release_type).isEqualTo("notApplicable")
+      assertThat(row.application_release_type).isEqualTo("notApplicable")
       assertThat(row.application_origin_cru).isEqualTo("apArea2")
       assertThat(row.referral_ldu).isEqualTo("ldu2")
       assertThat(row.referral_region).isEqualTo("refRegion2")
@@ -780,7 +780,7 @@ class Cas1ApplicationV2ReportTest : InitialiseDatabasePerClassTestBase() {
     val offence_id: String?,
     val premises_type: String?,
     val sentence_type: String?,
-    val release_type: String?,
+    val application_release_type: String?,
     val application_origin_cru: String?,
     val referral_ldu: String?,
     val referral_region: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/reporting/Cas1RequestForPlacementReportTest.kt
@@ -197,7 +197,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
         assertThat(headers).contains("initial_assessor_name")
         assertThat(headers).contains("last_appealed_assessor_username")
         assertThat(headers).contains("sentence_type")
-        assertThat(headers).contains("release_type")
+        assertThat(headers).contains("placement_release_type")
 
         val actual = DataFrame
           .readCSV(completeCsvString.byteInputStream())
@@ -373,7 +373,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_withdrawal_date).isEqualTo("2022-01-12T10:15:00Z")
       assertThat(row.request_for_placement_withdrawal_reason).isEqualTo("duplicate_application")
       assertThat(row.crn).isEqualTo("StandardRFPNotAssessed")
-      assertThat(row.release_type).isEqualTo("notApplicable")
+      assertThat(row.placement_release_type).isEqualTo("notApplicable")
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
     }
   }
@@ -420,7 +420,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_decision_made_date).isEqualTo("2020-12-01T09:15:45Z")
       assertThat(row.request_for_placement_withdrawal_date).isEqualTo("2021-03-15T00:10:00Z")
       assertThat(row.request_for_placement_withdrawal_reason).isEqualTo("DUPLICATE_PLACEMENT_REQUEST")
-      assertThat(row.release_type).isEqualTo("notApplicable")
+      assertThat(row.placement_release_type).isEqualTo("notApplicable")
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
     }
   }
@@ -523,7 +523,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
         assertThat(row.request_for_placement_withdrawal_reason).isNull()
       }
       assertThat(row.crn).isEqualTo("${releaseType}PlacementAppAssessed")
-      assertThat(row.release_type).isEqualTo(releaseType.name)
+      assertThat(row.placement_release_type).isEqualTo(releaseType.name)
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
     }
   }
@@ -582,7 +582,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
       assertThat(row.request_for_placement_withdrawal_date).isNull()
       assertThat(row.request_for_placement_withdrawal_reason).isNull()
       assertThat(row.crn).isEqualTo("PlacementAppRejected")
-      assertThat(row.release_type).isEqualTo("rotl")
+      assertThat(row.placement_release_type).isEqualTo("rotl")
       assertThat(row.sentence_type).isEqualTo("bailPlacement")
     }
   }
@@ -673,7 +673,7 @@ class Cas1RequestForPlacementReportTest : InitialiseDatabasePerClassTestBase() {
     val request_for_placement_withdrawal_reason: String?,
     val crn: String?,
     val sentence_type: String?,
-    val release_type: String?,
+    val placement_release_type: String?,
   )
 
   private fun createAndSubmitApplication(


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-746

# Changes in this PR
- Renamed the two "release type" columns to "Application Release Type" and "Placement Release Type" .
- Updated the integration tests to use the new column names.
- Generated all required reports locally and confirmed that the updated names are displayed correctly in the CSVs.

