### PR TITLE
FM-763 Remove the POST assessmentID closure endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/AssessmentController.kt
@@ -63,21 +63,6 @@ class AssessmentController(
 
   @Operation(
     tags = ["Assessment data"],
-    summary = "Closes an Assessment",
-  )
-  @RequestMapping(
-    method = [RequestMethod.POST],
-    value = ["/assessments/{assessmentId}/closure"],
-  )
-  fun assessmentsAssessmentIdClosurePost(@PathVariable assessmentId: UUID): ResponseEntity<Unit> {
-    val user = userService.getUserForRequest()
-    val assessmentAuthResult = cas3AssessmentService.closeAssessment(user, assessmentId)
-    extractEntityFromCasResult(assessmentAuthResult)
-    return ResponseEntity(HttpStatus.OK)
-  }
-
-  @Operation(
-    tags = ["Assessment data"],
     summary = "Adds a user-written note to an assessment",
   )
   @RequestMapping(


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-763

# Changes in this PR

Removed closure endpoint from `AssessmentController`

The POST endpoint now does not appear in SWAGGER index.