### PR TITLE
Add Inbox Functionality to handle domain events

### DIFF
--- a/script/generate_migration
+++ b/script/generate_migration
@@ -6,6 +6,9 @@
 
 set -e
 
+cd "$(dirname "$0")"
+script_dir="$(pwd)"
+
 if [ $1 == "dev+test" ]; then
     dir="dev+test"
 elif [ $1 == "all" ]; then
@@ -19,4 +22,4 @@ timestamp=`date "+%Y%m%d%H%M%S"`
 migration_name=`echo "$2" | awk '{print tolower($0)}' | tr ' ' '_'`
 filename="$(echo ${timestamp}__${migration_name}).sql"
 echo "Creating migration: $filename"
-touch "src/main/resources/db/migration/$dir/$filename"
+touch "${script_dir}/../src/main/resources/db/migration/$dir/$filename"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
@@ -1,0 +1,189 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.partition
+
+/**
+ * Dispatches inbox events to registered handlers. Each event is processed in isolation - handlers
+ * manage their own transactions. Add new event types by implementing [InboxEventHandler] and
+ * registering as a Spring bean.
+ *
+ * Partitions events by [InboxEventHandler.getPartitionKey] so that events for the same key are
+ * never processed concurrently. This avoids race conditions when updating the same resource. Events
+ * with different keys run in parallel using coroutines. Events are fetched ordered by
+ * [eventOccurredAt] ascending; within each partition, this order is preserved.
+ *
+ * If processing of an event fails (either with a FAILED response or from it throwing an exception)
+ * it will be recorded as FAILED and a sentry alert raised
+ */
+
+@Component
+@ConfigurationProperties(prefix = "domain-events.inbox.dispatcher")
+class DispatcherConfig(
+  var maxEventsPerBatch: Int = 10,
+  var maxConcurrentEvents: Int = 4,
+)
+
+@Component
+class InboxEventDispatcher(
+  handlers: List<InboxEventHandler>,
+  private val dispatcherConfig: DispatcherConfig,
+  private val inboxEventService: InboxEventService,
+  private val sentryService: SentryService,
+) {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val eventTypeToHandlers: Map<String, InboxEventHandler> =
+    handlers.associateBy { it.supportedEventType() }
+
+  @Scheduled(cron = $$"${domain-events.inbox.dispatcher.cron}")
+  @SchedulerLock(
+    name = "InboxEventDispatcher",
+    lockAtMostFor = $$"${domain-events.inbox.dispatcher.shedlock.lock-at-most-for}",
+    lockAtLeastFor = $$"${domain-events.inbox.dispatcher.shedlock.lock-at-least-for}",
+  )
+  fun processScheduled() = process()
+
+  fun process() = runBlocking {
+    log.info("processing again")
+
+    val progressTracker = ProgressTracker()
+    val batchSize = dispatcherConfig.maxEventsPerBatch
+
+    val inboxEvents = inboxEventService.findPendingOldestFirst(dispatcherConfig.maxEventsPerBatch)
+    if (inboxEvents.isEmpty()) {
+      return@runBlocking progressTracker.toStats()
+    }
+
+    val concurrencyLimit = Semaphore(dispatcherConfig.maxConcurrentEvents)
+
+    log.info("Processing inbox batch [count={}, eventIds={}, batchSize={}]", inboxEvents.size, inboxEvents.map { it.id }, batchSize)
+
+    val (partitions, eventsWithoutHandlers) = partitionByKey(inboxEvents)
+    eventsWithoutHandlers.forEach {
+      log.error("No handler registered for event type [inboxEventId={}, eventType={}]", it.id, it.eventType)
+      progressTracker.eventSkipped()
+    }
+    log.debug("Partitioned into {} groups", partitions.size)
+
+    coroutineScope {
+      partitions.map { (_, events) ->
+        async(Dispatchers.IO) {
+          concurrencyLimit.withPermit {
+            events.forEach { dispatchEvent(it, progressTracker) }
+          }
+        }
+      }.awaitAll()
+    }
+
+    log.info(
+      "Inbox batch complete [total={}, processed={}, notProcessed={}, failed={}, skipped={}]",
+      inboxEvents.size,
+      progressTracker.processedCount.get(),
+      progressTracker.notProcessedCount.get(),
+      progressTracker.failedCount.get(),
+      progressTracker.skippedCount.get(),
+    )
+
+    progressTracker.toStats()
+  }
+
+  /**
+   * Groups events by partition key. The given event order is retained with-in the partition
+   * (i.e. by eventOccurredAt asc)
+   */
+  private fun partitionByKey(
+    inboxEvents: List<InboxEventEntity>,
+  ): PartitioningResult {
+    val (withHandler, withoutHandler) = inboxEvents.partition { it.resolveHandler() != null }
+    val partitions: Map<String, List<InboxEventEntity>> = withHandler.groupBy { event ->
+      event.resolveHandler()!!.getPartitionKey(event.toInboxEvent()) ?: event.id.toString()
+    }
+    return PartitioningResult(partitions, withoutHandler)
+  }
+
+  @SuppressWarnings("TooGenericExceptionCaught")
+  private fun dispatchEvent(
+    inboxEvent: InboxEventEntity,
+    progressTracker: ProgressTracker,
+  ) {
+    val handler = inboxEvent.resolveHandler()!!
+
+    try {
+      when (handler.handle(inboxEvent.toInboxEvent())) {
+        InboxEventHandler.Result.PROCESSED -> {
+          inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.PROCESSED)
+          progressTracker.eventProcessed()
+        }
+        InboxEventHandler.Result.NOT_PROCESSED -> {
+          inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.NOT_PROCESSED)
+          progressTracker.eventNotProcessed()
+        }
+        InboxEventHandler.Result.FAILED -> {
+          sentryService.captureErrorMessage("Unexpected error dispatching to handler [inboxEventId=${inboxEvent.id}, eventType=${inboxEvent.eventType}]")
+          inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.FAILED)
+          progressTracker.eventFailed()
+        }
+      }
+    } catch (e: Throwable) {
+      sentryService.captureException(
+        InboxEventDispatcherFailureException("Unexpected error dispatching to handler [inboxEventId=${inboxEvent.id}, eventType=${inboxEvent.eventType}]", e),
+      )
+      inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.FAILED)
+      progressTracker.eventFailed()
+    }
+  }
+
+  class InboxEventDispatcherFailureException(
+    override val message: String,
+    override val cause: Throwable,
+  ) : Exception()
+
+  private data class ProgressTracker(
+    val processedCount: AtomicInteger = AtomicInteger(0),
+    val notProcessedCount: AtomicInteger = AtomicInteger(0),
+    val failedCount: AtomicInteger = AtomicInteger(0),
+    val skippedCount: AtomicInteger = AtomicInteger(0),
+  ) {
+    fun eventSkipped() = skippedCount.incrementAndGet()
+    fun eventFailed() = failedCount.incrementAndGet()
+    fun eventProcessed() = processedCount.incrementAndGet()
+    fun eventNotProcessed() = notProcessedCount.incrementAndGet()
+    fun toStats() = EventDispatcherStats(processedCount.get(), notProcessedCount.get(), failedCount.get(), skippedCount.get())
+  }
+
+  data class EventDispatcherStats(
+    val processedCount: Int,
+    val notProcessedCount: Int,
+    val failedCount: Int,
+    val skippedCount: Int,
+  )
+
+  private data class PartitioningResult(
+    val partitions: Map<String, List<InboxEventEntity>>,
+    val withoutHandlers: List<InboxEventEntity>,
+  )
+
+  private fun InboxEventEntity.resolveHandler() = eventTypeToHandlers[this.eventType]
+
+  private fun InboxEventEntity.toInboxEvent() = InboxEventHandler.InboxEvent(
+    id = this.id,
+    eventDetailUrl = this.eventDetailUrl,
+    payload = this.payload,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener
+
+import java.net.URI
+import java.util.UUID
+
+/**
+ * Handles processing of a specific inbox event type. Each handler is responsible for a single event
+ * type and manages its own transaction boundary. Add new handlers by implementing this interface
+ * and registering as a Spring bean.
+ *
+ * Events with the same [getPartitionKey] are processed sequentially to avoid concurrent updates to
+ * the same resource (e.g. case per CRN). Events with different keys are processed in parallel.
+ */
+interface InboxEventHandler {
+
+  /**
+   * The event type this handler supports (typically the value of IncomingHmppsDomainEventType.typeName). Only one handler per type
+   *
+   * We use a non-bounded type here so we can use custom handlers during integration testing
+   **/
+  fun supportedEventType(): String
+
+  /**
+   * Partition key for serialising processing. Events with the same key are never processed
+   * concurrently. Return null to process independently (each event in its own partition).
+   */
+  fun getPartitionKey(inboxEvent: InboxEvent): String? = null
+
+  /**
+   * Process the inbox event. Should run in its own transaction to make success or failure isolated per
+   * event. This function should be idempotent.
+   *
+   * If [Result.FAILED] is returned an alert will be raised by the caller
+   *
+   * Exceptions can be rethrown to the caller, in which case an alert will be raised and the event will
+   * be treated as if [Result.FAILED] has been returned
+   */
+  fun handle(inboxEvent: InboxEvent): Result
+
+  enum class Result {
+    PROCESSED,
+    NOT_PROCESSED,
+    FAILED,
+  }
+
+  data class InboxEvent(
+    val id: UUID,
+    val eventDetailUrl: String?,
+    val payload: String,
+  ) {
+    fun uri(): URI = URI.create(requireNotNull(eventDetailUrl) { "Missing detail url" })
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventService.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+import java.time.Instant
+
+@Service
+class InboxEventService(
+  private val inboxEventRepository: InboxEventRepository,
+) {
+  fun findPendingOldestFirst(maxSize: Int): List<InboxEventEntity> {
+    val pageable = PageRequest.of(
+      0,
+      maxSize,
+      Sort.by("eventOccurredAt").ascending(),
+    )
+
+    return inboxEventRepository.findAllByProcessedStatus(ProcessedStatus.PENDING, pageable)
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun saveInboxEvent(inboxEvent: InboxEventEntity) {
+    inboxEventRepository.save(inboxEvent)
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun updateInboxEventStatusAndSave(inboxEvent: InboxEventEntity, status: ProcessedStatus) {
+    inboxEvent.processedStatus = status
+    inboxEvent.processedAt = Instant.now()
+    inboxEventRepository.save(inboxEvent)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jpa/InboxEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jpa/InboxEventEntity.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.net.URI
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.UUID
+
+interface InboxEventRepository : JpaRepository<InboxEventEntity, UUID> {
+  fun findAllByProcessedStatus(processedStatus: ProcessedStatus, pageable: Pageable): List<InboxEventEntity>
+}
+
+@Entity
+@Table(name = "inbox_events")
+class InboxEventEntity(
+  @Id
+  val id: UUID,
+  val eventType: String,
+  val eventDetailUrl: String?,
+  val eventOccurredAt: OffsetDateTime,
+  val createdAt: Instant,
+  @Enumerated(EnumType.STRING)
+  var processedStatus: ProcessedStatus,
+  var processedAt: Instant?,
+  @Column(columnDefinition = "jsonb")
+  @JdbcTypeCode(SqlTypes.JSON)
+  var payload: String,
+)
+
+fun InboxEventEntity.uri(): URI = URI.create(requireNotNull(eventDetailUrl) { "Missing detail url" })
+
+enum class ProcessedStatus {
+  PENDING,
+  PROCESSED,
+  NOT_PROCESSED,
+  FAILED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/HmppsDomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/HmppsDomainEvent.kt
@@ -8,7 +8,7 @@ data class HmppsDomainEvent(
   val detailUrl: String? = null,
   val occurredAt: ZonedDateTime = ZonedDateTime.now(),
   val description: String? = null,
-  val additionalInformation: AdditionalInformation,
+  val additionalInformation: AdditionalInformation = AdditionalInformation(),
   val personReference: PersonReference = PersonReference(),
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/SnsEvent.kt
@@ -15,7 +15,10 @@ data class SnsEvent(
 
 data class SnsEventPersonReferenceCollection(
   val identifiers: List<SnsEventPersonReference>,
-)
+) {
+  fun findCrn() = get("CRN")
+  fun get(key: String) = identifiers.find { it.type == key }?.value
+}
 
 data class SnsEventPersonReference(
   val type: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -350,3 +350,14 @@ scheduling:
 
 feature-flags:
   cas2-sqs-listener-enabled: false
+
+domain-events:
+  inbox:
+    dispatcher:
+      # - means disabled
+      cron: '-'
+      max-events-per-batch: 10
+      max-concurrent-events: 4
+      shedlock:
+        lock-at-most-for: PT2M
+        lock-at-least-for: PT1S

--- a/src/main/resources/db/migration/all/20260623110259__add_inbox_events.sql
+++ b/src/main/resources/db/migration/all/20260623110259__add_inbox_events.sql
@@ -1,0 +1,14 @@
+CREATE TABLE inbox_events
+(
+    id                UUID PRIMARY KEY,
+    event_type        TEXT                     NOT NULL,
+    event_detail_url  TEXT                     NOT NULL,
+    event_occurred_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL,
+    processed_status  VARCHAR(20)              NOT NULL,
+    processed_at      TIMESTAMP WITH TIME ZONE,
+    payload           JSONB                    not null
+);
+
+CREATE INDEX idx_inbox_event_processed_status_occurred_at
+    ON inbox_events (processed_status, event_occurred_at);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/InboxEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/InboxEventEntityFactory.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class InboxEventEntityFactory : Factory<InboxEventEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var eventType: Yielded<String> = { randomStringUpperCase(12) }
+  private var eventDetailUrl: Yielded<String> = { randomStringUpperCase(12) }
+  private var eventOccurredAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(5) }
+  private var createdAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(14) }
+  private var processedStatus: Yielded<ProcessedStatus> = { ProcessedStatus.entries.random() }
+  private var processedAt: Yielded<Instant?> = { Instant.now().randomDateTimeBefore(14) }
+  private var payload: Yielded<String> = { randomStringUpperCase(12) }
+
+  fun withEventType(eventType: String) = apply {
+    this.eventType = { eventType }
+  }
+
+  fun withEventOccurredAt(eventOccurredAt: OffsetDateTime) = apply {
+    this.eventOccurredAt = { eventOccurredAt }
+  }
+
+  fun withPayload(payload: String) = apply {
+    this.payload = { payload }
+  }
+
+  fun withProcessedStatus(status: ProcessedStatus) = apply {
+    this.processedStatus = { status }
+  }
+
+  fun withProcessedAt(processedAt: Instant?) = apply {
+    this.processedAt = { processedAt }
+  }
+
+  override fun produce(): InboxEventEntity = InboxEventEntity(
+    id = this.id(),
+    eventType = this.eventType(),
+    eventDetailUrl = this.eventDetailUrl(),
+    eventOccurredAt = this.eventOccurredAt(),
+    createdAt = this.createdAt(),
+    processedStatus = this.processedStatus(),
+    processedAt = this.processedAt(),
+    payload = this.payload(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxEventDispatcherIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxEventDispatcherIT.kt
@@ -1,0 +1,208 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.DispatcherConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventDispatcher
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonIdentifier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonReference
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Integration tests for [InboxEventDispatcher] proving:
+ * - Virtual threads enable concurrent processing
+ * - Events are processed in eventOccurredAt order (oldest first)
+ * - maxEventsPerBatch limits batch size
+ */
+
+class InboxEventDispatcherIT : IntegrationTestBase() {
+  @Autowired
+  lateinit var inboxEventDispatcher: InboxEventDispatcher
+
+  @Autowired
+  lateinit var dispatcherConfig: DispatcherConfig
+
+  @Autowired
+  lateinit var mockEventHandler: MockInboxEventHandler
+
+  private val crn = UUID.randomUUID().toString()
+
+  @BeforeEach
+  fun setup() {
+    dispatcherConfig.maxConcurrentEvents = 4
+    dispatcherConfig.maxEventsPerBatch = 10
+  }
+
+  @Test
+  fun `processes only maxEventsPerBatch events per invocation`() {
+    dispatcherConfig.maxEventsPerBatch = 2
+
+    val baseTime = OffsetDateTime.now(ZoneOffset.UTC)
+    (1..5).forEach { i ->
+      createInboxEvent(eventOccurredAt = baseTime.plusSeconds(i.toLong()), crn = UUID.randomUUID().toString())
+    }
+
+    inboxEventDispatcher.process()
+
+    val processed =
+      inboxEventRepository.findAllByProcessedStatus(
+        ProcessedStatus.PROCESSED,
+        Pageable.unpaged(Sort.by("eventOccurredAt").ascending()),
+      )
+    val pending =
+      inboxEventRepository.findAllByProcessedStatus(
+        ProcessedStatus.PENDING,
+        Pageable.unpaged(Sort.by("eventOccurredAt").ascending()),
+      )
+
+    assertThat(processed).hasSize(2)
+    assertThat(pending).hasSize(3)
+
+    mockEventHandler.assertThatHasProcessedEvents(processed)
+  }
+
+  @Test
+  fun `processes events in eventOccurredAt ascending order`() {
+    dispatcherConfig.maxEventsPerBatch = 1
+
+    val t1 = OffsetDateTime.of(2025, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC)
+    val t2 = OffsetDateTime.of(2025, 1, 1, 11, 0, 0, 0, ZoneOffset.UTC)
+    val t3 = OffsetDateTime.of(2025, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    createInboxEvent(eventOccurredAt = t3, crn = UUID.randomUUID().toString())
+    createInboxEvent(eventOccurredAt = t1, crn = UUID.randomUUID().toString())
+    createInboxEvent(eventOccurredAt = t2, crn = UUID.randomUUID().toString())
+
+    inboxEventDispatcher.process()
+
+    val firstBatch =
+      inboxEventRepository
+        .findAllByProcessedStatus(
+          ProcessedStatus.PROCESSED,
+          PageRequest.of(0, 10, Sort.by("processedAt").ascending()),
+        )
+
+    val firstProcessed = firstBatch.single()
+
+    inboxEventDispatcher.process()
+
+    val secondBatch = inboxEventRepository
+      .findAllByProcessedStatus(
+        ProcessedStatus.PROCESSED,
+        PageRequest.of(0, 10, Sort.by("processedAt").ascending()),
+      )
+    assertThat(secondBatch).hasSize(2)
+    val secondProcessed = secondBatch.last()
+
+    inboxEventDispatcher.process()
+    val thirdBatch =
+      inboxEventRepository
+        .findAllByProcessedStatus(
+          ProcessedStatus.PROCESSED,
+          PageRequest.of(0, 10, Sort.by("processedAt").ascending()),
+        )
+    assertThat(thirdBatch).hasSize(3)
+    val thirdProcessed = thirdBatch.last()
+
+    assertThat(firstProcessed.eventOccurredAt).isEqualTo(t1)
+    assertThat(secondProcessed.eventOccurredAt).isEqualTo(t2)
+    assertThat(thirdProcessed.eventOccurredAt).isEqualTo(t3)
+
+    mockEventHandler.assertThatHasProcessedEvents(listOf(firstProcessed, secondProcessed, thirdProcessed))
+  }
+
+  @Test
+  fun `processes at most 4 events concurrently due to semaphore limit`() {
+    dispatcherConfig.maxEventsPerBatch = 5
+    dispatcherConfig.maxConcurrentEvents = 4
+    val crns = (1..5).map { "X12345$it" }
+
+    val baseTime = OffsetDateTime.now(ZoneOffset.UTC)
+    crns.mapIndexed { i, c ->
+      createInboxEvent(eventOccurredAt = baseTime.plusSeconds(i.toLong()), crn = c)
+    }
+
+    inboxEventDispatcher.process()
+
+    val processed =
+      inboxEventRepository.findAllByProcessedStatus(
+        ProcessedStatus.PROCESSED,
+        PageRequest.of(0, 10, Sort.by("eventOccurredAt").ascending()),
+      )
+    assertThat(processed).hasSize(5)
+
+    assertThat(mockEventHandler.maxConcurrent.get()).isEqualTo(4)
+  }
+
+  @Test
+  fun `processes multiple events concurrently using coroutines`() {
+    val delayMs = 200
+    val crns = listOf("X123451", "X123452", "X123453", "X123454")
+
+    val baseTime = OffsetDateTime.now(ZoneOffset.UTC)
+    crns.mapIndexed { i, c ->
+      createInboxEvent(eventOccurredAt = baseTime.plusSeconds(i.toLong()), crn = c)
+    }
+
+    val start = System.currentTimeMillis()
+    inboxEventDispatcher.process()
+    val elapsed = System.currentTimeMillis() - start
+
+    val processed =
+      inboxEventRepository.findAllByProcessedStatus(
+        ProcessedStatus.PROCESSED,
+        PageRequest.of(0, 10, Sort.by("eventOccurredAt").ascending()),
+      )
+    assertThat(processed).hasSize(4)
+
+    // With 4 events and semaphore(4), parallel execution: ~delayMs. Sequential would be
+    // 4*delayMs.
+    assertThat(elapsed).isLessThan((delayMs * 3).toLong())
+  }
+
+  private fun createInboxEvent(
+    eventOccurredAt: OffsetDateTime,
+    crn: String = this.crn,
+  ): InboxEventEntity {
+    val payload =
+      HmppsDomainEvent(
+        eventType = MockInboxEventHandler.EVENT_TYPE,
+        version = 1,
+        description = "Integration test event",
+        detailUrl = "localhost",
+        occurredAt = eventOccurredAt.toZonedDateTime(),
+        personReference =
+        PersonReference(
+          identifiers = listOf(PersonIdentifier("CRN", crn)),
+        ),
+      )
+    return buildPendingInboxEventEntity(
+      eventType = MockInboxEventHandler.EVENT_TYPE,
+      eventOccurredAt = eventOccurredAt,
+      payload = jsonMapper.writeValueAsString(payload),
+    )
+  }
+
+  private fun buildPendingInboxEventEntity(
+    eventType: String,
+    eventOccurredAt: OffsetDateTime,
+    payload: String,
+  ) = inboxEventEntityFactory.produceAndPersist {
+    withEventType(eventType)
+    withEventOccurredAt(eventOccurredAt)
+    withPayload(payload)
+    withProcessedStatus(ProcessedStatus.PENDING)
+    withProcessedAt(null)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/MockInboxEventHandler.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/MockInboxEventHandler.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.stereotype.Service
+import org.springframework.test.context.event.annotation.BeforeTestMethod
+import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventHandler
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEvent
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.map
+import kotlin.jvm.java
+
+/**
+ * A mock event handler installed as a spring bean so it can be used when testing
+ * the inbox event dispatcher in [InboxEventDispatcherIT]. Partitions on CRN
+ *
+ * Will always return 'PROCESSED'
+ */
+@Service
+class MockInboxEventHandler(
+  private val jsonMapper: JsonMapper,
+  val currentCount: AtomicInteger = AtomicInteger(0),
+  val maxConcurrent: AtomicInteger = AtomicInteger(0),
+) : InboxEventHandler {
+
+  companion object {
+    const val EVENT_TYPE: String = "mock.event.handler"
+  }
+
+  val processedEvents: MutableList<InboxEventHandler.InboxEvent> = mutableListOf()
+
+  override fun getPartitionKey(inboxEvent: InboxEventHandler.InboxEvent): String? {
+    val snsDomainEvent = jsonMapper.readValue(inboxEvent.payload, SnsEvent::class.java)
+    return snsDomainEvent.personReference.findCrn()
+  }
+
+  override fun supportedEventType() = EVENT_TYPE
+
+  override fun handle(inboxEvent: InboxEventHandler.InboxEvent): InboxEventHandler.Result {
+    val c = currentCount.incrementAndGet()
+    maxConcurrent.updateAndGet { maxOf(it, c) }
+
+    try {
+      Thread.sleep(150)
+
+      processedEvents.add(inboxEvent)
+
+      return InboxEventHandler.Result.PROCESSED
+    } finally {
+      currentCount.decrementAndGet()
+    }
+  }
+
+  fun assertThatHasProcessedEvents(events: List<InboxEventEntity>) {
+    assertThat(processedEvents.map { it.id }).containsExactlyInAnyOrderElementsOf(events.map { it.id })
+  }
+
+  @BeforeTestMethod
+  fun reset() {
+    processedEvents.clear()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
@@ -1,0 +1,221 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.unit.domainevents.listener
+
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.DispatcherConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventDispatcher
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventHandler
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.InboxEventEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
+
+/**
+ * Concurrency and batching is tested by [InboxEventDispatcherIT]
+ */
+@ExtendWith(MockKExtension::class)
+class InboxEventDispatcherTest {
+
+  @RelaxedMockK
+  lateinit var inboxEventService: InboxEventService
+
+  @RelaxedMockK
+  lateinit var sentryService: SentryService
+
+  @Test
+  fun `no events, do nothing`() {
+    every { inboxEventService.findPendingOldestFirst(10) } returns emptyList()
+
+    val stats = inboxEventDispatcher(
+      maxEventsPerBatch = 10,
+    ).process()
+
+    assertThat(stats.processedCount).isEqualTo(0)
+    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.skippedCount).isEqualTo(0)
+    assertThat(stats.failedCount).isEqualTo(0)
+
+    verifyNoEventUpdatesMade()
+  }
+
+  @Test
+  fun `single event, no handler, skip`() {
+    val event = buildPendingInboxEventEntity(eventType = "test.event")
+
+    every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
+
+    val stats = inboxEventDispatcher(
+      handlers = emptyList(),
+      maxEventsPerBatch = 10,
+    ).process()
+
+    assertThat(stats.processedCount).isEqualTo(0)
+    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.skippedCount).isEqualTo(1)
+    assertThat(stats.failedCount).isEqualTo(0)
+
+    verifyNoEventUpdatesMade()
+  }
+
+  @Test
+  fun `handler returns PROCESSED, update event processed state to PROCESSED`() {
+    val event = buildPendingInboxEventEntity(eventType = "test.event")
+
+    every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
+
+    val handler = MockEventHandler(
+      supportedEventType = "test.event",
+      result = InboxEventHandler.Result.PROCESSED,
+    )
+
+    val stats = inboxEventDispatcher(
+      handlers = listOf(handler),
+      maxEventsPerBatch = 10,
+    ).process()
+
+    handler.assertThatHasProcessedEvent(event)
+
+    assertThat(stats.processedCount).isEqualTo(1)
+    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.skippedCount).isEqualTo(0)
+    assertThat(stats.failedCount).isEqualTo(0)
+
+    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.PROCESSED) }
+  }
+
+  @Test
+  fun `handler returns NOT PROCESSED, update event processed state to NOT_PROCESSED`() {
+    val event = buildPendingInboxEventEntity(eventType = "test.event")
+
+    every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
+
+    val handler = MockEventHandler(
+      supportedEventType = "test.event",
+      result = InboxEventHandler.Result.NOT_PROCESSED,
+    )
+
+    val stats = inboxEventDispatcher(
+      handlers = listOf(handler),
+      maxEventsPerBatch = 10,
+    ).process()
+
+    handler.assertThatHasProcessedEvent(event)
+
+    assertThat(stats.processedCount).isEqualTo(0)
+    assertThat(stats.notProcessedCount).isEqualTo(1)
+    assertThat(stats.skippedCount).isEqualTo(0)
+    assertThat(stats.failedCount).isEqualTo(0)
+
+    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.NOT_PROCESSED) }
+  }
+
+  @Test
+  fun `handler returns FAILED, update event processed state to FAILED and raise alert`() {
+    val event = buildPendingInboxEventEntity(eventType = "test.event")
+
+    every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
+
+    val handler = MockEventHandler(
+      supportedEventType = "test.event",
+      result = InboxEventHandler.Result.FAILED,
+    )
+
+    val stats = inboxEventDispatcher(
+      handlers = listOf(handler),
+      maxEventsPerBatch = 10,
+    ).process()
+
+    handler.assertThatHasProcessedEvent(event)
+
+    assertThat(stats.processedCount).isEqualTo(0)
+    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.skippedCount).isEqualTo(0)
+    assertThat(stats.failedCount).isEqualTo(1)
+
+    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.FAILED) }
+    verify { sentryService.captureErrorMessage("Unexpected error dispatching to handler [inboxEventId=${event.id}, eventType=${event.eventType}]") }
+  }
+
+  @Test
+  fun `handler throws Exception, ,update event processed state to FAILED and raise alert`() {
+    val event = buildPendingInboxEventEntity(eventType = "test.event")
+
+    every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
+
+    val exception = Exception("error message")
+
+    val handler = MockEventHandler(
+      supportedEventType = "test.event",
+      responseException = exception,
+      result = InboxEventHandler.Result.FAILED,
+    )
+
+    val stats = inboxEventDispatcher(
+      handlers = listOf(handler),
+      maxEventsPerBatch = 10,
+    ).process()
+
+    handler.assertThatHasProcessedEvent(event)
+
+    assertThat(stats.processedCount).isEqualTo(0)
+    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.skippedCount).isEqualTo(0)
+    assertThat(stats.failedCount).isEqualTo(1)
+
+    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.FAILED) }
+
+    val raisedExceptionSlot = slot<InboxEventDispatcher.InboxEventDispatcherFailureException>()
+    verify { sentryService.captureException(capture(raisedExceptionSlot)) }
+
+    assertThat(raisedExceptionSlot.captured.message).isEqualTo("Unexpected error dispatching to handler [inboxEventId=${event.id}, eventType=${event.eventType}]")
+    assertThat(raisedExceptionSlot.captured.cause).isEqualTo(exception)
+  }
+
+  private fun inboxEventDispatcher(
+    handlers: List<InboxEventHandler> = emptyList(),
+    maxEventsPerBatch: Int = 1,
+    maxConcurrentEvents: Int = 1,
+  ) = InboxEventDispatcher(
+    handlers = handlers,
+    dispatcherConfig = DispatcherConfig(maxEventsPerBatch, maxConcurrentEvents),
+    inboxEventService = inboxEventService,
+    sentryService = sentryService,
+  )
+
+  private data class MockEventHandler(
+    val supportedEventType: String,
+    val result: InboxEventHandler.Result,
+    val responseException: Throwable? = null,
+    val processedEvents: MutableList<InboxEventHandler.InboxEvent> = mutableListOf(),
+  ) : InboxEventHandler {
+    override fun supportedEventType() = supportedEventType
+    override fun handle(inboxEvent: InboxEventHandler.InboxEvent): InboxEventHandler.Result {
+      processedEvents.add(inboxEvent)
+
+      if (responseException != null) {
+        throw responseException
+      }
+
+      return result
+    }
+
+    fun assertThatHasProcessedEvent(event: InboxEventEntity) {
+      assertThat(processedEvents.map { it.id }).contains(event.id)
+    }
+  }
+
+  private fun verifyNoEventUpdatesMade() {
+    verify(exactly = 0) { inboxEventService.updateInboxEventStatusAndSave(any(), any()) }
+  }
+
+  private fun buildPendingInboxEventEntity(eventType: String) = InboxEventEntityFactory()
+    .withEventType(eventType)
+    .produce()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -124,6 +124,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Sta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppsauth.GetTokenResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.InboxEventEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -642,6 +645,9 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var cas3BedspacesRepository: Cas3BedspacesRepository
 
+  @Autowired
+  lateinit var inboxEventRepository: InboxEventRepository
+
   lateinit var offenderManagementUnitEntityFactory: PersistedFactory<OffenderManagementUnitEntity, UUID, OffenderManagementUnitEntityFactory>
   lateinit var probationRegionEntityFactory: PersistedFactory<ProbationRegionEntity, UUID, ProbationRegionEntityFactory>
   lateinit var apAreaEntityFactory: PersistedFactory<ApAreaEntity, UUID, ApAreaEntityFactory>
@@ -725,6 +731,7 @@ abstract class IntegrationTestBase {
   lateinit var placementApplicationEntityFactory: PersistedFactory<PlacementApplicationEntity, UUID, PlacementApplicationEntityFactory>
   lateinit var placementRequestEntityFactory: PersistedFactory<PlacementRequestEntity, UUID, PlacementRequestEntityFactory>
   lateinit var cas1PremisesLocalRestrictionEntityFactory: PersistedFactory<Cas1PremisesLocalRestrictionEntity, UUID, Cas1PremisesLocalRestrictionEntityFactory>
+  lateinit var inboxEventEntityFactory: PersistedFactory<InboxEventEntity, UUID, InboxEventEntityFactory>
   private var clientCredentialsCallMocked = false
 
   @BeforeEach
@@ -848,6 +855,7 @@ abstract class IntegrationTestBase {
     cas1ChangeRequestRejectionReasonEntityFactory = PersistedFactory({ Cas1ChangeRequestRejectionReasonEntityFactory() }, cas1ChangeRequestRejectionReasonRepository)
     cas1ChangeRequestEntityFactory = PersistedFactory({ Cas1ChangeRequestEntityFactory() }, cas1ChangeRequestRepository)
     cas1PremisesLocalRestrictionEntityFactory = PersistedFactory({ Cas1PremisesLocalRestrictionEntityFactory() }, cas1PremisesLocalRestrictionRepository)
+    inboxEventEntityFactory = PersistedFactory({ InboxEventEntityFactory() }, inboxEventRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -89,6 +89,8 @@ hmpps.sqs:
       dlqName: ${random.uuid}
       queueName: ${random.uuid}
       subscribeTopicId: domainevents
+
+
 domain-events:
   cas1:
     emit-enabled: true
@@ -96,6 +98,10 @@ domain-events:
     emit-enabled: true
   cas3:
     emit-enabled: bookingCancelled,bookingConfirmed,bookingProvisionallyMade,personArrived,personDeparted,referralSubmitted,personDepartureUpdated,bookingCancelledUpdated,personArrivedUpdated
+  inbox:
+    dispatcher:
+      # - means disabled
+      cron: '-'
 
 hmpps:
   auth:


### PR DESCRIPTION
This is currently disabled as the SQS listener is not yet configured, and there are no event handlers

This is a lightly modified version of the SAS inbox event handler