### PR TITLE
FM-814 Add default duration calculation logic for CAS1 requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1RequestsForPlacementController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1RequestsForPlacementController.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationRequestDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1RequestForPlacementService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@Cas1Controller
+@Tag(name = "CAS1 Requests for Placement Controller")
+class Cas1RequestsForPlacementController(
+  private val cas1RequestForPlacementService: Cas1RequestForPlacementService,
+) {
+
+  @Operation(summary = "Get request for placement duration")
+  @PostMapping(
+    value = ["/requests-for-placement/calc/durations"],
+    consumes = ["application/json"],
+  )
+  fun getRequestForPlacementDuration(
+    @RequestBody requestDto: Cas1RequestsForPlacementDurationsCalculationRequestDto,
+  ): ResponseEntity<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
+    val result = cas1RequestForPlacementService.defaultDurations(requestDto)
+
+    return ResponseEntity.ok(extractEntityFromCasResult(result))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1RequestsForPlacementDurationsCalculationRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1RequestsForPlacementDurationsCalculationRequestDto.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
+
+data class Cas1RequestsForPlacementDurationsCalculationRequestDto(
+  val apType: ApType,
+  val tier: Cas1TierDto,
+  val isWomensApplication: Boolean,
+  val sentenceType: SentenceTypeOption,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1RequestsForPlacementDurationsCalculationResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1RequestsForPlacementDurationsCalculationResponseDto.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
+
+data class Cas1RequestsForPlacementDurationsCalculationResponseDto(
+  val defaultDurationDays: Int,
+  val maxDurationDays: Int?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationRequestDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
@@ -11,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
+import java.time.Period
 import java.util.UUID
 
 @Component
@@ -37,6 +42,22 @@ class Cas1RequestForPlacementService(
         placementRequests.map { toRequestForPlacement(it, requestingUser) }
 
     return CasResult.Success(result.sortedByDescending { it.submittedAt })
+  }
+
+  fun defaultDurations(
+    requestDto: Cas1RequestsForPlacementDurationsCalculationRequestDto,
+  ): CasResult<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
+    if (requestDto.tier.version == Cas1TierVersionDto.V3) return CasResult.GeneralValidationError("Tier version V3 is not supported for duration calculations")
+    val responseDto = when (requestDto.apType) {
+      ApType.pipe -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null)
+      ApType.esap -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(52).days, maxDurationDays = null)
+      ApType.normal,
+      ApType.rfap,
+      ApType.mhapStJosephs,
+      ApType.mhapElliottHouse,
+      -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(12).days, maxDurationDays = null)
+    }
+    return CasResult.Success(responseDto)
   }
 
   private fun toRequestForPlacement(placementApplication: PlacementApplicationEntity, user: UserEntity?) = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/factory/Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/factory/Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationRequestDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierDto
+
+class Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory : Factory<Cas1RequestsForPlacementDurationsCalculationRequestDto> {
+  private var apType: Yielded<ApType> = { ApType.normal }
+  private var tier: Yielded<Cas1TierDto> = { Cas1TierDtoFactory().produce() }
+  private var isWomensApplication: Yielded<Boolean> = { false }
+  private var sentenceType: Yielded<SentenceTypeOption> = { SentenceTypeOption.standardDeterminate }
+
+  fun withApType(apType: ApType) = apply {
+    this.apType = { apType }
+  }
+
+  fun withTier(tier: Cas1TierDto) = apply {
+    this.tier = { tier }
+  }
+
+  override fun produce(): Cas1RequestsForPlacementDurationsCalculationRequestDto = Cas1RequestsForPlacementDurationsCalculationRequestDto(
+    apType = this.apType(),
+    tier = this.tier(),
+    isWomensApplication = this.isWomensApplication(),
+    sentenceType = this.sentenceType(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/factory/Cas1TierDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/factory/Cas1TierDtoFactory.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import java.time.LocalDateTime
+
+class Cas1TierDtoFactory : Factory<Cas1TierDto> {
+  private var tierScore: Yielded<String> = { randomStringLowerCase(8) }
+  private var calculationDate: Yielded<LocalDateTime> = { LocalDateTime.now() }
+  private var provisional: Yielded<Boolean?> = { null }
+  private var version: Yielded<Cas1TierVersionDto> = { Cas1TierVersionDto.V2 }
+
+  fun withVersion(version: Cas1TierVersionDto) = apply {
+    this.version = { version }
+  }
+
+  override fun produce(): Cas1TierDto = Cas1TierDto(
+    tierScore = this.tierScore(),
+    calculationDate = this.calculationDate(),
+    provisional = this.provisional(),
+    version = this.version(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ValidationError
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1TierDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+
+class Cas1RequestsForPlacementIT : IntegrationTestBase() {
+
+  @Nested
+  @DisplayName("POST /cas1/requests-for-placement/calc/durations")
+  inner class GetDurations {
+
+    @Test
+    fun `returns 401 without valid JWT`() {
+      val requestDto = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory().produce()
+
+      webTestClient.post()
+        .uri("/cas1/requests-for-placement/calc/durations")
+        .bodyValue(requestDto)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `returns error if tier has v3 version`() {
+      val (_, jwt) = givenAUser()
+
+      val requestDto = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory()
+        .withApType(ApType.mhapElliottHouse)
+        .withTier(Cas1TierDtoFactory().withVersion(Cas1TierVersionDto.V3).produce())
+        .produce()
+
+      val response = webTestClient.post()
+        .uri("/cas1/requests-for-placement/calc/durations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          requestDto,
+        )
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+        .bodyAsObject<ValidationError>()
+
+      assertThat(response.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
+      assertThat(response.detail).isEqualTo("Tier version V3 is not supported for duration calculations")
+    }
+
+    @Test
+    fun `returns correct response body if type is ApType`() {
+      val (_, jwt) = givenAUser()
+
+      val requestDto = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory()
+        .withApType(ApType.mhapElliottHouse)
+        .withTier(Cas1TierDtoFactory().withVersion(Cas1TierVersionDto.V2).produce())
+        .produce()
+
+      val response = webTestClient.post()
+        .uri("/cas1/requests-for-placement/calc/durations")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          requestDto,
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1RequestsForPlacementDurationsCalculationResponseDto>()
+
+      assertThat(response.defaultDurationDays).isEqualTo(84)
+      assertThat(response.maxDurationDays).isNull()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -7,12 +7,18 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1TierDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
@@ -251,6 +257,61 @@ class Cas1RequestForPlacementServiceTest {
       placementRequests.forEach {
         verify(exactly = 1) { requestForPlacementTransformer.transformPlacementRequestEntityToApi(it, true) }
       }
+    }
+  }
+
+  @Nested
+  inner class GetRequestsForPlacementDurations {
+    @ParameterizedTest
+    @ValueSource(
+      strings = [
+        "normal",
+        "mhapElliottHouse",
+        "mhapStJosephs",
+        "rfap",
+      ],
+    )
+    fun `returns duration 84 (12 x 7) when apType is normal or mhapElliottHouse or mhapStJosephs or rfap and tier version is V2`(apType: String) {
+      val request = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory().withApType(ApType.valueOf(apType)).produce()
+      val result = cas1RequestForPlacementService.defaultDurations(request)
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.defaultDurationDays).isEqualTo(84)
+        assertThat(it.maxDurationDays).isNull()
+      }
+    }
+
+    @Test
+    fun `returns duration 182 (26 x 7) when apType is pipe and tier version is V2`() {
+      val request = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory().withApType(ApType.pipe).produce()
+      val result = cas1RequestForPlacementService.defaultDurations(request)
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.defaultDurationDays).isEqualTo(182)
+        assertThat(it.maxDurationDays).isNull()
+      }
+    }
+
+    @Test
+    fun `returns duration 364 (52 x 7) when apType is esap and tier version is V2`() {
+      val request = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory().withApType(ApType.esap).produce()
+      val result = cas1RequestForPlacementService.defaultDurations(request)
+
+      assertThatCasResult(result).isSuccess().with {
+        assertThat(it.defaultDurationDays).isEqualTo(364)
+        assertThat(it.maxDurationDays).isNull()
+      }
+    }
+
+    @Test
+    fun `returns error when tier version is v3`() {
+      val request = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory().withApType(ApType.esap).withTier(
+        Cas1TierDtoFactory().withVersion(Cas1TierVersionDto.V3).produce(),
+      ).produce()
+
+      val result = cas1RequestForPlacementService.defaultDurations(request)
+
+      assertThatCasResult(result).isGeneralValidationError("Tier version V3 is not supported for duration calculations")
     }
   }
 }


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-814

Add default duration calculation logic for CAS1 requests, related DTOs, factories, controller, service method, and tests.