### PR TITLE
FM-760 Add CAS2 status update email

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationStatusUpdateEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationStatusUpdateEmailService.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormat
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHourOfDay
+import java.time.format.DateTimeFormatter
+
+@Service
+class Cas2ApplicationStatusUpdateEmailService(
+  private val cas2EmailService: Cas2EmailService,
+  @Value("\${url-templates.frontend.cas2v2.application-overview}") private val applicationOverviewUrlTemplate: UrlTemplate,
+) {
+
+  fun statusUpdate(cas2Application: Cas2ApplicationEntity, status: Cas2StatusUpdateEntity) {
+    val recipientEmailAddress = cas2Application.createdByUser.email ?: return
+    val submittedAt = requireNotNull(cas2Application.submittedAt) ?: return
+    val cohort = requireNotNull(cas2Application.cohort)
+    val timeReceived = submittedAt.format(DateTimeFormatter.ofPattern("HH:mm"))
+    val dateReceived = submittedAt.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+
+    val personalisation = mapOf(
+      "applicationStatusChange" to status.label,
+      "dateStatusChanged" to status.createdAt.toLocalDate().toCas2UiFormat(),
+      "timeStatusChanged" to status.createdAt.toCas2UiFormattedHourOfDay(),
+      "cohort" to cohort.displayName,
+      "crn" to cas2Application.crn,
+      "timeApplicationReceived" to timeReceived,
+      "dateApplicationReceived" to dateReceived,
+      "nacroReferenceId" to cas2Application.id.toString(),
+      "viewSubmittedApplicationUrl" to applicationOverviewUrlTemplate
+        .resolve("applicationId", cas2Application.id.toString()),
+    )
+
+    cas2EmailService.sendEmail(
+      recipientEmailAddress = recipientEmailAddress,
+      templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_STATUS_UPDATE,
+      personalisation = personalisation,
+      cas2Application = cas2Application,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.Validatio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.DomainEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHourOfDay
 import java.time.OffsetDateTime
@@ -44,6 +45,8 @@ class Cas2StatusUpdateService(
   private val emailNotificationService: EmailNotificationService,
   private val cas2PersistedApplicationStatusFinder: Cas2PersistedApplicationStatusFinder,
   private val statusTransformer: Cas2HdcApplicationStatusTransformer,
+  private val cas2ApplicationStatusUpdateEmailService: Cas2ApplicationStatusUpdateEmailService,
+  private val featureFlagService: FeatureFlagService,
   @Value("\${url-templates.frontend.cas2v2.application}") private val applicationUrlTemplate: String,
   @Value("\${url-templates.frontend.cas2v2.application-overview}") private val applicationOverviewUrlTemplate: String,
 ) {
@@ -67,7 +70,7 @@ class Cas2StatusUpdateService(
     val statusDetails = if (newDetails) {
       emptyList()
     } else {
-      statusUpdate.newStatusDetails?.map { detail ->
+      statusUpdate.newStatusDetails.map { detail ->
         status.findStatusDetailOnStatus(detail)
           ?: return CasResult.GeneralValidationError("The status detail $detail is not valid")
       }
@@ -90,7 +93,7 @@ class Cas2StatusUpdateService(
       ),
     )
 
-    statusDetails?.forEach { detail ->
+    statusDetails.forEach { detail ->
       cas2StatusUpdateDetailRepository.save(
         Cas2StatusUpdateDetailEntity(
           id = UUID.randomUUID(),
@@ -101,7 +104,11 @@ class Cas2StatusUpdateService(
       )
     }
 
-    sendEmailStatusUpdated(assessment.application.createdByUser, assessment.application, createdStatusUpdate)
+    if (featureFlagService.getBooleanFlag("isr-email-changes-enabled")) {
+      cas2ApplicationStatusUpdateEmailService.statusUpdate(assessment.application, createdStatusUpdate)
+    } else {
+      sendEmailStatusUpdated(assessment.application.createdByUser, assessment.application, createdStatusUpdate)
+    }
 
     createStatusUpdatedDomainEvent(createdStatusUpdate, statusDetails)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/NotifyConfig.kt
@@ -80,6 +80,7 @@ object Cas2NotifyTemplates {
 
   const val CAS2_BAIL_APPLICATION_SUBMITTED = "5fc14c45-8efa-49e1-81b9-e7fec0d22a0c"
   const val CAS2_BAIL_APPLICATION_TO_ASSESS = "cd4b3c2b-6ab4-47ca-a134-df55846d02fa"
+  const val CAS2_BAIL_APPLICATION_STATUS_UPDATE = "7f5f44f8-d3ff-4934-a558-c5d50bf0e010"
 }
 
 enum class NotifyMode {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2StatusUpdateTest.kt
@@ -17,14 +17,17 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcAssessmentStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_STATUS_UPDATE
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2Assessor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHourOfDay
 import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class Cas2v2StatusUpdateTest(
@@ -91,6 +94,7 @@ class Cas2v2StatusUpdateTest(
             withSubmittedAt(OffsetDateTime.now())
             withApplicationOrigin(ApplicationOrigin.courtBail)
             withServiceOrigin(Cas2ServiceOrigin.BAIL)
+            withCohort(Cas2Cohort.COURT_BAIL)
           }
 
           cas2AssessmentEntityFactory.produceAndPersist {
@@ -189,6 +193,7 @@ class Cas2v2StatusUpdateTest(
       fun `Create cas2v2 status update returns 201 and creates StatusUpdate when given status and detail are valid, and sends an email to the referrer`() {
         val assessmentId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
         val submittedAt = OffsetDateTime.now()
+        mockFeatureFlagService.setFlag("isr-email-changes-enabled", false)
 
         try {
           givenACas2v2Assessor { _, jwt ->
@@ -276,6 +281,94 @@ class Cas2v2StatusUpdateTest(
               // verify that the persisted domain event contains the expected status details
               val expected = listOf(Cas2StatusDetail("changeOfCircumstances", "Change of circumstances"))
               assertThat(domainEventFromJson.eventDetails.newStatus.statusDetails).isEqualTo(expected)
+            }
+          }
+        } finally {
+          unmockkAll()
+        }
+      }
+
+      @Test
+      fun `Create cas2v2 status update returns 201 and sends the new email when the flag is true`() {
+        val assessmentId = UUID.fromString("22ceda56-98b2-411d-91cc-ace0ab8be872")
+        val submittedAt = OffsetDateTime.now()
+        mockFeatureFlagService.setFlag("isr-email-changes-enabled", true)
+
+        try {
+          givenACas2v2Assessor { _, jwt ->
+            givenACas2v2PomUser { applicant, _ ->
+              val application = cas2ApplicationEntityFactory.produceAndPersist {
+                withCreatedByUser(applicant)
+                withSubmittedAt(submittedAt)
+                withNomsNumber("123NOMS")
+                withServiceOrigin(Cas2ServiceOrigin.BAIL)
+                withCohort(Cas2Cohort.COURT_BAIL)
+              }
+
+              cas2AssessmentEntityFactory.produceAndPersist {
+                withId(assessmentId)
+                withApplication(application)
+                withServiceOrigin(Cas2ServiceOrigin.BAIL)
+              }
+
+              assertThat(realCas2StatusUpdateRepository.count()).isEqualTo(0)
+
+              val now = OffsetDateTime.now()
+              mockkStatic(OffsetDateTime::class)
+              every { OffsetDateTime.now() } returns now
+
+              webTestClient.post()
+                .uri("/cas2/assessments/$assessmentId/status-updates")
+                .header("Authorization", "Bearer $jwt")
+                .bodyValue(
+                  Cas2HdcAssessmentStatusUpdate(
+                    newStatus = "offerDeclined",
+                    newStatusDetails = listOf("changeOfCircumstances"),
+                  ),
+                )
+                .exchange()
+                .expectStatus()
+                .isCreated
+
+              assertThat(realCas2StatusUpdateRepository.count()).isEqualTo(1)
+              assertThat(realCas2StatusUpdateDetailRepository.count()).isEqualTo(1)
+
+              val persistedStatusUpdate =
+                realCas2StatusUpdateRepository.findFirstByApplicationIdOrderByCreatedAtDesc(application.id)
+              assertThat(persistedStatusUpdate!!.assessment!!.id).isEqualTo(assessmentId)
+
+              val persistedStatusDetailUpdate =
+                realCas2StatusUpdateDetailRepository.findFirstByStatusUpdateIdOrderByCreatedAtDesc(persistedStatusUpdate.id)
+              assertThat(persistedStatusDetailUpdate).isNotNull
+
+              val appliedStatus = Cas2ApplicationStatusSeeding.statusList(ServiceName.cas2)
+                .find { status ->
+                  status.id == persistedStatusUpdate.statusId
+                }
+
+              assertThat(appliedStatus!!.name).isEqualTo("offerDeclined")
+              assertThat(appliedStatus.statusDetails?.find { detail -> detail.id == persistedStatusDetailUpdate?.statusDetailId })
+                .isNotNull()
+
+              emailAsserter.assertEmailsRequestedCount(1)
+
+              emailAsserter.assertEmailRequested(
+                toEmailAddress = applicant.email!!,
+                templateId = CAS2_BAIL_APPLICATION_STATUS_UPDATE,
+                personalisation = mapOf(
+                  "applicationStatusChange" to "Offer declined or withdrawn",
+                  "dateStatusChanged" to now.toLocalDate().toCas2UiFormat(),
+                  "timeStatusChanged" to now.toCas2UiFormattedHourOfDay(),
+                  "cohort" to application.cohort!!.displayName,
+                  "crn" to application.crn,
+                  "timeApplicationReceived" to application.submittedAt!!.format(DateTimeFormatter.ofPattern("HH:mm")),
+                  "dateApplicationReceived" to application.submittedAt!!.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                  "nacroReferenceId" to application.id.toString(),
+                  "viewSubmittedApplicationUrl" to applicationOverviewUrlTemplate
+                    .replace("applicationId", application.id.toString()),
+                ),
+                replyToEmailId = notifyConfig.emailAddresses.cas2ReplyToId,
+              )
             }
           }
         } finally {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationStatusUpdateEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationStatusUpdateEmailServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.unit.service
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationStatusUpdateEmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2EmailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2StatusUpdateEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2Cohort
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2ApplicationStatusUpdateEmailServiceTest {
+  private val mockCas2EmailService = mockk<Cas2EmailService>(relaxed = true)
+  private val applicationOverviewUrlTemplate = UrlTemplate("http://frontend/applications/#applicationId")
+
+  private val service = Cas2ApplicationStatusUpdateEmailService(
+    cas2EmailService = mockCas2EmailService,
+    applicationOverviewUrlTemplate = applicationOverviewUrlTemplate,
+  )
+
+  private val user = Cas2UserEntityFactory()
+    .withEmail("test@example.com")
+    .produce()
+
+  @Test
+  fun `statusUpdate sends email with correct personalisation`() {
+    val applicationId = UUID.randomUUID()
+    val submittedAt = OffsetDateTime.parse("2024-06-24T16:07:00Z")
+    val statusCreatedAt = OffsetDateTime.parse("2024-06-25T10:30:00Z")
+
+    val application = Cas2ApplicationEntityFactory()
+      .withId(applicationId)
+      .withCreatedByUser(user)
+      .withSubmittedAt(submittedAt)
+      .withCrn("CRN123")
+      .withCohort(Cas2Cohort.PRISON_BAIL)
+      .produce()
+
+    val status = Cas2StatusUpdateEntityFactory()
+      .withApplication(application)
+      .withAssessor(user)
+      .withLabel("More information requested")
+      .withCreatedAt(statusCreatedAt)
+      .produce()
+
+    service.statusUpdate(application, status)
+
+    verify(exactly = 1) {
+      mockCas2EmailService.sendEmail(
+        recipientEmailAddress = user.email!!,
+        templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_STATUS_UPDATE,
+        personalisation = mapOf(
+          "applicationStatusChange" to "More information requested",
+          "dateStatusChanged" to "25 June 2024",
+          "timeStatusChanged" to "10:30am",
+          "cohort" to "Prison Bail",
+          "crn" to "CRN123",
+          "timeApplicationReceived" to "16:07",
+          "dateApplicationReceived" to "24/06/2024",
+          "nacroReferenceId" to applicationId.toString(),
+          "viewSubmittedApplicationUrl" to "http://frontend/applications/$applicationId",
+        ),
+        cas2Application = application,
+      )
+    }
+  }
+
+  @Test
+  fun `statusUpdate does not send email if user has no email address`() {
+    val userNoEmail = Cas2UserEntityFactory()
+      .withEmail(null)
+      .produce()
+
+    val application = Cas2ApplicationEntityFactory()
+      .withCreatedByUser(userNoEmail)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    val status = Cas2StatusUpdateEntityFactory()
+      .withApplication(application)
+      .withAssessor(user)
+      .produce()
+
+    service.statusUpdate(application, status)
+
+    verify(exactly = 0) {
+      mockCas2EmailService.sendEmail(any(), any(), any(), any())
+    }
+  }
+
+  @Test
+  fun `statusUpdate does not send email if application is not submitted`() {
+    val application = Cas2ApplicationEntityFactory()
+      .withCreatedByUser(user)
+      .withSubmittedAt(null)
+      .produce()
+
+    val status = Cas2StatusUpdateEntityFactory()
+      .withApplication(application)
+      .withAssessor(user)
+      .produce()
+
+    assertThatThrownBy {
+      service.statusUpdate(application, status)
+    }.isInstanceOf(IllegalArgumentException::class.java)
+
+    verify(exactly = 0) {
+      mockCas2EmailService.sendEmail(any(), any(), any(), any())
+    }
+  }
+}


### PR DESCRIPTION
Added a new email template for CAS2 application status updates.

Update the service to send emails using the new template.