### PR TITLE
FM-793 Add CAS 2 get current user endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.controller
 
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2UserDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 
 @Cas2Controller
 class Cas2UsersController(
@@ -19,4 +21,7 @@ class Cas2UsersController(
     // endpoint that explicitly returns information for the current user
     cas2UserService.getUserForRequest(),
   )
+
+  @GetMapping("/users/me")
+  fun getCurrentUserDetails(): ResponseEntity<Cas2UserDto> = ResponseEntity.ok(extractEntityFromCasResult(cas2UserService.getUserDtoForRequest()))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/controller/Cas2UsersController.kt
@@ -16,6 +16,7 @@ class Cas2UsersController(
 
   @SuppressWarnings("UnusedParameter")
   @GetMapping("/users/{userName}")
+  @Deprecated("This endpoint is deprecated and will be removed in a future release. Use /users/me instead.")
   fun getUserDetails(@PathVariable userName: String): Cas2UserDto = cas2HdcUserService.getUserDetails(
     // This is a quick fix to unblock an issue in production. It will be replaced by an
     // endpoint that explicitly returns information for the current user

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
@@ -3,7 +3,11 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2DeliusUserInfoDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2UserDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2UserTypeDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.ProbationAreaDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
@@ -13,6 +17,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ManageUsersApiCli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.NomisUserRolesForRequesterApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.StaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.nomisuserroles.NomisUserDetail
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.toCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import java.util.UUID
 
@@ -37,6 +43,37 @@ class Cas2UserService(
     return getUserForUsername(username, jwt, userType)
   }
 
+  fun getUserDtoForRequest(): CasResult<Cas2UserDto> {
+    val user = getUserForRequest()
+
+    val deliusUserInfo =
+      if (user.userType == Cas2UserType.DELIUS) {
+        val deliusUser = when (val deliusUserResult = getDeliusUser(user.username)) {
+          is CasResult.Success -> deliusUserResult.value
+          is CasResult.Error -> return deliusUserResult.reviseType()
+        }
+
+        Cas2DeliusUserInfoDto(
+          probationArea = ProbationAreaDto(
+            code = deliusUser.probationArea.code,
+            description = deliusUser.probationArea.description,
+          ),
+        )
+      } else {
+        null
+      }
+
+    return CasResult.Success(
+      Cas2UserDto(
+        username = user.username,
+        type = Cas2UserTypeDto.valueOf(user.userType.name),
+        deliusUserInfo = deliusUserInfo,
+      ),
+    )
+  }
+
+  private fun getDeliusUser(username: String): CasResult<StaffDetail> = apDeliusContextApiClient.getStaffDetail(username).toCasResult(entityType = "DeliusUser", id = username)
+
   private fun getUserForUsername(username: String, jwt: String, userType: Cas2UserType): Cas2UserEntity {
     val normalisedUsername = username.uppercase()
 
@@ -58,7 +95,7 @@ class Cas2UserService(
 
   fun userForRequestHasRole(grantedAuthorities: List<GrantedAuthority>): Boolean {
     val roles = getRolesForUserForRequest()
-    return roles?.any { it in grantedAuthorities } ?: false
+    return roles.any { it in grantedAuthorities }
   }
 
   private fun getRolesForUserForRequest(): MutableCollection<GrantedAuthority> = httpAuthService.getCas2v2AuthenticatedPrincipalOrThrow().authorities

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2UserService.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.NomisUserRolesFor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.StaffDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.nomisuserroles.NomisUserDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.toCasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import java.util.UUID
 
@@ -34,56 +33,41 @@ class Cas2UserService(
     getUserForRequest()
   }
 
-  fun getUserForRequest(): Cas2UserEntity {
+  fun getUserForRequest(): Cas2UserEntity = getTypedUserForRequest().userEntity
+
+  fun getUserDtoForRequest(): CasResult<Cas2UserDto> {
+    val typedUser = getTypedUserForRequest()
+
+    return CasResult.Success(
+      Cas2UserDto(
+        username = typedUser.userEntity.username,
+        type = Cas2UserTypeDto.valueOf(typedUser.userEntity.userType.name),
+        deliusUserInfo = when (typedUser) {
+          is Cas2TypedUser.Delius -> Cas2DeliusUserInfoDto(
+            ProbationAreaDto(
+              typedUser.deliusUser.probationArea.code,
+              typedUser.deliusUser.probationArea.description,
+            ),
+          )
+          else -> null
+        },
+      ),
+    )
+  }
+
+  private fun getTypedUserForRequest(): Cas2TypedUser {
     val authenticatedPrincipal = httpAuthService.getCas2v2AuthenticatedPrincipalOrThrow()
     val jwt = authenticatedPrincipal.token.tokenValue
     val username = authenticatedPrincipal.name
     val userType = Cas2UserType.fromString(authenticatedPrincipal.authenticationSource())
 
-    return getUserForUsername(username, jwt, userType)
-  }
-
-  fun getUserDtoForRequest(): CasResult<Cas2UserDto> {
-    val user = getUserForRequest()
-
-    val deliusUserInfo =
-      if (user.userType == Cas2UserType.DELIUS) {
-        val deliusUser = when (val deliusUserResult = getDeliusUser(user.username)) {
-          is CasResult.Success -> deliusUserResult.value
-          is CasResult.Error -> return deliusUserResult.reviseType()
-        }
-
-        Cas2DeliusUserInfoDto(
-          probationArea = ProbationAreaDto(
-            code = deliusUser.probationArea.code,
-            description = deliusUser.probationArea.description,
-          ),
-        )
-      } else {
-        null
-      }
-
-    return CasResult.Success(
-      Cas2UserDto(
-        username = user.username,
-        type = Cas2UserTypeDto.valueOf(user.userType.name),
-        deliusUserInfo = deliusUserInfo,
-      ),
-    )
-  }
-
-  private fun getDeliusUser(username: String): CasResult<StaffDetail> = apDeliusContextApiClient.getStaffDetail(username).toCasResult(entityType = "DeliusUser", id = username)
-
-  private fun getUserForUsername(username: String, jwt: String, userType: Cas2UserType): Cas2UserEntity {
     val normalisedUsername = username.uppercase()
 
-    val userEntity = when (userType) {
+    return when (userType) {
       Cas2UserType.NOMIS -> getEntityForNomisUser(normalisedUsername, jwt)
       Cas2UserType.DELIUS -> getEntityForDeliusUser(normalisedUsername)
       Cas2UserType.EXTERNAL -> getEntityForExternalUser(normalisedUsername, jwt)
     }
-
-    return userEntity
   }
 
   fun requiresCaseLoadIdCheck(): Boolean = !userForRequestHasRole(
@@ -102,7 +86,7 @@ class Cas2UserService(
 
   private fun getExistingUser(username: String, userType: Cas2UserType): Cas2UserEntity? = cas2UserRepository.findByUsernameAndUserTypeAndServiceOrigin(username, userType, Cas2ServiceOrigin.BAIL)
 
-  private fun getEntityForNomisUser(username: String, jwt: String): Cas2UserEntity {
+  private fun getEntityForNomisUser(username: String, jwt: String): Cas2TypedUser.Nomis {
     val nomisUserDetails: NomisUserDetail = when (
       val nomisUserDetailResponse = nomisUserRolesApiClient.getUserDetailsForMe(jwt)
     ) {
@@ -116,10 +100,10 @@ class Cas2UserService(
         existingUser.email = nomisUserDetails.primaryEmail
         existingUser.activeNomisCaseloadId = nomisUserDetails.activeCaseloadId
 
-        return cas2UserRepository.save(existingUser)
+        return Cas2TypedUser.Nomis(cas2UserRepository.save(existingUser))
       }
 
-      return existingUser
+      return Cas2TypedUser.Nomis(existingUser)
     }
 
     cas2UserRepository.createCas2User(
@@ -139,10 +123,10 @@ class Cas2UserService(
         nomisAccountType = nomisUserDetails.accountType,
       ),
     )
-    return getExistingUser(username, Cas2UserType.NOMIS)!!
+    return Cas2TypedUser.Nomis(getExistingUser(username, Cas2UserType.NOMIS)!!)
   }
 
-  private fun getEntityForDeliusUser(username: String): Cas2UserEntity {
+  private fun getEntityForDeliusUser(username: String): Cas2TypedUser.Delius {
     val deliusUser: StaffDetail =
       when (val staffUserDetailsResponse = apDeliusContextApiClient.getStaffDetail(username)) {
         is ClientResult.Success<*> -> staffUserDetailsResponse.body as StaffDetail
@@ -155,10 +139,10 @@ class Cas2UserService(
       if (deliusUser.email != existingUser.email || teamsDiffer) {
         existingUser.email = deliusUser.email
         existingUser.deliusTeamCodes = deliusUser.teamCodes()
-        return cas2UserRepository.save(existingUser)
+        return Cas2TypedUser.Delius(cas2UserRepository.save(existingUser), deliusUser)
       }
 
-      return existingUser
+      return Cas2TypedUser.Delius(existingUser, deliusUser)
     }
 
     cas2UserRepository.createCas2User(
@@ -177,12 +161,12 @@ class Cas2UserService(
         serviceOrigin = Cas2ServiceOrigin.BAIL,
       ),
     )
-    return getExistingUser(username, Cas2UserType.DELIUS)!!
+    return Cas2TypedUser.Delius(getExistingUser(username, Cas2UserType.DELIUS)!!, deliusUser)
   }
 
-  private fun getEntityForExternalUser(username: String, jwt: String): Cas2UserEntity {
+  private fun getEntityForExternalUser(username: String, jwt: String): Cas2TypedUser.External {
     val existingUser = getExistingUser(username, Cas2UserType.EXTERNAL)
-    if (existingUser != null) return existingUser
+    if (existingUser != null) return Cas2TypedUser.External(existingUser)
 
     val externalUserDetailsResponse = manageUsersApiClient.getExternalUserDetails(username, jwt)
 
@@ -208,6 +192,14 @@ class Cas2UserService(
         externalType = "NACRO",
       ),
     )
-    return getExistingUser(username, Cas2UserType.EXTERNAL)!!
+    return Cas2TypedUser.External(getExistingUser(username, Cas2UserType.EXTERNAL)!!)
   }
+}
+
+private sealed interface Cas2TypedUser {
+  val userEntity: Cas2UserEntity
+
+  data class Nomis(override val userEntity: Cas2UserEntity) : Cas2TypedUser
+  data class Delius(override val userEntity: Cas2UserEntity, val deliusUser: StaffDetail) : Cas2TypedUser
+  data class External(override val userEntity: Cas2UserEntity) : Cas2TypedUser
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcUserService.kt
@@ -54,6 +54,7 @@ class Cas2HdcUserService(
     return findOrCreateNomisUser(username = normalisedUsername, userDetail, serviceOrigin)
   }
 
+  @Deprecated("This endpoint is deprecated and will be removed in a future release. Use Cas2UserService.getUserDtoForRequest() instead.")
   fun getUserDetails(user: Cas2UserEntity): Cas2UserDto {
     val deliusUserInfo =
       if (user.userType == Cas2UserType.DELIUS) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
@@ -49,54 +49,53 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
         assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
       }
     }
-  }
+    @Test
+    fun `Getting a user returns region information for the logged in Nomis user does not include region information`() {
+      givenACas2v2NomisUser { userEntity, jwt ->
+        val response = webTestClient.get()
+          .uri("/cas2/users/DOESNTMATTER")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody<Cas2UserDto>()
+          .returnResult()
+          .responseBody
 
-  @Test
-  fun `Getting a user returns region information for the logged in Nomis user does not include region information`() {
-    givenACas2v2NomisUser { userEntity, jwt ->
-      val response = webTestClient.get()
-        .uri("/cas2/users/DOESNTMATTER")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectBody<Cas2UserDto>()
-        .returnResult()
-        .responseBody
-
-      assertThat(response).isNotNull
-      assertThat(response?.username).isEqualTo(userEntity.username)
-      assertThat(response?.type).isEqualTo(Cas2UserTypeDto.NOMIS)
-      assertThat(response?.deliusUserInfo).isNull()
+        assertThat(response).isNotNull
+        assertThat(response?.username).isEqualTo(userEntity.username)
+        assertThat(response?.type).isEqualTo(Cas2UserTypeDto.NOMIS)
+        assertThat(response?.deliusUserInfo).isNull()
+      }
     }
-  }
 
-  @Test
-  fun `Does not fail if there are multiple users with the same username`() {
-    val nomisUser = givenACas2v2NomisUser()
+    @Test
+    fun `Does not fail if there are multiple users with the same username`() {
+      val nomisUser = givenACas2v2NomisUser()
 
-    val staffDetail = StaffDetailFactory.staffDetail(
-      deliusUsername = nomisUser.username,
-    )
+      val staffDetail = StaffDetailFactory.staffDetail(
+        deliusUsername = nomisUser.username,
+      )
 
-    givenACas2v2DeliusUser(
-      staffDetail = staffDetail,
-    ) { userEntity, jwt ->
-      val response = webTestClient.get()
-        .uri("/cas2/users/DOESNTMATTER")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isOk
-        .expectBody<Cas2UserDto>()
-        .returnResult()
-        .responseBody
+      givenACas2v2DeliusUser(
+        staffDetail = staffDetail,
+      ) { userEntity, jwt ->
+        val response = webTestClient.get()
+          .uri("/cas2/users/DOESNTMATTER")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody<Cas2UserDto>()
+          .returnResult()
+          .responseBody
 
-      assertThat(response).isNotNull
-      assertThat(response?.username).isEqualTo(userEntity.username)
-      assertThat(response?.type).isEqualTo(Cas2UserTypeDto.DELIUS)
-      assertThat(response?.deliusUserInfo!!.probationArea.code).isEqualTo(staffDetail.probationArea.code)
-      assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
+        assertThat(response).isNotNull
+        assertThat(response?.username).isEqualTo(userEntity.username)
+        assertThat(response?.type).isEqualTo(Cas2UserTypeDto.DELIUS)
+        assertThat(response?.deliusUserInfo!!.probationArea.code).isEqualTo(staffDetail.probationArea.code)
+        assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
@@ -51,7 +51,7 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
-    fun `Getting a user returns region information for the logged in Nomis user does not include region information`() {
+    fun `Getting a user as a Nomis user does not include deliusUserInfo`() {
       givenACas2v2NomisUser { userEntity, jwt ->
         val response = webTestClient.get()
           .uri("/cas2/users/DOESNTMATTER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2UsersTest.kt
@@ -49,6 +49,7 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
         assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
       }
     }
+
     @Test
     fun `Getting a user returns region information for the logged in Nomis user does not include region information`() {
       givenACas2v2NomisUser { userEntity, jwt ->
@@ -95,6 +96,63 @@ class Cas2v2UsersTest : InitialiseDatabasePerClassTestBase() {
         assertThat(response?.type).isEqualTo(Cas2UserTypeDto.DELIUS)
         assertThat(response?.deliusUserInfo!!.probationArea.code).isEqualTo(staffDetail.probationArea.code)
         assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
+      }
+    }
+  }
+
+  @Nested
+  inner class GetCurrentUserDetailsTest {
+    @Test
+    fun `Getting the current user without a JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas2/users/me")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Returns user details (including region) when user is a Delius user`() {
+      val staffDetail = StaffDetailFactory.staffDetail()
+
+      givenACas2v2DeliusUser(
+        staffDetail = staffDetail,
+      ) { userEntity, jwt ->
+        val response = webTestClient.get()
+          .uri("/cas2/users/me")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody<Cas2UserDto>()
+          .returnResult()
+          .responseBody
+
+        assertThat(response).isNotNull
+        assertThat(response?.username).isEqualTo(userEntity.username)
+        assertThat(response?.type).isEqualTo(Cas2UserTypeDto.DELIUS)
+        assertThat(response?.deliusUserInfo!!.probationArea.code).isEqualTo(staffDetail.probationArea.code)
+        assertThat(response.deliusUserInfo.probationArea.description).isEqualTo(staffDetail.probationArea.description)
+      }
+    }
+
+    @Test
+    fun `Returns user details (excluding region) when user is a Nomis user`() {
+      givenACas2v2NomisUser { userEntity, jwt ->
+        val response = webTestClient.get()
+          .uri("/cas2/users/me")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody<Cas2UserDto>()
+          .returnResult()
+          .responseBody
+
+        assertThat(response).isNotNull
+        assertThat(response?.username).isEqualTo(userEntity.username)
+        assertThat(response?.type).isEqualTo(Cas2UserTypeDto.NOMIS)
+        assertThat(response?.deliusUserInfo).isNull()
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2UserServiceTest.kt
@@ -107,7 +107,7 @@ class Cas2UserServiceTest {
     @Test
     fun `returns error when Nomis user look up fails`() {
       val username = "NOMISUSER"
-      val nomisUser = Cas2UserEntityFactory()
+      Cas2UserEntityFactory()
         .withUsername(username)
         .withUserType(Cas2UserType.NOMIS)
         .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2UserServiceTest.kt
@@ -1,0 +1,159 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.unit.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2UserTypeDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ManageUsersApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.NomisUserRolesForRequesterApiClient
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.ProbationArea
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.AuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+class Cas2UserServiceTest {
+  private val mockHttpAuthService = mockk<HttpAuthService>()
+  private val mockCas2UserRepository = mockk<Cas2UserRepository>()
+  private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
+  private val mockNomisUserRolesForRequesterApiClient = mockk<NomisUserRolesForRequesterApiClient>()
+  private val mockManageUsersApiClient = mockk<ManageUsersApiClient>()
+  private val cas2UserService = Cas2UserService(
+    mockHttpAuthService,
+    mockCas2UserRepository,
+    mockApDeliusContextApiClient,
+    mockNomisUserRolesForRequesterApiClient,
+    mockManageUsersApiClient,
+  )
+
+  @Nested
+  inner class GetCurrentUserTest {
+    @Test
+    fun `returns error when Delius user look up fails`() {
+      val username = "DELIUSUSER"
+      val deliusUser = Cas2UserEntityFactory()
+        .withUsername(username)
+        .withUserType(Cas2UserType.DELIUS)
+        .produce()
+
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+      every { mockHttpAuthService.getCas2v2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+      every { mockPrincipal.token.tokenValue } returns "abc123"
+      every { mockPrincipal.authenticationSource() } returns "delius"
+      every { mockPrincipal.name } returns username
+      every {
+        mockCas2UserRepository.findByUsernameAndUserTypeAndServiceOrigin(username, Cas2UserType.DELIUS, deliusUser.serviceOrigin)
+      } returns deliusUser
+
+      every { mockApDeliusContextApiClient.getStaffDetail(username) } returns ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/staff/username/$username",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+
+      assertThrows<RuntimeException> { cas2UserService.getUserDtoForRequest() }
+    }
+
+    @Test
+    fun `returns success when user is Delius user`() {
+      val username = "DELIUSUSER"
+      val deliusUser = Cas2UserEntityFactory()
+        .withUsername(username)
+        .withUserType(Cas2UserType.DELIUS)
+        .withServiceOrigin(Cas2ServiceOrigin.BAIL)
+        .produce()
+      val staffDetail = StaffDetailFactory.staffDetail(
+        probationArea = ProbationArea(
+          code = "PA01",
+          description = "probation area description",
+        ),
+      )
+
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+      every { mockHttpAuthService.getCas2v2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+      every { mockPrincipal.token.tokenValue } returns "abc123"
+      every { mockPrincipal.authenticationSource() } returns "delius"
+      every { mockPrincipal.name } returns username
+      every { mockApDeliusContextApiClient.getStaffDetail(username) } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = staffDetail,
+      )
+      every {
+        mockCas2UserRepository.findByUsernameAndUserTypeAndServiceOrigin(username, Cas2UserType.DELIUS, deliusUser.serviceOrigin)
+      } returns deliusUser
+      every { mockCas2UserRepository.save(any()) } returns deliusUser
+
+      val userDto = extractEntityFromCasResult(cas2UserService.getUserDtoForRequest())
+      assertThat(userDto.username).isEqualTo("DELIUSUSER")
+      assertThat(userDto.type).isEqualTo(Cas2UserTypeDto.DELIUS)
+      assertThat(userDto.deliusUserInfo!!.probationArea.code).isEqualTo("PA01")
+      assertThat(userDto.deliusUserInfo.probationArea.description).isEqualTo("probation area description")
+    }
+
+    @Test
+    fun `returns error when Nomis user look up fails`() {
+      val username = "NOMISUSER"
+      val nomisUser = Cas2UserEntityFactory()
+        .withUsername(username)
+        .withUserType(Cas2UserType.NOMIS)
+        .produce()
+
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+      every { mockHttpAuthService.getCas2v2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+      every { mockPrincipal.token.tokenValue } returns "abc123"
+      every { mockPrincipal.authenticationSource() } returns "nomis"
+      every { mockPrincipal.name } returns username
+      every { mockNomisUserRolesForRequesterApiClient.getUserDetailsForMe("abc123") } returns ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/me",
+        HttpStatus.NOT_FOUND,
+        body = null,
+      )
+
+      assertThrows<RuntimeException> { cas2UserService.getUserDtoForRequest() }
+    }
+
+    @Test
+    fun `returns success when user is Nomis user`() {
+      val username = "NOMISUSER"
+      val nomisUser = Cas2UserEntityFactory()
+        .withUsername(username)
+        .withUserType(Cas2UserType.NOMIS)
+        .withServiceOrigin(Cas2ServiceOrigin.BAIL)
+        .produce()
+      val nomisUserDetail = NomisUserDetailFactory().produce()
+
+      val mockPrincipal = mockk<AuthAwareAuthenticationToken>()
+      every { mockHttpAuthService.getCas2v2AuthenticatedPrincipalOrThrow() } returns mockPrincipal
+      every { mockPrincipal.token.tokenValue } returns "abc123"
+      every { mockPrincipal.authenticationSource() } returns "nomis"
+      every { mockPrincipal.name } returns username
+      every { mockNomisUserRolesForRequesterApiClient.getUserDetailsForMe("abc123") } returns ClientResult.Success(
+        status = HttpStatus.OK,
+        body = nomisUserDetail,
+      )
+      every {
+        mockCas2UserRepository.findByUsernameAndUserTypeAndServiceOrigin(username, Cas2UserType.NOMIS, nomisUser.serviceOrigin)
+      } returns nomisUser
+      every { mockCas2UserRepository.save(nomisUser) } returns nomisUser
+
+      val userDto = extractEntityFromCasResult(cas2UserService.getUserDtoForRequest())
+      assertThat(userDto.username).isEqualTo("NOMISUSER")
+      assertThat(userDto.type).isEqualTo(Cas2UserTypeDto.NOMIS)
+    }
+  }
+}


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-793

Changes:

- Added GET `/cas2/users/me` endpoint to return the currently authenticated user’s details.
- Extended Cas2UserService to build a `Cas2UserDto` for the current request, including Delius probation area info.
- Added/updated unit and integration tests to cover both Delius and Nomis current-user flows.