### PR TITLE
FM-820: Remove Tier service call

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationDomainEventService.kt
@@ -67,10 +67,6 @@ class Cas1ApplicationDomainEventService(
           )
       }
 
-    val risks = offenderRisksService.getPersonRisks(application.crn)
-
-    val mappaLevel = risks.mappa.value?.level
-
     val staffDetails = when (val staffDetailsResult = apDeliusContextApiClient.getStaffDetail(username)) {
       is ClientResult.Success -> staffDetailsResult.body
       is ClientResult.Failure -> staffDetailsResult.throwException()
@@ -80,6 +76,8 @@ class Cas1ApplicationDomainEventService(
       is ClientResult.Success -> caseDetailResult.body
       is ClientResult.Failure -> caseDetailResult.throwException()
     }
+
+    val mappaLevel = offenderRisksService.run { caseDetail.toMappa() }.value ?.level
 
     domainEventService.saveApplicationSubmittedDomainEvent(
       SaveCas1DomainEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MappaDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
@@ -36,10 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Withdrawn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MetaDataName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.asApiType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
@@ -56,15 +53,21 @@ import java.util.UUID
 
 class Cas1ApplicationCas1DomainEventServiceTest {
   private val mockOffenderService = mockk<OffenderService>()
-  private val mockOffenderRisksService = mockk<OffenderRisksService>()
   private val mockDomainEventService = mockk<Cas1DomainEventService>()
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockDomainEventTransformer = mockk<DomainEventTransformer>()
 
+  private val offenderRisksService = OffenderRisksService(
+    apDeliusContextApiClient = mockApDeliusContextApiClient,
+    apAndOASysClient = mockk(),
+    hmppsTierApiClient = mockk(),
+    sentryService = mockk(),
+  )
+
   private val service = Cas1ApplicationDomainEventService(
     mockDomainEventService,
     mockOffenderService,
-    mockOffenderRisksService,
+    offenderRisksService,
     mockApDeliusContextApiClient,
     mockDomainEventTransformer,
     UrlTemplate("http://frontend/applications/#id"),
@@ -86,7 +89,14 @@ class Cas1ApplicationCas1DomainEventServiceTest {
   inner class ApplicationSubmitted {
 
     private lateinit var application: ApprovedPremisesApplicationEntity
-    private val caseDetails = CaseDetailFactory().produce()
+    private val caseDetails = CaseDetailFactory()
+      .withMappaDetail(
+        MappaDetailFactory()
+          .withLevelDescription("L1")
+          .withCategoryDescription("C1")
+          .produce(),
+      )
+      .produce()
     private val domainEventProbationArea = ProbationAreaFactory().produce()
 
     private val staffUserDetails = StaffDetailFactory.staffDetail()
@@ -115,22 +125,6 @@ class Cas1ApplicationCas1DomainEventServiceTest {
           .withDateOfBirth(LocalDate.of(1982, 3, 11))
           .produce(),
       )
-
-      val risks = PersonRisksFactory()
-        .withMappa(
-          RiskWithStatus(
-            status = RiskStatus.Retrieved,
-            value = Mappa(
-              level = "CAT C1/LEVEL L1",
-              lastUpdated = LocalDate.now(),
-            ),
-          ),
-        )
-        .produce()
-
-      every {
-        mockOffenderRisksService.getPersonRisks(application.crn)
-      } returns risks
 
       every { mockApDeliusContextApiClient.getCaseDetail(application.crn) } returns ClientResult.Success(
         status = HttpStatus.OK,


### PR DESCRIPTION
- Removed the Tier service call when creating the application-submitted domain event.
- Added the `toMappa()` extension function to `CaseDetail` to map MAPPA details.