### PR TITLE
SAS-467: Fix cas1 and cas3 status.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalReferralsController.kt
@@ -6,18 +6,21 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ReferralHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external.Cas1ExternalApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
 
 @Cas1ExternalController
 class Cas1ExternalReferralsController(
   private val cas1AssessmentService: Cas1AssessmentService,
   private val cas1AssessmentTransformer: Cas1AssessmentTransformer,
+  private val cas1ExternalApplicationService: Cas1ExternalApplicationService,
 ) {
   @PreAuthorize("hasRole('APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE')")
   @GetMapping("/referrals/{crn}")
   fun getReferralsByCrn(@PathVariable crn: String): ResponseEntity<List<Cas1ReferralHistory>> = ResponseEntity.ok(
-    cas1AssessmentService.getApprovedPremisesAssessmentsByCrn(crn).map {
-      cas1AssessmentTransformer.transformDomainToApiCas1ReferralHistory(it)
+    cas1AssessmentService.getApprovedPremisesAssessmentsByCrn(crn).flatMap {
+      val placementHistories = cas1ExternalApplicationService.getPlacementHistories(it.application.id)
+      cas1AssessmentTransformer.transformDomainToApiCas1ReferralHistory(it, placementHistories)
     },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1ReferralHistory.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import java.time.Instant
 import java.util.UUID
 
@@ -8,13 +10,14 @@ data class Cas1ReferralHistory(
   val type: ServiceType,
   val id: UUID,
   val applicationId: UUID,
-  val status: Cas1AssessmentStatus,
+  val applicationStatus: ApprovedPremisesApplicationStatus,
+  val requestForPlacementStatus: RequestForPlacementStatus?,
   val createdAt: Instant,
   val referralRejectionReason: String?,
   val localAuthorityArea: String?,
   val pdu: String?,
   val referredBy: Cas1StaffDto,
   val placementAddress: String?,
-  val placementStatus: String?,
+  val placementStatus: Cas1SpaceBookingStatus?,
   val uiUrl: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/external/Cas3ExternalReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/external/Cas3ExternalReferralController.kt
@@ -19,7 +19,7 @@ class Cas3ExternalReferralController(
   fun getReferralsByCrn(
     @PathVariable crn: String,
   ): ResponseEntity<List<Cas3ReferralHistory>> = ResponseEntity.ok(
-    cas3AssessmentService.getAssessmentsByCrn(crn).map {
+    cas3AssessmentService.getAssessmentsByCrn(crn).flatMap {
       cas3AssessmentTransformer.transformAssessmentToCas3ReferralHistory(it)
     },
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingEntity.kt
@@ -171,13 +171,13 @@ interface Cas3v2BookingRepository : JpaRepository<Cas3BookingEntity, UUID> {
   fun findFirstBookingByBedId(bedId: UUID): Cas3BookingEntity?
 
   @Query(
-    "SELECT * FROM bookings WHERE application_id = :applicationId AND service = :service ORDER BY created_at DESC LIMIT 1",
+    "SELECT * FROM bookings WHERE application_id = :applicationId AND service = :service ORDER BY created_at DESC",
     nativeQuery = true,
   )
-  fun findLatestBookingEntity(
+  fun findAllCas3BookingEntity(
     applicationId: UUID,
     service: String,
-  ): Cas3BookingEntity?
+  ): List<Cas3BookingEntity>
 
   @Query(
     """      

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3ReferralHistory.kt
@@ -1,7 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import java.time.Instant
 import java.util.UUID
 
@@ -9,7 +10,7 @@ data class Cas3ReferralHistory(
   val type: ServiceType,
   val id: UUID,
   val applicationId: UUID,
-  val status: TemporaryAccommodationAssessmentStatus,
+  val applicationStatus: ApplicationStatus,
   val createdAt: Instant,
   val referralRejectionReason: String?,
   val referralRejectionReasonDetail: String?,
@@ -17,6 +18,6 @@ data class Cas3ReferralHistory(
   val pdu: String?,
   val referredBy: Cas3StaffDto,
   val placementAddress: String?,
-  val placementStatus: String?,
+  val bookingStatus: Cas3BookingStatus?,
   val uiUrl: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -84,30 +84,33 @@ class Cas3AssessmentTransformer(
     probationDeliveryUnitName = ase.probationDeliveryUnitName,
   )
 
-  fun transformAssessmentToCas3ReferralHistory(a: TemporaryAccommodationAssessmentEntity): Cas3ReferralHistory {
+  fun transformAssessmentToCas3ReferralHistory(a: TemporaryAccommodationAssessmentEntity): List<Cas3ReferralHistory> {
     val application = a.typedApplication<TemporaryAccommodationApplicationEntity>()
 
-    val latestBooking = bookingRepository.findLatestBookingEntity(application.id, ServiceName.temporaryAccommodation.value)
+    val bookings = bookingRepository.findAllCas3BookingEntity(application.id, ServiceName.temporaryAccommodation.value)
 
-    val placementAddress = latestBooking?.let {
-      listOfNotNull(it.premises.addressLine1, it.premises.town, it.premises.postcode).joinToString(", ")
-    }
-
-    return Cas3ReferralHistory(
+    val referralHistory = Cas3ReferralHistory(
       id = a.id,
       applicationId = application.id,
       createdAt = a.createdAt.toInstant(),
-      status = a.deriveAssessmentStatus(),
+      applicationStatus = application.getStatus(),
       type = ServiceType.CAS3,
       referralRejectionReason = a.referralRejectionReason?.name ?: a.rejectionRationale,
       referralRejectionReasonDetail = a.referralRejectionReasonDetail,
       localAuthorityArea = application.dutyToReferLocalAuthorityAreaName,
       pdu = application.probationDeliveryUnit?.name,
       referredBy = transformToStaffDto(application.createdByUser),
-      placementAddress = placementAddress,
-      placementStatus = latestBooking?.status?.value,
+      placementAddress = null,
+      bookingStatus = null,
       uiUrl = cas3ApplicationFullUrlTemplate.replace("#applicationId", application.id.toString()),
     )
+
+    return bookings.map {
+      referralHistory.copy(
+        placementAddress = listOfNotNull(it.premises.addressLine1, it.premises.town, it.premises.postcode).joinToString(", "),
+        bookingStatus = it.status,
+      )
+    }.ifEmpty { listOf(referralHistory) }
   }
 
   fun transformApiStatusToDomainSummaryState(status: AssessmentStatus) = when (status) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
@@ -8,17 +8,18 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ReferralHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external.Cas1ExternalApplicationService.Cas1PlacementHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
@@ -34,7 +35,6 @@ class Cas1AssessmentTransformer(
   private val userTransformer: UserTransformer,
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
-  private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
   @Value($$"${url-templates.frontend.application}") private val cas1ApplicationUrlTemplate: String,
 ) {
 
@@ -62,7 +62,10 @@ class Cas1AssessmentTransformer(
     createdFromAppeal = jpa.createdFromAppeal,
   )
 
-  fun transformDomainToCas1AssessmentSummary(ase: DomainAssessmentSummary, personInfo: PersonInfoResult): Cas1AssessmentSummary = Cas1AssessmentSummary(
+  fun transformDomainToCas1AssessmentSummary(
+    ase: DomainAssessmentSummary,
+    personInfo: PersonInfoResult,
+  ): Cas1AssessmentSummary = Cas1AssessmentSummary(
     id = ase.id,
     applicationId = ase.applicationId,
     createdAt = ase.createdAt,
@@ -79,30 +82,39 @@ class Cas1AssessmentTransformer(
     dueAt = ase.dueAt!!,
   )
 
-  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity): Cas1ReferralHistory {
+  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity, placementHistories: List<Cas1PlacementHistory>): List<Cas1ReferralHistory> {
     val application = entity.cas1Application()
 
-    val latestBooking = cas1SpaceBookingRepository.findLatestCas1SpaceBooking(application.id).firstOrNull()
-
-    val placementAddress = latestBooking?.premises?.let {
-      listOfNotNull(it.addressLine1, it.town, it.postcode).joinToString(", ")
-    }
-
-    return Cas1ReferralHistory(
+    val referralHistory = Cas1ReferralHistory(
       id = entity.id,
       applicationId = entity.application.id,
       createdAt = entity.createdAt.toInstant(),
-      status = getStatusForCas1Assessment(entity),
+      applicationStatus = application.status,
       type = ServiceType.CAS1,
       referralRejectionReason = entity.rejectionRationale,
       localAuthorityArea = application.apArea?.name,
       pdu = application.cruManagementArea?.name,
       referredBy = transformToStaffDto(application.createdByUser),
-      placementAddress = placementAddress,
-      placementStatus = latestBooking?.getSpaceBookingStatus()?.status?.value,
+      placementAddress = null,
+      placementStatus = null,
+      requestForPlacementStatus = null,
       uiUrl = cas1ApplicationUrlTemplate.replace("#id", entity.application.id.toString()),
     )
+
+    return placementHistories.map {
+      referralHistory.copy(
+        placementAddress = toPlacementAddress(it.premises),
+        placementStatus = it.placementStatus,
+        requestForPlacementStatus = it.requestForPlacementStatus,
+      )
+    }.ifEmpty { listOf(referralHistory) }
   }
+
+  private fun toPlacementAddress(premises: Cas1ExternalPremisesDto?): String? = listOfNotNull(
+    premises?.addressLine1,
+    premises?.town,
+    premises?.postcode,
+  ).takeIf { it.isNotEmpty() }?.joinToString(", ")
 
   fun transformCas1AssessmentStatusToDomainSummaryState(status: Cas1AssessmentStatus) = when (status) {
     Cas1AssessmentStatus.awaitingResponse -> DomainAssessmentSummaryStatus.AWAITING_RESPONSE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.Cas3IntegrationTestBase
@@ -11,7 +12,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Prem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ReferralHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -75,7 +75,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               id = assessment1.id,
               applicationId = assessment1.application.id,
               createdAt = assessment1.createdAt.toInstant(),
-              status = TemporaryAccommodationAssessmentStatus.readyToPlace,
+              applicationStatus = ApplicationStatus.submitted,
               type = ServiceType.CAS3,
               referralRejectionReason = null,
               referralRejectionReasonDetail = null,
@@ -83,14 +83,14 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               pdu = (assessment1.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
               referredBy = createStaffDto(user),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas3BookingStatus.provisional.value,
+              bookingStatus = Cas3BookingStatus.provisional,
               uiUrl = "http://frontend.cas3/referrals/${assessment1.application.id}/full",
             ),
             Cas3ReferralHistory(
               id = assessment2.id,
               applicationId = assessment2.application.id,
               createdAt = assessment2.createdAt.toInstant(),
-              status = TemporaryAccommodationAssessmentStatus.rejected,
+              applicationStatus = ApplicationStatus.submitted,
               type = ServiceType.CAS3,
               referralRejectionReason = "A random rejection reason",
               referralRejectionReasonDetail = "Some random rejection detail",
@@ -98,14 +98,14 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               pdu = (assessment2.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
               referredBy = createStaffDto(user),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas3BookingStatus.provisional.value,
+              bookingStatus = Cas3BookingStatus.provisional,
               uiUrl = "http://frontend.cas3/referrals/${assessment2.application.id}/full",
             ),
             Cas3ReferralHistory(
               id = assessment3.id,
               applicationId = assessment3.application.id,
               createdAt = assessment3.createdAt.toInstant(),
-              status = TemporaryAccommodationAssessmentStatus.closed,
+              applicationStatus = ApplicationStatus.submitted,
               type = ServiceType.CAS3,
               referralRejectionReason = null,
               referralRejectionReasonDetail = null,
@@ -113,14 +113,14 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               pdu = (assessment3.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
               referredBy = createStaffDto(user),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas3BookingStatus.provisional.value,
+              bookingStatus = Cas3BookingStatus.provisional,
               uiUrl = "http://frontend.cas3/referrals/${assessment3.application.id}/full",
             ),
             Cas3ReferralHistory(
               id = assessment4.id,
               applicationId = assessment4.application.id,
               createdAt = assessment4.createdAt.toInstant(),
-              status = TemporaryAccommodationAssessmentStatus.inReview,
+              applicationStatus = ApplicationStatus.submitted,
               type = ServiceType.CAS3,
               referralRejectionReason = null,
               referralRejectionReasonDetail = null,
@@ -128,14 +128,14 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               pdu = (assessment4.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
               referredBy = createStaffDto(user),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas3BookingStatus.provisional.value,
+              bookingStatus = Cas3BookingStatus.provisional,
               uiUrl = "http://frontend.cas3/referrals/${assessment4.application.id}/full",
             ),
             Cas3ReferralHistory(
               id = assessment5.id,
               applicationId = assessment5.application.id,
               createdAt = assessment5.createdAt.toInstant(),
-              status = TemporaryAccommodationAssessmentStatus.unallocated,
+              applicationStatus = ApplicationStatus.submitted,
               type = ServiceType.CAS3,
               referralRejectionReason = null,
               referralRejectionReasonDetail = null,
@@ -143,7 +143,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               pdu = (assessment5.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
               referredBy = createStaffDto(user),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas3BookingStatus.provisional.value,
+              bookingStatus = Cas3BookingStatus.provisional,
               uiUrl = "http://frontend.cas3/referrals/${assessment5.application.id}/full",
             ),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/external/Cas1ExternalReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/external/Cas1ExternalReferralsTest.kt
@@ -4,8 +4,8 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.expectBodyList
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ReferralHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -57,6 +58,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           val apArea = givenAnApArea(name = "London AP Area")
           val cruManagementArea = givenACas1CruManagementArea(name = "London CRU")
+
           val premises = approvedPremisesEntityFactory.produceAndPersist {
             withCruManagementArea(cruManagementArea)
             withAddressLine1("10 Test Street")
@@ -77,70 +79,75 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               id = assessment1.id,
               applicationId = assessment1.application.id,
               createdAt = assessment1.createdAt.toInstant(),
-              status = Cas1AssessmentStatus.completed,
+              applicationStatus = (assessment1.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
               localAuthorityArea = apArea.name,
               pdu = cruManagementArea.name,
               referredBy = createStaffDto(assessment1.application.createdByUser),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED,
+              requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
               uiUrl = "http://frontend/applications/${assessment1.application.id}",
             ),
             Cas1ReferralHistory(
               id = assessment2.id,
               applicationId = assessment2.application.id,
               createdAt = assessment2.createdAt.toInstant(),
-              status = Cas1AssessmentStatus.completed,
+              applicationStatus = (assessment2.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
               localAuthorityArea = apArea.name,
               pdu = cruManagementArea.name,
               referredBy = createStaffDto(assessment2.application.createdByUser),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED,
+              requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
               uiUrl = "http://frontend/applications/${assessment2.application.id}",
             ),
             Cas1ReferralHistory(
               id = assessment3.id,
               applicationId = assessment3.application.id,
               createdAt = assessment3.createdAt.toInstant(),
-              status = Cas1AssessmentStatus.completed,
+              applicationStatus = (assessment3.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
               localAuthorityArea = apArea.name,
               pdu = cruManagementArea.name,
               referredBy = createStaffDto(assessment3.application.createdByUser),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED,
+              requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
               uiUrl = "http://frontend/applications/${assessment3.application.id}",
             ),
             Cas1ReferralHistory(
               id = assessment4.id,
               applicationId = assessment4.application.id,
               createdAt = assessment4.createdAt.toInstant(),
-              status = Cas1AssessmentStatus.inProgress,
+              applicationStatus = (assessment4.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
               localAuthorityArea = apArea.name,
               pdu = cruManagementArea.name,
               referredBy = createStaffDto(assessment4.application.createdByUser),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED,
+              requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
               uiUrl = "http://frontend/applications/${assessment4.application.id}",
             ),
             Cas1ReferralHistory(
               id = assessment5.id,
               applicationId = assessment5.application.id,
               createdAt = assessment5.createdAt.toInstant(),
-              status = Cas1AssessmentStatus.inProgress,
+              applicationStatus = (assessment5.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
               localAuthorityArea = apArea.name,
               pdu = cruManagementArea.name,
               referredBy = createStaffDto(assessment5.application.createdByUser),
               placementAddress = "10 Test Street, London, SW1A 1AA",
-              placementStatus = Cas1SpaceBookingStatus.ARRIVED.value,
+              placementStatus = Cas1SpaceBookingStatus.ARRIVED,
+              requestForPlacementStatus = RequestForPlacementStatus.placementBooked,
               uiUrl = "http://frontend/applications/${assessment5.application.id}",
             ),
           )
@@ -180,6 +187,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
       if (apArea != null) withApArea(apArea)
       if (cruManagementArea != null) withCruManagementArea(cruManagementArea)
     }
+
     val assessment = approvedPremisesAssessmentEntityFactory.produceAndPersist {
       withApplication(application)
       withAllocatedToUser(allocated ?: user)
@@ -188,15 +196,33 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
       withCreatedAt(OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres())
     }
     if (premises != null) {
+      val placementRequirements = placementRequirementsFactory.produceAndPersist {
+        withApplication(application)
+        withAssessment(assessment)
+        withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
+        withEssentialCriteria(listOf())
+        withDesirableCriteria(listOf())
+      }
+      val placementRequest = placementRequestFactory.produceAndPersist {
+        withApplication(application)
+        withAssessment(assessment)
+        withPlacementRequirements(placementRequirements)
+        withCreatedAt(OffsetDateTime.now())
+        withExpectedArrival(LocalDate.now())
+        withDuration(7)
+      }
       cas1SpaceBookingEntityFactory.produceAndPersist {
         withPremises(premises)
         withApplication(application)
-        withPlacementRequest(null)
+        withPlacementRequest(placementRequest)
         withCreatedBy(user)
         withCrn(crn)
+        withExpectedArrivalDate(LocalDate.now())
+        withExpectedDepartureDate(LocalDate.now().plusDays(7))
         withActualArrivalDate(LocalDate.now())
       }
     }
+
     return assessment
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external.Cas1ExternalApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
@@ -71,6 +72,9 @@ class Cas1AssessmentTransformerTest {
 
   @MockK
   lateinit var mockCas1SpaceBookingRepository: Cas1SpaceBookingRepository
+
+  @MockK
+  lateinit var mockCs1ExternalApplicationService: Cas1ExternalApplicationService
 
   private val cas1ApplicationUrlTemplate: String = "http://localhost:3000/applications/#id"
 


### PR DESCRIPTION
Updates the CAS1 and CAS3 external referrals responses to report application-level status (and booking/placement status) rather than assessment status, and expands referral history to include multiple placement/booking history entries per assessment/application.

**Changes:**
- CAS1: `Cas1ReferralHistory` now includes `applicationStatus`, `requestForPlacementStatus`, and a typed `placementStatus`; controller/transformer updated to return multiple history rows via placement histories.
- CAS3: `Cas3ReferralHistory` now includes `applicationStatus` and a typed `bookingStatus`; controller/transformer updated to return multiple history rows via booking lists.
- Booking repository query changed to support returning CAS3 booking history entries.