### PR TITLE
FM-768 Update `cases.tier` on tier changed domain events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,8 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.44") {
     exclude(group = "io.swagger.core.v3")
   }
+
+  testImplementation("org.awaitility:awaitility:4.3.0")
 }
 
 springBoot {

--- a/helm_deploy/hmpps-approved-premises-api/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/values.yaml
@@ -41,6 +41,8 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
+    cas-domain-events-listener-queue:
+      HMPPS_SQS_QUEUES_CAS-DOMAIN-EVENTS-LISTENER-QUEUE_QUEUENAME: "QUEUE_NAME"
     cas-2-domain-events-listener-queue:
       HMPPS_SQS_QUEUES_CASTWODOMAINEVENTSLISTENERQUEUE_QUEUENAME: "QUEUE_NAME"
     cas-2-domain-events-listener-dlq:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -94,7 +94,6 @@ generic-service:
     URL-TEMPLATES_API_CAS3_PERSON-DEPARTURE-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/person-departure-updated/#eventId
     URL-TEMPLATES_API_CAS3_BOOKING-CANCELLED-UPDATED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/cas3/booking-cancelled-updated/#eventId
 
-
     NOTIFY_MODE: TEST_AND_GUEST_LIST
     NOTIFY_LOG_EMAILS: true
     HMPPS_SQS_USE_WEB_TOKEN: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/HmppsDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/HmppsDomainEventListener.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener
+
+import io.awspring.cloud.sqs.annotation.SqsListener
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.readValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
+import uk.gov.justice.hmpps.sqs.SnsMessage
+import java.time.Instant
+import java.util.UUID
+
+@ConditionalOnProperty(name = ["domain-events.listener.enabled"], havingValue = "true")
+@Component
+class HmppsDomainEventListener(
+  private val jsonMapper: JsonMapper,
+  private val inboxEventService: InboxEventService,
+  private val sentryService: SentryService,
+) {
+  companion object {
+    /**
+     * Message visibility should be set according to the longest possible processing
+     * time for a domain event. Given that we're writing straight into a database
+     * table, this can be short
+     */
+    const val MESSAGE_VISIBILITY_TIMEOUT: Long = 30L
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @SuppressWarnings("TooGenericExceptionCaught")
+  @SqsListener(
+    value = ["cas-domain-events-listener-queue"],
+    factory = "hmppsQueueContainerFactoryProxy",
+    messageVisibilitySeconds = MESSAGE_VISIBILITY_TIMEOUT.toString(),
+  )
+  fun processMessage(msg: String) {
+    try {
+      val snsMessage = jsonMapper.readValue<SnsMessage>(msg)
+      val event = jsonMapper.readValue<HmppsDomainEvent>(snsMessage.message)
+      inboxEventService.saveInboxEvent(
+        InboxEventEntity(
+          id = UUID.randomUUID(),
+          eventType = event.eventType,
+          eventDetailUrl = event.detailUrl,
+          eventOccurredAt = event.occurredAt.toOffsetDateTime(),
+          createdAt = Instant.now(),
+          processedStatus = ProcessedStatus.PENDING,
+          processedAt = null,
+          payload = snsMessage.message,
+        ),
+      )
+    } catch (e: Exception) {
+      log.error("Exception caught in HmppsDomainEventListener", e)
+      sentryService.captureException(e)
+      throw e
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
@@ -90,10 +90,10 @@ class InboxEventDispatcher(
     }
 
     log.info(
-      "Inbox batch complete [total={}, processed={}, notProcessed={}, failed={}, skipped={}]",
+      "Inbox batch complete [total={}, processed={}, ignored={}, failed={}, skipped={}]",
       inboxEvents.size,
       progressTracker.processedCount.get(),
-      progressTracker.notProcessedCount.get(),
+      progressTracker.ignoredCount.get(),
       progressTracker.failedCount.get(),
       progressTracker.skippedCount.get(),
     )
@@ -128,9 +128,9 @@ class InboxEventDispatcher(
           inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.PROCESSED)
           progressTracker.eventProcessed()
         }
-        InboxEventHandler.Result.NOT_PROCESSED -> {
-          inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.NOT_PROCESSED)
-          progressTracker.eventNotProcessed()
+        InboxEventHandler.Result.IGNORED -> {
+          inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.IGNORED)
+          progressTracker.eventIgnored()
         }
         InboxEventHandler.Result.FAILED -> {
           sentryService.captureErrorMessage("Unexpected error dispatching to handler [inboxEventId=${inboxEvent.id}, eventType=${inboxEvent.eventType}]")
@@ -154,20 +154,20 @@ class InboxEventDispatcher(
 
   private data class ProgressTracker(
     val processedCount: AtomicInteger = AtomicInteger(0),
-    val notProcessedCount: AtomicInteger = AtomicInteger(0),
+    val ignoredCount: AtomicInteger = AtomicInteger(0),
     val failedCount: AtomicInteger = AtomicInteger(0),
     val skippedCount: AtomicInteger = AtomicInteger(0),
   ) {
     fun eventSkipped() = skippedCount.incrementAndGet()
     fun eventFailed() = failedCount.incrementAndGet()
     fun eventProcessed() = processedCount.incrementAndGet()
-    fun eventNotProcessed() = notProcessedCount.incrementAndGet()
-    fun toStats() = EventDispatcherStats(processedCount.get(), notProcessedCount.get(), failedCount.get(), skippedCount.get())
+    fun eventIgnored() = ignoredCount.incrementAndGet()
+    fun toStats() = EventDispatcherStats(processedCount.get(), ignoredCount.get(), failedCount.get(), skippedCount.get())
   }
 
   data class EventDispatcherStats(
     val processedCount: Int,
-    val notProcessedCount: Int,
+    val ignoredCount: Int,
     val failedCount: Int,
     val skippedCount: Int,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
@@ -60,8 +60,6 @@ class InboxEventDispatcher(
   fun processScheduled() = process()
 
   fun process() = runBlocking {
-    log.info("processing again")
-
     val progressTracker = ProgressTracker()
     val batchSize = dispatcherConfig.maxEventsPerBatch
 
@@ -76,7 +74,7 @@ class InboxEventDispatcher(
 
     val (partitions, eventsWithoutHandlers) = partitionByKey(inboxEvents)
     eventsWithoutHandlers.forEach {
-      log.error("No handler registered for event type [inboxEventId={}, eventType={}]", it.id, it.eventType)
+      sentryService.captureErrorMessage("No handler registered for event type [inboxEventId=${it.id}, eventType=${it.eventType}]")
       progressTracker.eventSkipped()
     }
     log.debug("Partitioned into {} groups", partitions.size)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventDispatcher.kt
@@ -132,11 +132,6 @@ class InboxEventDispatcher(
           inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.IGNORED)
           progressTracker.eventIgnored()
         }
-        InboxEventHandler.Result.FAILED -> {
-          sentryService.captureErrorMessage("Unexpected error dispatching to handler [inboxEventId=${inboxEvent.id}, eventType=${inboxEvent.eventType}]")
-          inboxEventService.updateInboxEventStatusAndSave(inboxEvent, ProcessedStatus.FAILED)
-          progressTracker.eventFailed()
-        }
       }
     } catch (e: Throwable) {
       sentryService.captureException(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 interface InboxEventHandler {
 
   /**
-   * The event type this handler supports (typically the value of IncomingHmppsDomainEventType.typeName). Only one handler per type
+   * The domain event type this handler supports
    *
    * We use a non-bounded type here so we can use custom handlers during integration testing
    **/

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
@@ -30,17 +30,14 @@ interface InboxEventHandler {
    * Process the inbox event. Should run in its own transaction to make success or failure isolated per
    * event. This function should be idempotent.
    *
-   * If [Result.FAILED] is returned an alert will be raised by the caller
-   *
-   * Exceptions can be rethrown to the caller, in which case an alert will be raised and the event will
-   * be treated as if [Result.FAILED] has been returned
+   * Exceptions should be thrown to indicate failures that require manual intervention (in this case
+   * the event will be marked as `FAILED` and an alert will be raised)
    */
   fun handle(inboxEvent: InboxEvent): Result
 
   enum class Result {
     PROCESSED,
     IGNORED,
-    FAILED,
   }
 
   data class InboxEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventHandler.kt
@@ -39,7 +39,7 @@ interface InboxEventHandler {
 
   enum class Result {
     PROCESSED,
-    NOT_PROCESSED,
+    IGNORED,
     FAILED,
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/TierCalculationChangedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/TierCalculationChangedHandler.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener
+
+import org.springframework.stereotype.Component
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.readValue
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.HmppsDomainEvent
+
+@Component
+class TierCalculationChangedHandler(
+  val jsonMapper: JsonMapper,
+  val caseService: CaseService,
+) : InboxEventHandler {
+
+  companion object {
+    const val TIER_CALCULATION_EVENT_TYPE = "tier.calculation.changed"
+  }
+
+  override fun supportedEventType(): String = TIER_CALCULATION_EVENT_TYPE
+
+  override fun getPartitionKey(inboxEvent: InboxEventHandler.InboxEvent) = inboxEvent.extractCrn()
+
+  override fun handle(inboxEvent: InboxEventHandler.InboxEvent): InboxEventHandler.Result {
+    val crn = inboxEvent.extractCrn()
+
+    return when (caseService.reviseTier(crn!!)) {
+      true -> InboxEventHandler.Result.PROCESSED
+      false -> InboxEventHandler.Result.NOT_PROCESSED
+    }
+  }
+
+  private fun InboxEventHandler.InboxEvent.extractCrn() = jsonMapper.readValue<HmppsDomainEvent>(this.payload).personReference.findCrn()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/TierCalculationChangedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/TierCalculationChangedHandler.kt
@@ -25,7 +25,7 @@ class TierCalculationChangedHandler(
 
     return when (caseService.reviseTier(crn!!)) {
       true -> InboxEventHandler.Result.PROCESSED
-      false -> InboxEventHandler.Result.NOT_PROCESSED
+      false -> InboxEventHandler.Result.IGNORED
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jpa/InboxEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jpa/InboxEventEntity.kt
@@ -41,6 +41,6 @@ fun InboxEventEntity.uri(): URI = URI.create(requireNotNull(eventDetailUrl) { "M
 enum class ProcessedStatus {
   PENDING,
   PROCESSED,
-  NOT_PROCESSED,
+  IGNORED,
   FAILED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -55,7 +55,6 @@ class CaseService(
     val case = caseRepository.findByCrn(crn)
 
     if (case == null) {
-      log.debug("Not updating tier for $crn because have no case")
       return false
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
@@ -18,10 +19,11 @@ class CaseService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val hmppsTierApiClient: HMPPSTierApiClient,
 ) {
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   fun ensureCaseExists(crn: String): CaseEntity {
     val caseSummary = getCaseSummary(crn)
-    val riskTier = getRiskTier(crn)
+    val riskTier = getRiskTierOrNull(crn)
     val caseEntity = caseRepository.findByCrn(caseSummary.crn)?.apply {
       name = "${caseSummary.name.forename.uppercase()} ${caseSummary.name.surname.uppercase()}".trim()
       tier = riskTier
@@ -49,7 +51,27 @@ class CaseService(
     )
   }
 
-  private fun getRiskTier(crn: String): String? = when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
+  fun reviseTier(crn: String): Boolean {
+    val case = caseRepository.findByCrn(crn)
+
+    if (case == null) {
+      log.debug("Not updating tier for $crn because have no case")
+      return false
+    }
+
+    val tier = when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
+      is ClientResult.Success -> tierResponse.body.tierScore
+      is ClientResult.Failure -> throw tierResponse.toException()
+    }
+
+    case.tier = tier
+    caseRepository.save(case)
+
+    log.info("Have updated tier for $crn to $tier")
+    return true
+  }
+
+  private fun getRiskTierOrNull(crn: String): String? = when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
     is ClientResult.Success -> tierResponse.body.tierScore
     is ClientResult.Failure -> null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/HmppsDomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/domainevent/HmppsDomainEvent.kt
@@ -14,6 +14,7 @@ data class HmppsDomainEvent(
 
 data class PersonReference(val identifiers: List<PersonIdentifier> = listOf()) {
   fun findNomsNumber() = get("NOMS")
+  fun findCrn() = get("CRN")
   operator fun get(key: String) = identifiers.find { it.type == key }?.value
 }
 

--- a/src/main/resources/application-localdev.yml
+++ b/src/main/resources/application-localdev.yml
@@ -17,6 +17,11 @@ feature-flags:
 hmpps.sqs:
   provider: localstack
   queues:
+    cas-domain-events-listener-queue:
+      queueName: cas-domain-events-listener-queue
+      dlqName: cas-domain-events-listener-dlq
+      subscribeTopicId: domainevents
+      subscribeFilter: '{"eventType":["tier.calculation.complete"]}'
     castwodomaineventslistenerqueue:
       queueName: cas-2-domain-events-listener-queue
       dlqName: cas-2-domain-events-listener-dlq

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -352,10 +352,12 @@ feature-flags:
   cas2-sqs-listener-enabled: false
 
 domain-events:
+  listener:
+    enabled: true
   inbox:
     dispatcher:
-      # - means disabled
-      cron: '-'
+      # every 10 seconds
+      cron: '*/10 * * * * *'
       max-events-per-batch: 10
       max-concurrent-events: 4
       shedlock:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/HmppsDomainEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/HmppsDomainEventFactory.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.AdditionalInformation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonReference
+import java.time.ZonedDateTime
+
+class HmppsDomainEventFactory : Factory<HmppsDomainEvent> {
+  private var eventType: Yielded<String> = { "" }
+  private var version: Yielded<Int> = { 0 }
+  private var detailUrl: Yielded<String> = { "" }
+  private var occurredAt: Yielded<ZonedDateTime> = { ZonedDateTime.now() }
+  private var description: Yielded<String?> = { null }
+  private var additionalInformation: Yielded<AdditionalInformation> = { AdditionalInformation() }
+  private var personReference: Yielded<PersonReference> = { PersonReference() }
+
+  fun withEventType(eventType: String) = apply {
+    this.eventType = { eventType }
+  }
+
+  fun withPersonReference(personReference: PersonReference) = apply {
+    this.personReference = { personReference }
+  }
+
+  override fun produce() = HmppsDomainEvent(
+    eventType = eventType.invoke(),
+    version = version.invoke(),
+    detailUrl = detailUrl.invoke(),
+    occurredAt = occurredAt.invoke(),
+    description = description.invoke(),
+    additionalInformation = additionalInformation.invoke(),
+    personReference = personReference.invoke(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxAsserter.kt
@@ -20,7 +20,7 @@ class InboxAsserter(
 
   fun assertProcessedCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.PROCESSED)
 
-  fun assertNotProcessedCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.NOT_PROCESSED)
+  fun assertIgnoredCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.IGNORED)
 
   private fun assertCount(expectedCount: Int, status: ProcessedStatus) {
     val processed = inboxEventRepository.findAllByProcessedStatus(status, PageRequest.ofSize(Int.MAX_VALUE))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxAsserter.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
+
+@Component
+class InboxAsserter(
+  val inboxEventRepository: InboxEventRepository,
+) {
+
+  fun waitForPendingCount(expectedCount: Int) = Awaitility.await().untilAsserted { assertPendingCount(expectedCount) }
+
+  fun assertFailedCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.FAILED)
+
+  fun assertPendingCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.PENDING)
+
+  fun assertProcessedCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.PROCESSED)
+
+  fun assertNotProcessedCount(expectedCount: Int) = assertCount(expectedCount, ProcessedStatus.NOT_PROCESSED)
+
+  private fun assertCount(expectedCount: Int, status: ProcessedStatus) {
+    val processed = inboxEventRepository.findAllByProcessedStatus(status, PageRequest.ofSize(Int.MAX_VALUE))
+    assertThat(processed).hasSize(expectedCount)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxEventDispatcherIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxEventDispatcherIT.kt
@@ -9,10 +9,10 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.DispatcherConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventDispatcher
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.HmppsDomainEventFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonIdentifier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonReference
 import java.time.OffsetDateTime
@@ -35,6 +35,9 @@ class InboxEventDispatcherIT : IntegrationTestBase() {
 
   @Autowired
   lateinit var mockEventHandler: MockInboxEventHandler
+
+  @Autowired
+  lateinit var inboxAsserter: InboxAsserter
 
   private val crn = UUID.randomUUID().toString()
 
@@ -135,12 +138,7 @@ class InboxEventDispatcherIT : IntegrationTestBase() {
 
     inboxEventDispatcher.process()
 
-    val processed =
-      inboxEventRepository.findAllByProcessedStatus(
-        ProcessedStatus.PROCESSED,
-        PageRequest.of(0, 10, Sort.by("eventOccurredAt").ascending()),
-      )
-    assertThat(processed).hasSize(5)
+    inboxAsserter.assertProcessedCount(5)
 
     assertThat(mockEventHandler.maxConcurrent.get()).isEqualTo(4)
   }
@@ -164,7 +162,8 @@ class InboxEventDispatcherIT : IntegrationTestBase() {
         ProcessedStatus.PROCESSED,
         PageRequest.of(0, 10, Sort.by("eventOccurredAt").ascending()),
       )
-    assertThat(processed).hasSize(4)
+
+    inboxAsserter.assertProcessedCount(4)
 
     // With 4 events and semaphore(4), parallel execution: ~delayMs. Sequential would be
     // 4*delayMs.
@@ -176,17 +175,16 @@ class InboxEventDispatcherIT : IntegrationTestBase() {
     crn: String = this.crn,
   ): InboxEventEntity {
     val payload =
-      HmppsDomainEvent(
-        eventType = MockInboxEventHandler.EVENT_TYPE,
-        version = 1,
-        description = "Integration test event",
-        detailUrl = "localhost",
-        occurredAt = eventOccurredAt.toZonedDateTime(),
-        personReference =
-        PersonReference(
-          identifiers = listOf(PersonIdentifier("CRN", crn)),
-        ),
-      )
+      HmppsDomainEventFactory()
+        .withEventType(MockInboxEventHandler.EVENT_TYPE)
+        .withPersonReference(
+          PersonReference(
+            listOf(
+              PersonIdentifier("CRN", crn),
+            ),
+          ),
+        ).produce()
+
     return buildPendingInboxEventEntity(
       eventType = MockInboxEventHandler.EVENT_TYPE,
       eventOccurredAt = eventOccurredAt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/TierCalculationChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/TierCalculationChangedTest.kt
@@ -76,7 +76,7 @@ class TierCalculationChangedTest : IntegrationTestBase() {
 
     inboxEventDispatcher.process()
 
-    inboxAsserter.assertNotProcessedCount(1)
+    inboxAsserter.assertIgnoredCount(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/TierCalculationChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/TierCalculationChangedTest.kt
@@ -1,0 +1,141 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventDispatcher
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.TierCalculationChangedHandler.Companion.TIER_CALCULATION_EVENT_TYPE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.HmppsDomainEventFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock404TierCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock500TierCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonIdentifier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.PersonReference
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.MissingTopicException
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TierCalculationChangedTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var hmppsQueueService: HmppsQueueService
+
+  @Autowired
+  lateinit var inboxEventDispatcher: InboxEventDispatcher
+
+  @Autowired
+  lateinit var inboxAsserter: InboxAsserter
+
+  private val domainTopic by lazy {
+    hmppsQueueService.findByTopicId("domainevents") ?: throw MissingTopicException("domainevents topic not found")
+  }
+
+  companion object {
+    const val OLD_TIER = "OLD"
+    const val NEW_TIER = "NEW"
+    const val CRN = "CRN123"
+  }
+
+  @Test
+  fun `case exists, update tier, inbox event is PROCESSED`() {
+    caseEntityFactory.produceAndPersist {
+      withCrn(CRN)
+      withTier(OLD_TIER)
+    }
+
+    hmppsTierMockSuccessfulTierCall(
+      CRN,
+      Tier(
+        tierScore = NEW_TIER,
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.now(),
+      ),
+    )
+
+    publishTierEvent(CRN)
+
+    inboxAsserter.waitForPendingCount(1)
+
+    inboxEventDispatcher.process()
+
+    inboxAsserter.assertProcessedCount(1)
+
+    assertThat(caseService.getCase(CRN)!!.tier).isEqualTo(NEW_TIER)
+  }
+
+  @Test
+  fun `case doesnt exist, do nothing, inbox event is SKIPPED`() {
+    publishTierEvent("CRN123")
+
+    inboxAsserter.waitForPendingCount(1)
+
+    inboxEventDispatcher.process()
+
+    inboxAsserter.assertNotProcessedCount(1)
+  }
+
+  @Test
+  fun `case exists, tier not found, alert, inbox event is FAILED`() {
+    caseEntityFactory.produceAndPersist {
+      withCrn(CRN)
+      withTier(OLD_TIER)
+    }
+
+    hmppsTierMock404TierCall(CRN)
+
+    publishTierEvent(CRN)
+
+    inboxAsserter.waitForPendingCount(1)
+
+    inboxEventDispatcher.process()
+
+    inboxAsserter.assertFailedCount(1)
+  }
+
+  @Test
+  fun `case exists, upstream error, FAILED`() {
+    caseEntityFactory.produceAndPersist {
+      withCrn(CRN)
+      withTier(OLD_TIER)
+    }
+
+    hmppsTierMock500TierCall(CRN)
+
+    publishTierEvent(CRN)
+
+    inboxAsserter.waitForPendingCount(1)
+
+    inboxEventDispatcher.process()
+
+    inboxAsserter.assertFailedCount(1)
+  }
+
+  private fun publishTierEvent(crn: String) {
+    val domainEvent = HmppsDomainEventFactory()
+      .withEventType(TIER_CALCULATION_EVENT_TYPE)
+      .withPersonReference(
+        PersonReference(
+          listOf(
+            PersonIdentifier("CRN", crn),
+          ),
+        ),
+      )
+      .produce()
+
+    domainTopic.snsClient.publish(
+      PublishRequest.builder()
+        .topicArn(domainTopic.arn)
+        .message(jsonMapper.writeValueAsString(domainEvent))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(TIER_CALCULATION_EVENT_TYPE).build(),
+          ),
+        ).build(),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
@@ -118,34 +118,7 @@ class InboxEventDispatcherTest {
   }
 
   @Test
-  fun `handler returns FAILED, update event processed state to FAILED and raise alert`() {
-    val event = buildPendingInboxEventEntity(eventType = "test.event")
-
-    every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
-
-    val handler = MockEventHandler(
-      supportedEventType = "test.event",
-      result = InboxEventHandler.Result.FAILED,
-    )
-
-    val stats = inboxEventDispatcher(
-      handlers = listOf(handler),
-      maxEventsPerBatch = 10,
-    ).process()
-
-    handler.assertThatHasProcessedEvent(event)
-
-    assertThat(stats.processedCount).isEqualTo(0)
-    assertThat(stats.ignoredCount).isEqualTo(0)
-    assertThat(stats.skippedCount).isEqualTo(0)
-    assertThat(stats.failedCount).isEqualTo(1)
-
-    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.FAILED) }
-    verify { sentryService.captureErrorMessage("Unexpected error dispatching to handler [inboxEventId=${event.id}, eventType=${event.eventType}]") }
-  }
-
-  @Test
-  fun `handler throws Exception, ,update event processed state to FAILED and raise alert`() {
+  fun `handler throws Exception, update event processed state to FAILED and raise alert`() {
     val event = buildPendingInboxEventEntity(eventType = "test.event")
 
     every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
@@ -155,7 +128,6 @@ class InboxEventDispatcherTest {
     val handler = MockEventHandler(
       supportedEventType = "test.event",
       responseException = exception,
-      result = InboxEventHandler.Result.FAILED,
     )
 
     val stats = inboxEventDispatcher(
@@ -192,7 +164,7 @@ class InboxEventDispatcherTest {
 
   private data class MockEventHandler(
     val supportedEventType: String,
-    val result: InboxEventHandler.Result,
+    val result: InboxEventHandler.Result? = null,
     val responseException: Throwable? = null,
     val processedEvents: MutableList<InboxEventHandler.InboxEvent> = mutableListOf(),
   ) : InboxEventHandler {
@@ -204,7 +176,7 @@ class InboxEventDispatcherTest {
         throw responseException
       }
 
-      return result
+      return result!!
     }
 
     fun assertThatHasProcessedEvent(event: InboxEventEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
@@ -46,7 +46,7 @@ class InboxEventDispatcherTest {
   }
 
   @Test
-  fun `single event, no handler, skip`() {
+  fun `single event, no handler, skip and alert`() {
     val event = buildPendingInboxEventEntity(eventType = "test.event")
 
     every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
@@ -62,6 +62,7 @@ class InboxEventDispatcherTest {
     assertThat(stats.failedCount).isEqualTo(0)
 
     verifyNoEventUpdatesMade()
+    verify { sentryService.captureErrorMessage("No handler registered for event type [inboxEventId=${event.id}, eventType=test.event]") }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/unit/domainevents/listener/InboxEventDispatcherTest.kt
@@ -38,7 +38,7 @@ class InboxEventDispatcherTest {
     ).process()
 
     assertThat(stats.processedCount).isEqualTo(0)
-    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.ignoredCount).isEqualTo(0)
     assertThat(stats.skippedCount).isEqualTo(0)
     assertThat(stats.failedCount).isEqualTo(0)
 
@@ -57,7 +57,7 @@ class InboxEventDispatcherTest {
     ).process()
 
     assertThat(stats.processedCount).isEqualTo(0)
-    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.ignoredCount).isEqualTo(0)
     assertThat(stats.skippedCount).isEqualTo(1)
     assertThat(stats.failedCount).isEqualTo(0)
 
@@ -84,7 +84,7 @@ class InboxEventDispatcherTest {
     handler.assertThatHasProcessedEvent(event)
 
     assertThat(stats.processedCount).isEqualTo(1)
-    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.ignoredCount).isEqualTo(0)
     assertThat(stats.skippedCount).isEqualTo(0)
     assertThat(stats.failedCount).isEqualTo(0)
 
@@ -92,14 +92,14 @@ class InboxEventDispatcherTest {
   }
 
   @Test
-  fun `handler returns NOT PROCESSED, update event processed state to NOT_PROCESSED`() {
+  fun `handler returns IGNORED, update event processed state to IGNORED`() {
     val event = buildPendingInboxEventEntity(eventType = "test.event")
 
     every { inboxEventService.findPendingOldestFirst(10) } returns listOf(event)
 
     val handler = MockEventHandler(
       supportedEventType = "test.event",
-      result = InboxEventHandler.Result.NOT_PROCESSED,
+      result = InboxEventHandler.Result.IGNORED,
     )
 
     val stats = inboxEventDispatcher(
@@ -110,11 +110,11 @@ class InboxEventDispatcherTest {
     handler.assertThatHasProcessedEvent(event)
 
     assertThat(stats.processedCount).isEqualTo(0)
-    assertThat(stats.notProcessedCount).isEqualTo(1)
+    assertThat(stats.ignoredCount).isEqualTo(1)
     assertThat(stats.skippedCount).isEqualTo(0)
     assertThat(stats.failedCount).isEqualTo(0)
 
-    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.NOT_PROCESSED) }
+    verify { inboxEventService.updateInboxEventStatusAndSave(event, ProcessedStatus.IGNORED) }
   }
 
   @Test
@@ -136,7 +136,7 @@ class InboxEventDispatcherTest {
     handler.assertThatHasProcessedEvent(event)
 
     assertThat(stats.processedCount).isEqualTo(0)
-    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.ignoredCount).isEqualTo(0)
     assertThat(stats.skippedCount).isEqualTo(0)
     assertThat(stats.failedCount).isEqualTo(1)
 
@@ -166,7 +166,7 @@ class InboxEventDispatcherTest {
     handler.assertThatHasProcessedEvent(event)
 
     assertThat(stats.processedCount).isEqualTo(0)
-    assertThat(stats.notProcessedCount).isEqualTo(0)
+    assertThat(stats.ignoredCount).isEqualTo(0)
     assertThat(stats.skippedCount).isEqualTo(0)
     assertThat(stats.failedCount).isEqualTo(1)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -123,6 +123,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Sta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppsauth.GetTokenResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.InboxEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.InboxEventEntity
@@ -151,6 +152,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DateChangeEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
@@ -732,6 +734,8 @@ abstract class IntegrationTestBase {
   lateinit var placementRequestEntityFactory: PersistedFactory<PlacementRequestEntity, UUID, PlacementRequestEntityFactory>
   lateinit var cas1PremisesLocalRestrictionEntityFactory: PersistedFactory<Cas1PremisesLocalRestrictionEntity, UUID, Cas1PremisesLocalRestrictionEntityFactory>
   lateinit var inboxEventEntityFactory: PersistedFactory<InboxEventEntity, UUID, InboxEventEntityFactory>
+  lateinit var caseEntityFactory: PersistedFactory<CaseEntity, UUID, CaseEntityFactory>
+
   private var clientCredentialsCallMocked = false
 
   @BeforeEach
@@ -856,6 +860,7 @@ abstract class IntegrationTestBase {
     cas1ChangeRequestEntityFactory = PersistedFactory({ Cas1ChangeRequestEntityFactory() }, cas1ChangeRequestRepository)
     cas1PremisesLocalRestrictionEntityFactory = PersistedFactory({ Cas1PremisesLocalRestrictionEntityFactory() }, cas1PremisesLocalRestrictionRepository)
     inboxEventEntityFactory = PersistedFactory({ InboxEventEntityFactory() }, inboxEventRepository)
+    caseEntityFactory = PersistedFactory({ CaseEntityFactory() }, caseRepository)
   }
 
   fun mockClientCredentialsJwtRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/HMPPSTier.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/HMPPSTier.kt
@@ -7,3 +7,15 @@ fun IntegrationTestBase.hmppsTierMockSuccessfulTierCall(crn: String, response: T
   url = "/crn/$crn/tier",
   responseBody = response,
 )
+
+fun IntegrationTestBase.hmppsTierMock404TierCall(crn: String) = mockSuccessfulGetCallWithJsonResponse(
+  url = "/crn/$crn/tier",
+  responseStatus = 404,
+  responseBody = "",
+)
+
+fun IntegrationTestBase.hmppsTierMock500TierCall(crn: String) = mockSuccessfulGetCallWithJsonResponse(
+  url = "/crn/$crn/tier",
+  responseStatus = 500,
+  responseBody = "",
+)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -78,6 +78,11 @@ hmpps.sqs:
     domainevents:
       arn: "dynamically set per test"
   queues:
+    cas-domain-events-listener-queue:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
+      subscribeTopicId: domainevents
+      subscribeFilter: '{"eventType":["tier.calculation.changed"]}'
     castwodomaineventslistenerqueue:
       dlqName: ${random.uuid}
       queueName: ${random.uuid}


### PR DESCRIPTION
This PR introduces a domain event listener for the `tier.calculation.changed` domain event, updating the `cases.tier` value where we have a corresponding record for the CRN

Any failures retreiving an updatng the tier are propagated back to the domain event dispatcher as an exception, which will be alerted. Under normal operation this should never happen because:

a) the CRN should exist because we just received a domain event about it
b) we’re only updating CRNs we’re interested in, so there shouldn’t any database issues

The most likely cause of this error is failure to retrieve the tier from the API due to a temporary issue. In this case replay tooling will be required, which will be added by a subsequent commit (e.g. replay failed domain events)

Some additional tweaks were made to the inbox event dispatcher:

* Rename processing status `NOT_PROCESSED` to `IGNORED`. This provides clarity on what this status means.
* Remove event handler response status `FAILED`, favouring use of exceptions to report failures