### PR TITLE
FM-792 `/cas2/users/{username}` duplicate user fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
@@ -3,13 +3,20 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2UserDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcUserService
 
 @Cas2Controller
 class Cas2UsersController(
+  private val cas2UserService: Cas2UserService,
   private val cas2HdcUserService: Cas2HdcUserService,
 ) {
 
+  @SuppressWarnings("UnusedParameter")
   @GetMapping("/users/{userName}")
-  fun getUserDetails(@PathVariable userName: String): Cas2UserDto = cas2HdcUserService.getCas2v2UserDetails(userName)
+  fun getUserDetails(@PathVariable userName: String): Cas2UserDto = cas2HdcUserService.getUserDetails(
+    // This is a quick fix to unblock an issue in production. It will be replaced by an
+    // endpoint that explicitly returns information for the current user
+    cas2UserService.getUserForRequest(),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcUserService.kt
@@ -54,14 +54,10 @@ class Cas2HdcUserService(
     return findOrCreateNomisUser(username = normalisedUsername, userDetail, serviceOrigin)
   }
 
-  fun getCas2v2UserDetails(userName: String): Cas2UserDto {
-    val existingUser =
-      cas2UserRepository.findByUsernameAndServiceOrigin(userName, Cas2ServiceOrigin.BAIL)
-        ?: throw NotFoundProblem(entityType = "Cas2v2User", id = userName)
-
+  fun getUserDetails(user: Cas2UserEntity): Cas2UserDto {
     val deliusUserInfo =
-      if (existingUser.userType == Cas2UserType.DELIUS) {
-        val deliusUser = getDeliusUser(existingUser.username)
+      if (user.userType == Cas2UserType.DELIUS) {
+        val deliusUser = getDeliusUser(user.username)
 
         Cas2DeliusUserInfoDto(
           probationArea = ProbationAreaDto(
@@ -74,8 +70,8 @@ class Cas2HdcUserService(
       }
 
     return Cas2UserDto(
-      username = existingUser.username,
-      type = Cas2UserTypeDto.valueOf(existingUser.userType.name),
+      username = user.username,
+      type = Cas2UserTypeDto.valueOf(user.userType.name),
       deliusUserInfo = deliusUserInfo,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
@@ -26,13 +26,14 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Getting a user returns region information for a Delius user`() {
+    fun `Getting a user returns region information for the logged in Delius user`() {
       val staffDetail = StaffDetailFactory.staffDetail()
+
       givenACas2v2DeliusUser(
         staffDetail = staffDetail,
       ) { userEntity, jwt ->
         val response = webTestClient.get()
-          .uri("/cas2/users/${userEntity.username}")
+          .uri("/cas2/users/DOESNTMATTER")
           .header("Authorization", "Bearer $jwt")
           .exchange()
           .expectStatus()
@@ -51,10 +52,10 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
   }
 
   @Test
-  fun `Getting a NOMIS user does not include region information`() {
+  fun `Getting a user returns region information for the logged in Nomis user does not include region information`() {
     givenACas2v2NomisUser { userEntity, jwt ->
       val response = webTestClient.get()
-        .uri("/cas2/users/${userEntity.username}")
+        .uri("/cas2/users/DOESNTMATTER")
         .header("Authorization", "Bearer $jwt")
         .exchange()
         .expectStatus()
@@ -67,6 +68,35 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
       assertThat(response?.username).isEqualTo(userEntity.username)
       assertThat(response?.type).isEqualTo(Cas2UserTypeDto.NOMIS)
       assertThat(response?.deliusUserInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `Does not fail if there are multiple users with the same username`() {
+    val nomisUser = givenACas2v2NomisUser()
+
+    val staffDetail = StaffDetailFactory.staffDetail(
+      deliusUsername = nomisUser.username,
+    )
+
+    givenACas2v2DeliusUser(
+      staffDetail = staffDetail,
+    ) { userEntity, jwt ->
+      val response = webTestClient.get()
+        .uri("/cas2/users/DOESNTMATTER")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<Cas2UserDto>()
+        .returnResult()
+        .responseBody
+
+      assertThat(response).isNotNull
+      assertThat(response?.username).isEqualTo(userEntity.username)
+      assertThat(response?.type).isEqualTo(Cas2UserTypeDto.DELIUS)
+      assertThat(response?.deliusUserInfo!!.probationArea.code).isEqualTo(staffDetail.probationArea.code)
+      assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/Cas2UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/Cas2UserServiceTest.kt
@@ -332,9 +332,7 @@ class Cas2UserServiceTest {
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
         .produce()
 
-      every { mockCas2UserRepository.findByUsernameAndServiceOrigin(username, Cas2ServiceOrigin.BAIL) } returns user
-
-      val result = cas2HdcUserService.getCas2v2UserDetails(username)
+      val result = cas2HdcUserService.getUserDetails(user)
 
       assertThat(result.username).isEqualTo(username)
       assertThat(result.type.name).isEqualTo("NOMIS")
@@ -355,29 +353,18 @@ class Cas2UserServiceTest {
         probationArea = StaffDetailFactory.probationArea().copy(code = "P1", description = "Probation Area 1"),
       )
 
-      every { mockCas2UserRepository.findByUsernameAndServiceOrigin(username, Cas2ServiceOrigin.BAIL) } returns user
       every { mockApDeliusContextApiClient.getStaffDetail(username) } returns ClientResult.Success(
         HttpStatus.OK,
         staffDetail,
       )
 
-      val result = cas2HdcUserService.getCas2v2UserDetails(username)
+      val result = cas2HdcUserService.getUserDetails(user)
 
       assertThat(result.username).isEqualTo(username)
       assertThat(result.type.name).isEqualTo("DELIUS")
       assertThat(result.deliusUserInfo).isNotNull
       assertThat(result.deliusUserInfo!!.probationArea.code).isEqualTo("P1")
       assertThat(result.deliusUserInfo.probationArea.description).isEqualTo("Probation Area 1")
-    }
-
-    @Test
-    fun `throws NotFoundProblem when user is not found`() {
-      val username = "NON_EXISTENT_USER"
-      every { mockCas2UserRepository.findByUsernameAndServiceOrigin(username, Cas2ServiceOrigin.BAIL) } returns null
-
-      assertThrows<NotFoundProblem> {
-        cas2HdcUserService.getCas2v2UserDetails(username)
-      }
     }
 
     @Test
@@ -389,7 +376,6 @@ class Cas2UserServiceTest {
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
         .produce()
 
-      every { mockCas2UserRepository.findByUsernameAndServiceOrigin(username, Cas2ServiceOrigin.BAIL) } returns user
       every { mockApDeliusContextApiClient.getStaffDetail(username) } returns ClientResult.Failure.StatusCode(
         method = org.springframework.http.HttpMethod.GET,
         path = "/",
@@ -398,7 +384,7 @@ class Cas2UserServiceTest {
       )
 
       assertThrows<NotFoundProblem> {
-        cas2HdcUserService.getCas2v2UserDetails(username)
+        cas2HdcUserService.getUserDetails(user)
       }
     }
 
@@ -411,7 +397,6 @@ class Cas2UserServiceTest {
         .withServiceOrigin(Cas2ServiceOrigin.BAIL)
         .produce()
 
-      every { mockCas2UserRepository.findByUsernameAndServiceOrigin(username, Cas2ServiceOrigin.BAIL) } returns user
       every { mockApDeliusContextApiClient.getStaffDetail(username) } returns ClientResult.Failure.StatusCode(
         method = org.springframework.http.HttpMethod.GET,
         path = "/",
@@ -420,7 +405,7 @@ class Cas2UserServiceTest {
       )
 
       assertThrows<RuntimeException> {
-        cas2HdcUserService.getCas2v2UserDetails(username)
+        cas2HdcUserService.getUserDetails(user)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAUser.kt
@@ -200,8 +200,8 @@ fun IntegrationTestBase.givenACas2v2PomUser(
 fun IntegrationTestBase.givenACas2v2NomisUser(
   id: UUID = UUID.randomUUID(),
   nomisUserDetailsConfigBlock: (NomisUserDetailFactory.() -> Unit)? = null,
-  block: (userEntity: Cas2UserEntity, jwt: String) -> Unit,
-) {
+  block: ((userEntity: Cas2UserEntity, jwt: String) -> Unit)? = null,
+): Cas2UserEntity {
   val nomisUserDetailsFactory = NomisUserDetailFactory()
 
   if (nomisUserDetailsConfigBlock != null) {
@@ -223,7 +223,11 @@ fun IntegrationTestBase.givenACas2v2NomisUser(
 
   nomisUserRolesMockSuccessfulGetMeCall(jwt, nomisUserDetails)
 
-  block(user, jwt)
+  if (block != null) {
+    block(user, jwt)
+  }
+
+  return user
 }
 
 fun IntegrationTestBase.givenACas2LicenceCaseAdminUser(


### PR DESCRIPTION
update `/cas2/users/{username}` to return the current user in a way that will not fail if there are multiple entries in the cas2 users table with the same username (but different types)

This is a quick fix to work around a production issue. It will be followed by a new endpoint that explicitly returns the dto for the current user and this endpoint will be removed.