### PR TITLE
SAS-615: Open up CAS3 referrer view referral access

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
@@ -100,7 +100,7 @@ class Cas3ApplicationService(
     val userEntity = userRepository.findByDeliusUsername(userDistinguishedName)
       ?: throw RuntimeException("Could not get user")
 
-    val canAccess = userAccessService.userCanViewApplication(userEntity, applicationEntity)
+    val canAccess = userAccessService.userCanViewCas3Application(userEntity, applicationEntity)
 
     return if (canAccess) {
       CasResult.Success(applicationEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3AssessmentService.kt
@@ -91,7 +91,8 @@ class Cas3AssessmentService(
     val assessment = temporaryAccommodationAssessmentRepository.findByIdOrNull(assessmentId)
       ?: return CasResult.NotFound("AssessmentEntity", assessmentId.toString())
 
-    val isAuthorised = userAccessService.userCanViewCas3Assessment(user, assessment) || (forTimeline && userAccessService.userCanViewCas3Application(user, assessment.application as TemporaryAccommodationApplicationEntity))
+    val isAuthorised = userAccessService.userCanViewCas3Assessment(user, assessment) ||
+      (forTimeline && userAccessService.userCanViewCas3Application(user, assessment.application as TemporaryAccommodationApplicationEntity))
 
     if (!isAuthorised) {
       return CasResult.Unauthorised("Not authorised to view the assessment")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3AssessmentService.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LockableAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralHistorySystemNoteType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -90,7 +91,7 @@ class Cas3AssessmentService(
     val assessment = temporaryAccommodationAssessmentRepository.findByIdOrNull(assessmentId)
       ?: return CasResult.NotFound("AssessmentEntity", assessmentId.toString())
 
-    val isAuthorised = userAccessService.userCanViewAssessment(user, assessment) || (forTimeline && userAccessService.userCanViewApplication(user, assessment.application))
+    val isAuthorised = userAccessService.userCanViewCas3Assessment(user, assessment) || (forTimeline && userAccessService.userCanViewCas3Application(user, assessment.application as TemporaryAccommodationApplicationEntity))
 
     if (!isAuthorised) {
       return CasResult.Unauthorised("Not authorised to view the assessment")
@@ -117,7 +118,7 @@ class Cas3AssessmentService(
         ?: return CasResult.NotFound("TemporaryAccommodationAssessmentEntity", assessmentId.toString())
       )
 
-    if (!userAccessService.userCanViewAssessment(user, assessment)) {
+    if (!userAccessService.userCanViewCas3Assessment(user, assessment)) {
       return CasResult.Unauthorised()
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -103,7 +103,7 @@ class UserAccessService(
     user: UserEntity,
     application: TemporaryAccommodationApplicationEntity,
   ): Boolean = userCanAccessRegion(user, ServiceName.temporaryAccommodation, application.probationRegion.id) &&
-    user.hasRole(UserRole.CAS3_ASSESSOR) &&
+    user.hasAnyRole(UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER) &&
     application.submittedAt != null
 
   fun userCanReallocateTask(user: UserEntity): Boolean = when (requestContextService.getServiceForRequest()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -118,7 +118,7 @@ class UserAccessService(
     else -> false
   }
 
-  fun userCanViewAssessment(user: UserEntity, assessment: AssessmentEntity): Boolean = assessment is ApprovedPremisesAssessmentEntity
+  fun userCanViewAssessment(assessment: AssessmentEntity): Boolean = assessment is ApprovedPremisesAssessmentEntity
 
   fun userCanViewCas3Assessment(user: UserEntity, assessment: TemporaryAccommodationAssessmentEntity): Boolean = user.hasRole(UserRole.CAS3_ASSESSOR) &&
     userCanAccessRegion(user, ServiceName.temporaryAccommodation, (assessment.application as TemporaryAccommodationApplicationEntity).probationRegion.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/UserAccessService.kt
@@ -89,7 +89,6 @@ class UserAccessService(
 
     return when (application) {
       is ApprovedPremisesApplicationEntity -> userCanViewApprovedPremisesApplicationCreatedBySomeoneElse(user, application)
-      is TemporaryAccommodationApplicationEntity -> userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(user, application)
       else -> false
     }
   }
@@ -99,12 +98,15 @@ class UserAccessService(
     application: ApprovedPremisesApplicationEntity,
   ) = offenderService.canAccessOffender(application.crn, user.cas1LaoStrategy())
 
-  private fun userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse(
-    user: UserEntity,
-    application: TemporaryAccommodationApplicationEntity,
-  ): Boolean = userCanAccessRegion(user, ServiceName.temporaryAccommodation, application.probationRegion.id) &&
-    user.hasAnyRole(UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER) &&
-    application.submittedAt != null
+  fun userCanViewCas3Application(user: UserEntity, application: TemporaryAccommodationApplicationEntity): Boolean {
+    if (user.id == application.createdByUser.id) {
+      return true
+    }
+
+    return userCanAccessRegion(user, ServiceName.temporaryAccommodation, application.probationRegion.id) &&
+      user.hasAnyRole(UserRole.CAS3_ASSESSOR, UserRole.CAS3_REFERRER) &&
+      application.submittedAt != null
+  }
 
   fun userCanReallocateTask(user: UserEntity): Boolean = when (requestContextService.getServiceForRequest()) {
     ServiceName.temporaryAccommodation -> user.hasRole(UserRole.CAS3_ASSESSOR)
@@ -116,16 +118,10 @@ class UserAccessService(
     else -> false
   }
 
-  fun userCanViewAssessment(user: UserEntity, assessment: AssessmentEntity): Boolean = when (assessment) {
-    is ApprovedPremisesAssessmentEntity ->
-      true
+  fun userCanViewAssessment(user: UserEntity, assessment: AssessmentEntity): Boolean = assessment is ApprovedPremisesAssessmentEntity
 
-    is TemporaryAccommodationAssessmentEntity ->
-      user.hasRole(UserRole.CAS3_ASSESSOR) &&
-        userCanAccessRegion(user, ServiceName.temporaryAccommodation, (assessment.application as TemporaryAccommodationApplicationEntity).probationRegion.id)
-
-    else -> false
-  }
+  fun userCanViewCas3Assessment(user: UserEntity, assessment: TemporaryAccommodationAssessmentEntity): Boolean = user.hasRole(UserRole.CAS3_ASSESSOR) &&
+    userCanAccessRegion(user, ServiceName.temporaryAccommodation, (assessment.application as TemporaryAccommodationApplicationEntity).probationRegion.id)
 
   fun userCanAccessTemporaryAccommodationApplication(user: UserEntity, application: ApplicationEntity): Boolean = (user == application.createdByUser) &&
     userCanAccessRegion(user, ServiceName.temporaryAccommodation, (application as TemporaryAccommodationApplicationEntity).probationRegion.id) &&

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1AssessmentService.kt
@@ -151,7 +151,7 @@ class Cas1AssessmentService(
     val assessment = approvedPremisesAssessmentRepository.findByIdOrNull(assessmentId)
       ?: return CasResult.NotFound("AssessmentEntity", assessmentId.toString())
 
-    if (!userAccessService.userCanViewAssessment(user, assessment)) {
+    if (!userAccessService.userCanViewAssessment(assessment)) {
       return CasResult.Unauthorised("Not authorised to view the assessment")
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3ApplicationTest.kt
@@ -239,6 +239,115 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
+    fun `Get single application returns 200 with correct body when a user with the CAS3_REFERRER role requests a submitted application in their region created by someone else`() {
+      givenAUser(roles = listOf(UserRole.CAS3_REFERRER)) { userEntity, jwt ->
+        givenAUser(probationRegion = userEntity.probationRegion) { createdByUser, _ ->
+          givenAnOffender { offenderDetails, _ ->
+
+            val applicationEntity = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(createdByUser)
+              withProbationRegion(createdByUser.probationRegion)
+              withSubmittedAt(OffsetDateTime.parse("2023-06-01T12:34:56.789+01:00"))
+              withData(
+                """
+              {
+                 "thingId": 123
+              }
+              """,
+              )
+            }
+
+            apDeliusContextAddResponseToUserAccessCall(
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
+              userEntity.deliusUsername,
+            )
+
+            callCas3ApiAndAssertApiResponse(jwt, applicationEntity)
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get single application returns 403 Forbidden when a user with the CAS3_REFERRER role requests an application not in their region`() {
+      givenAUser(roles = listOf(UserRole.CAS3_REFERRER)) { userEntity, jwt ->
+        givenAUser { createdByUser, _ ->
+          givenAnOffender { offenderDetails, _ ->
+
+            val applicationEntity = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(createdByUser)
+              withProbationRegion(createdByUser.probationRegion)
+              withSubmittedAt(OffsetDateTime.now())
+              withData(
+                """
+              {
+                 "thingId": 123
+              }
+              """,
+              )
+            }
+
+            apDeliusContextAddResponseToUserAccessCall(
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
+              userEntity.deliusUsername,
+            )
+
+            callCas3Api(jwt, applicationEntity.id)
+              .expectStatus()
+              .isForbidden
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get single application returns 403 Forbidden when a user with the CAS3_REFERRER role requests a draft application created by someone else`() {
+      givenAUser(roles = listOf(UserRole.CAS3_REFERRER)) { userEntity, jwt ->
+        givenAUser(probationRegion = userEntity.probationRegion) { createdByUser, _ ->
+          givenAnOffender { offenderDetails, _ ->
+
+            val applicationEntity = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
+              withCrn(offenderDetails.otherIds.crn)
+              withCreatedByUser(createdByUser)
+              withProbationRegion(createdByUser.probationRegion)
+              withSubmittedAt(null)
+              withData(
+                """
+              {
+                 "thingId": 123
+              }
+              """,
+              )
+            }
+
+            apDeliusContextAddResponseToUserAccessCall(
+              listOf(
+                CaseAccessFactory()
+                  .withCrn(offenderDetails.otherIds.crn)
+                  .produce(),
+              ),
+              userEntity.deliusUsername,
+            )
+
+            callCas3Api(jwt, applicationEntity.id)
+              .expectStatus()
+              .isForbidden
+          }
+        }
+      }
+    }
+
+    @Test
     fun `Get single LAO application for application creator with LAO access returns 200`() {
       givenAUser { createdByUser, jwt ->
         givenAnOffender(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
@@ -594,7 +594,7 @@ class Cas3ApplicationServiceTest {
         .withProbationRegion(probationRegion)
         .produce()
 
-      every { mockUserAccessService.userCanViewApplication(any(), any()) } returns false
+      every { mockUserAccessService.userCanViewCas3Application(any(), any()) } returns false
 
       assertThat(
         cas3ApplicationService.getApplicationForUsername(
@@ -626,7 +626,7 @@ class Cas3ApplicationServiceTest {
 
       every { mockTemporaryAccommodationApplicationRepository.findByIdOrNull(any()) } returns applicationEntity
       every { mockUserRepository.findByDeliusUsername(any()) } returns userEntity
-      every { mockUserAccessService.userCanViewApplication(any(), any()) } returns true
+      every { mockUserAccessService.userCanViewCas3Application(any(), any()) } returns true
 
       val result = cas3ApplicationService.getApplicationForUsername(applicationId, distinguishedName)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3AssessmentServiceTest.kt
@@ -120,7 +120,7 @@ class Cas3AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(user, assessment) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(user, assessment) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
       every {
@@ -174,7 +174,7 @@ class Cas3AssessmentServiceTest {
           )
           .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(user, assessment) } returns false
+      every { userAccessServiceMock.userCanViewCas3Assessment(user, assessment) } returns false
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -388,7 +388,7 @@ class Cas3AssessmentServiceTest {
       val assessment = assessmentEntity(user)
 
       every { assessmentRepositoryMock.findById(assessmentId) } returns Optional.of(assessment)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns false
 
       val result =
         assessmentService.updateAssessment(
@@ -415,7 +415,7 @@ class Cas3AssessmentServiceTest {
       val assessment = assessmentEntity(user)
 
       every { assessmentRepositoryMock.findById(assessmentId) } returns Optional.of(assessment)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       val result = assessmentService.updateAssessment(
         user,
@@ -441,7 +441,7 @@ class Cas3AssessmentServiceTest {
 
       every { assessmentRepositoryMock.findById(assessmentId) } returns Optional.of(assessment)
       every { assessmentRepositoryMock.save(any()) } returnsArgument 0
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       val result = assessmentService.updateAssessment(
         user,
@@ -465,7 +465,7 @@ class Cas3AssessmentServiceTest {
         )
 
       every { assessmentRepositoryMock.findById(any()) } returns Optional.of(assessment)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       val result = assessmentService.updateAssessment(
         user,
@@ -503,7 +503,7 @@ class Cas3AssessmentServiceTest {
       assessment.accommodationRequiredFromDate = existingDate
 
       every { assessmentRepositoryMock.findById(assessmentId) } returns Optional.of(assessment)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
       every { assessmentRepositoryMock.save(any()) } returnsArgument 0
       every { cas3DomainEventBuilderMock.buildAssessmentUpdatedDomainEvent(any(), any()) } answers { callOriginal() }
       every { cas3DomainEventServiceMock.saveAssessmentUpdatedEvent(any()) } just Runs
@@ -565,7 +565,7 @@ class Cas3AssessmentServiceTest {
         .withAllocatedToUser(user)
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -605,7 +605,7 @@ class Cas3AssessmentServiceTest {
         .withAllocatedToUser(user)
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns false
 
       val result = assessmentService.acceptAssessment(user, assessmentId, "{}")
 
@@ -619,7 +619,7 @@ class Cas3AssessmentServiceTest {
         .withReallocatedAt(OffsetDateTime.now())
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -642,7 +642,7 @@ class Cas3AssessmentServiceTest {
         .withApplication(application)
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -704,7 +704,7 @@ class Cas3AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns false
 
       val result = assessmentService.rejectAssessment(user, assessmentId, "{}", "reasoning")
 
@@ -721,7 +721,7 @@ class Cas3AssessmentServiceTest {
         .withReallocatedAt(OffsetDateTime.now())
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -757,7 +757,7 @@ class Cas3AssessmentServiceTest {
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { assessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -804,7 +804,7 @@ class Cas3AssessmentServiceTest {
         .withId(referralRejectionReasonId)
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -883,7 +883,7 @@ class Cas3AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns false
 
       val result = assessmentService.closeAssessment(user, assessmentId)
 
@@ -917,7 +917,7 @@ class Cas3AssessmentServiceTest {
         .withCompletedAt(OffsetDateTime.now())
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -962,7 +962,7 @@ class Cas3AssessmentServiceTest {
         .withData("{\"test\": \"data\"}")
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewCas3Assessment(any(), any()) } returns true
 
       every { temporaryAccommodationAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -555,6 +555,51 @@ class UserAccessServiceTest {
   }
 
   @Test
+  fun `userCanViewApplication returns false if the user has the CAS3_REFERRER role but the application is not in their region for Temporary Accommodation`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(CAS3_REFERRER)
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withCreatedByUser(anotherUserNotInRegion)
+      .withProbationRegion(anotherProbationRegion)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+  }
+
+  @Test
+  fun `userCanViewApplication returns false if the user has the CAS3_REFERRER role and the application is in their region but it has not been submitted for Temporary Accommodation`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(CAS3_REFERRER)
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withCreatedByUser(anotherUserInRegion)
+      .withProbationRegion(probationRegion)
+      .withSubmittedAt(null)
+      .produce()
+
+    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+  }
+
+  @Test
+  fun `userCanViewApplication returns true if the application has been submitted, is in the user's region, and the user has the CAS3_REFERRER role for Temporary Accommodation`() {
+    currentRequestIsFor(ServiceName.temporaryAccommodation)
+
+    user.addRoleForUnitTest(CAS3_REFERRER)
+
+    val application = TemporaryAccommodationApplicationEntityFactory()
+      .withCreatedByUser(anotherUserInRegion)
+      .withProbationRegion(probationRegion)
+      .withSubmittedAt(OffsetDateTime.now())
+      .produce()
+
+    assertThat(userAccessService.userCanViewApplication(user, application)).isTrue
+  }
+
+  @Test
   fun `userCanViewApplication returns false otherwise for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -499,18 +499,18 @@ class UserAccessServiceTest {
   }
 
   @Test
-  fun `userCanViewApplication returns true if the user created the application for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns true if the user created the application for Temporary Accommodation`() {
     val application = TemporaryAccommodationApplicationEntityFactory()
       .withCreatedByUser(user)
       .withProbationRegion(probationRegion)
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isTrue
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isTrue
   }
 
   @Test
-  fun `userCanViewApplication returns false if the user has the CAS3_ASSESSOR role but the application is not in their region for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns false if the user has the CAS3_ASSESSOR role but the application is not in their region for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
@@ -521,11 +521,11 @@ class UserAccessServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isFalse
   }
 
   @Test
-  fun `userCanViewApplication returns false if the user has the CAS3_ASSESSOR role and the application is in their region but it has not been submitted for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns false if the user has the CAS3_ASSESSOR role and the application is in their region but it has not been submitted for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
@@ -536,11 +536,11 @@ class UserAccessServiceTest {
       .withSubmittedAt(null)
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isFalse
   }
 
   @Test
-  fun `userCanViewApplication returns true if the application has been submitted, is in the user's region, and the user has the CAS3_ASSESSOR role for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns true if the application has been submitted, is in the user's region, and the user has the CAS3_ASSESSOR role for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
@@ -551,11 +551,11 @@ class UserAccessServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isTrue
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isTrue
   }
 
   @Test
-  fun `userCanViewApplication returns false if the user has the CAS3_REFERRER role but the application is not in their region for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns false if the user has the CAS3_REFERRER role but the application is not in their region for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(CAS3_REFERRER)
@@ -566,11 +566,11 @@ class UserAccessServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isFalse
   }
 
   @Test
-  fun `userCanViewApplication returns false if the user has the CAS3_REFERRER role and the application is in their region but it has not been submitted for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns false if the user has the CAS3_REFERRER role and the application is in their region but it has not been submitted for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(CAS3_REFERRER)
@@ -581,11 +581,11 @@ class UserAccessServiceTest {
       .withSubmittedAt(null)
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isFalse
   }
 
   @Test
-  fun `userCanViewApplication returns true if the application has been submitted, is in the user's region, and the user has the CAS3_REFERRER role for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns true if the application has been submitted, is in the user's region, and the user has the CAS3_REFERRER role for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     user.addRoleForUnitTest(CAS3_REFERRER)
@@ -596,11 +596,11 @@ class UserAccessServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isTrue
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isTrue
   }
 
   @Test
-  fun `userCanViewApplication returns false otherwise for Temporary Accommodation`() {
+  fun `userCanViewCas3Application returns false otherwise for Temporary Accommodation`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     val application = TemporaryAccommodationApplicationEntityFactory()
@@ -609,7 +609,7 @@ class UserAccessServiceTest {
       .withSubmittedAt(OffsetDateTime.now())
       .produce()
 
-    assertThat(userAccessService.userCanViewApplication(user, application)).isFalse
+    assertThat(userAccessService.userCanViewCas3Application(user, application)).isFalse
   }
 
   @Test
@@ -724,7 +724,7 @@ class UserAccessServiceTest {
   }
 
   @Test
-  fun `userCanViewAssessment returns true for a Temporary Accommodation assessment if the user has the CAS3_ASSESSOR role and the assessment is in the same region`() {
+  fun `userCanViewCas3Assessment returns true for a Temporary Accommodation assessment if the user has the CAS3_ASSESSOR role and the assessment is in the same region`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     val application = TemporaryAccommodationApplicationEntityFactory()
@@ -738,11 +738,11 @@ class UserAccessServiceTest {
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-    assertThat(userAccessService.userCanViewAssessment(user, assessment)).isTrue
+    assertThat(userAccessService.userCanViewCas3Assessment(user, assessment)).isTrue
   }
 
   @Test
-  fun `userCanViewAssessment returns false for a Temporary Accommodation assessment if the user has the CAS3_ASSESSOR role but the assessment is not in the same region`() {
+  fun `userCanViewCas3Assessment returns false for a Temporary Accommodation assessment if the user has the CAS3_ASSESSOR role but the assessment is not in the same region`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     val application = TemporaryAccommodationApplicationEntityFactory()
@@ -756,11 +756,11 @@ class UserAccessServiceTest {
 
     user.addRoleForUnitTest(UserRole.CAS3_ASSESSOR)
 
-    assertThat(userAccessService.userCanViewAssessment(user, assessment)).isFalse
+    assertThat(userAccessService.userCanViewCas3Assessment(user, assessment)).isFalse
   }
 
   @Test
-  fun `userCanViewAssessment returns false for a Temporary Accommodation assessment if the user does not have the CAS3_ASSESSOR role`() {
+  fun `userCanViewCas3Assessment returns false for a Temporary Accommodation assessment if the user does not have the CAS3_ASSESSOR role`() {
     currentRequestIsFor(ServiceName.temporaryAccommodation)
 
     val application = TemporaryAccommodationApplicationEntityFactory()
@@ -772,7 +772,7 @@ class UserAccessServiceTest {
       .withApplication(application)
       .produce()
 
-    assertThat(userAccessService.userCanViewAssessment(user, assessment)).isFalse
+    assertThat(userAccessService.userCanViewCas3Assessment(user, assessment)).isFalse
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/UserAccessServiceTest.kt
@@ -788,7 +788,7 @@ class UserAccessServiceTest {
       .withAllocatedToUser(anotherUserNotInRegion)
       .produce()
 
-    assertThat(userAccessService.userCanViewAssessment(user, assessment)).isTrue
+    assertThat(userAccessService.userCanViewAssessment(assessment)).isTrue
   }
 
   @ParameterizedTest
@@ -806,7 +806,7 @@ class UserAccessServiceTest {
       .withAllocatedToUser(user)
       .produce()
 
-    assertThat(userAccessService.userCanViewAssessment(user, assessment)).isTrue
+    assertThat(userAccessService.userCanViewAssessment(assessment)).isTrue
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1AssessmentServiceTest.kt
@@ -198,7 +198,7 @@ class Cas1AssessmentServiceTest {
       )
       .produce()
 
-    every { userAccessServiceMock.userCanViewAssessment(user, assessment) } returns true
+    every { userAccessServiceMock.userCanViewAssessment(assessment) } returns true
 
     every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -251,7 +251,7 @@ class Cas1AssessmentServiceTest {
         )
         .produce()
 
-    every { userAccessServiceMock.userCanViewAssessment(user, assessment) } returns false
+    every { userAccessServiceMock.userCanViewAssessment(assessment) } returns false
 
     every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -492,7 +492,7 @@ class Cas1AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns false
 
       val result = cas1AssessmentService.addAssessmentClarificationNote(user, assessmentId, "clarification note")
 
@@ -534,7 +534,7 @@ class Cas1AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -602,7 +602,7 @@ class Cas1AssessmentServiceTest {
         .withAllocatedToUser(user)
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -662,7 +662,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -689,7 +689,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -719,7 +719,7 @@ class Cas1AssessmentServiceTest {
         .withAllocatedToUser(user)
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns false
 
       val result = cas1AssessmentService.updateAssessment(user, assessmentId, "{}")
 
@@ -737,7 +737,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -764,7 +764,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -792,7 +792,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -817,7 +817,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -843,7 +843,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -917,7 +917,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -954,7 +954,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -999,7 +999,7 @@ class Cas1AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns false
 
       val result =
         cas1AssessmentService.acceptAssessment(user, assessmentId, "{}", placementRequirements, null, null, null)
@@ -1015,7 +1015,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -1043,7 +1043,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -1069,7 +1069,7 @@ class Cas1AssessmentServiceTest {
       val assessment = assessmentFactory.produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -1106,7 +1106,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -1195,7 +1195,7 @@ class Cas1AssessmentServiceTest {
       val notes = "Some Notes"
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -1352,7 +1352,7 @@ class Cas1AssessmentServiceTest {
         )
         .produce()
 
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns false
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns false
 
       val result = cas1AssessmentService.rejectAssessment(user, assessmentId, "{}", "reasoning")
 
@@ -1369,7 +1369,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -1399,7 +1399,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -1429,7 +1429,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -1462,7 +1462,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessment.id) } returns LockableAssessmentEntity(assessment.id)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessment.id) } returns assessment
 
@@ -1496,7 +1496,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 
@@ -1525,7 +1525,7 @@ class Cas1AssessmentServiceTest {
         .produce()
 
       every { lockableAssessmentRepositoryMock.acquirePessimisticLock(assessmentId) } returns LockableAssessmentEntity(assessmentId)
-      every { userAccessServiceMock.userCanViewAssessment(any(), any()) } returns true
+      every { userAccessServiceMock.userCanViewAssessment(any()) } returns true
 
       every { approvedPremisesAssessmentRepositoryMock.findByIdOrNull(assessmentId) } returns assessment
 


### PR DESCRIPTION
This PR allows users with the `CAS3_REFERRER` role to view a referral created by another user (previously they could only view a referral created by themselves) returned via the `GET /applications/{applicationId}` endpoint. 

**Background**
SAS is building deeplinks into CAS3 to allow probation practitioners to view a specific referral (either current or historic). After implementing this feature, we discovered the users are only able to view the referral if they have the `CAS3_REFERRER` role and the referral was created by themselves - otherwise they would see 'You do not have permission to complete this action' page in CAS3. 

After some discussion, it was agreed that we should open up the access to allow referrers to view any referral - including ones created by others. 

**This PR**

- Refactors CAS3 access checks into two specific functions - `userCanViewCas3Application` and `userCanViewCas3Assessment` (`userCanViewTemporaryAccommodationApplicationCreatedBySomeoneElse` removed)
- `userCanViewCas3Application` allows access to `CAS3_REFERRER` role (needed for SAS users) alongside `CAS3_ASSESSOR` role
- Region lock is kept as is (can only view referrals in your probation region)
- Additional test coverage / new function name refactors