### PR TITLE
Stop grouping renovate upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,6 @@
   "ignoreDeps": ["postgres", "postgis", "redis"],
   "packageRules": [
     {
-      "matchManagers": ["gradle"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non major Gradle dependencies",
-      "groupSlug": "all-gradle-minor-patch"
-    },
-    {
       "description": "Ignore openapi version that breaks our swagger (see build.kts)",
       "matchPackageNames": [
         "org.springdoc:springdoc-openapi-starter-webmvc-ui",


### PR DESCRIPTION
We’ve observed that renovate isn’t applying the 7 day release rule. Until we’ve resolve this we’ll stop grouping releases together so we can merge those that are over 7 days