### PR TITLE
FM-850 Return RoSH not found when OASys assessment is older than 6 months.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysService.kt
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.HealthDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.NeedsDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
@@ -131,12 +130,6 @@ class OASysService(
     }
     is ClientResult.Failure -> response.throwException()
   }
-
-  private fun AssessmentInfo.toAssessmentDates(crn: String) = OASysSuitabilityService.OASysAssessmentDates(
-    crn = crn,
-    initiationDate = initiationDate,
-    dateCompleted = dateCompleted,
-  )
 
   private fun <T> notFound(crn: String) = CasResult.NotFound<T>("OASysAssessment", crn)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysSuitabilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OASysSuitabilityService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
 import java.time.Clock
 import java.time.OffsetDateTime
 
@@ -12,6 +13,15 @@ class OASysSuitabilityService(
   private val sentryService: SentryService,
 ) {
   var logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+  fun isSuitable(
+    crn: String,
+    assessmentInfo: AssessmentInfo,
+    strategy: SuitabilityStrategy,
+  ) = isSuitable(
+    assessmentDates = assessmentInfo.toAssessmentDates(crn),
+    strategy = strategy,
+  )
 
   fun isSuitable(
     assessmentDates: OASysAssessmentDates,
@@ -50,3 +60,9 @@ class OASysSuitabilityService(
     CompletedInLastSixMonths,
   }
 }
+
+fun AssessmentInfo.toAssessmentDates(crn: String) = OASysSuitabilityService.OASysAssessmentDates(
+  crn = crn,
+  initiationDate = initiationDate,
+  dateCompleted = dateCompleted,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
@@ -21,6 +21,7 @@ class OffenderRisksService(
   private val apAndOASysClient: ApAndOASysClient,
   private val hmppsTierApiClient: HMPPSTierApiClient,
   private val sentryService: SentryService,
+  private val oaSysSuitabilityService: OASysSuitabilityService,
 ) {
 
   private val ignoredRegisterTypesForFlags = listOf("RVHR", "RHRH", "RMRH", "RLRH", "MAPP")
@@ -40,19 +41,29 @@ class OffenderRisksService(
     is ClientResult.Success -> {
       val summary = roshRisksResponse.body.rosh
 
-      when (summary.anyRisksAreNull()) {
-        true -> RiskWithStatus(status = RiskStatus.NotFound)
-        false -> RiskWithStatus(
-          value = RoshRisks(
-            overallRisk = summary.determineOverallRiskLevel().text,
-            riskToChildren = summary.riskChildrenCommunity!!.text,
-            riskToPublic = summary.riskPublicCommunity!!.text,
-            riskToKnownAdult = summary.riskKnownAdultCommunity!!.text,
-            riskToStaff = summary.riskStaffCommunity!!.text,
-            lastUpdated = roshRisksResponse.body.dateCompleted?.toLocalDate()
-              ?: roshRisksResponse.body.initiationDate.toLocalDate(),
-          ),
-        )
+      val isSuitable = oaSysSuitabilityService.isSuitable(
+        crn,
+        assessmentInfo = roshRisksResponse.body,
+        strategy = OASysSuitabilityService.SuitabilityStrategy.CompletedInLastSixMonths,
+      )
+
+      if (!isSuitable) {
+        RiskWithStatus(status = RiskStatus.NotFound)
+      } else {
+        when (summary.anyRisksAreNull()) {
+          true -> RiskWithStatus(status = RiskStatus.NotFound)
+          false -> RiskWithStatus(
+            value = RoshRisks(
+              overallRisk = summary.determineOverallRiskLevel().text,
+              riskToChildren = summary.riskChildrenCommunity!!.text,
+              riskToPublic = summary.riskPublicCommunity!!.text,
+              riskToKnownAdult = summary.riskKnownAdultCommunity!!.text,
+              riskToStaff = summary.riskStaffCommunity!!.text,
+              lastUpdated = roshRisksResponse.body.dateCompleted?.toLocalDate()
+                ?: roshRisksResponse.body.initiationDate.toLocalDate(),
+            ),
+          )
+        }
       }
     }
     is ClientResult.Failure.StatusCode -> when (roshRisksResponse.status) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.time.LocalDate
@@ -34,12 +35,14 @@ class OffenderRisksServiceTest {
   private val mockApOASysContextApiClient = mockk<ApAndOASysClient>()
   private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
   private val mockSentryService = mockk<SentryService>()
+  private val mockOASysSuitabilityService = mockk<OASysSuitabilityService>()
 
   private val apDeliusContextApiOffenderRisksService = OffenderRisksService(
     mockApDeliusContextApiClient,
     mockApOASysContextApiClient,
     mockHMPPSTierApiClient,
     mockSentryService,
+    mockOASysSuitabilityService,
   )
 
   @Test
@@ -111,6 +114,73 @@ class OffenderRisksServiceTest {
   }
 
   @Test
+  fun `getPersonRisks returns RoSH not found when OASys assessment is older than 6 months`() {
+    val crn = "a-crn"
+
+    mock200RoSH(
+      crn,
+      RoshRatingsFactory().apply {
+        withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
+        withAssessmentId(34853487)
+        withRiskChildrenCommunity(RiskLevel.LOW)
+        withRiskPublicCommunity(RiskLevel.MEDIUM)
+        withRiskKnownAdultCommunity(RiskLevel.HIGH)
+        withRiskStaffCommunity(RiskLevel.VERY_HIGH)
+      }.produce(),
+    )
+
+    mock200Tier(
+      crn,
+      Tier(
+        tierScore = "M2",
+        calculationId = UUID.randomUUID(),
+        calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+      ),
+    )
+
+    mock200CaseDetail(
+      crn,
+      CaseDetailFactory()
+        .withRegistrations(
+          listOf(
+            Registration(
+              code = "MAPP",
+              description = "MAPPA",
+              startDate = LocalDate.parse("2022-09-06"),
+            ),
+            Registration(
+              code = "FLAG",
+              description = "RISK FLAG",
+              startDate = LocalDate.parse("2022-09-06"),
+            ),
+          ),
+        )
+        .withMappaDetail(
+          MappaDetail(
+            level = 1,
+            levelDescription = "L1",
+            category = 1,
+            categoryDescription = "C1",
+            startDate = LocalDate.parse("2022-09-06"),
+            lastUpdated = ZonedDateTime.parse("2022-09-06T00:00:00Z"),
+          ),
+        )
+        .produce(),
+    )
+
+    every { mockOASysSuitabilityService.isSuitable(crn, any(), OASysSuitabilityService.SuitabilityStrategy.CompletedInLastSixMonths) } returns false
+
+    val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
+
+    assertThat(result.roshRisks.status).isEqualTo(RiskStatus.NotFound)
+    assertThat(result.tier.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.mappa.status).isEqualTo(RiskStatus.Retrieved)
+    assertThat(result.flags.status).isEqualTo(RiskStatus.Retrieved)
+
+    verify { mockSentryService wasNot Called }
+  }
+
+  @Test
   fun `getPersonRisks returns Retrieved envelopes with expected contents for RoSH, Tier, Mappa & flags when respective Clients return 200`() {
     val crn = "a-crn"
 
@@ -164,6 +234,8 @@ class OffenderRisksServiceTest {
         )
         .produce(),
     )
+
+    every { mockOASysSuitabilityService.isSuitable(crn, any(), OASysSuitabilityService.SuitabilityStrategy.CompletedInLastSixMonths) } returns true
 
     val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
 
@@ -249,6 +321,8 @@ class OffenderRisksServiceTest {
         )
         .produce(),
     )
+
+    every { mockOASysSuitabilityService.isSuitable(crn, any(), OASysSuitabilityService.SuitabilityStrategy.CompletedInLastSixMonths) } returns true
 
     val result = apDeliusContextApiOffenderRisksService.getPersonRisks(crn)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCas1DomainEventServiceTest.kt
@@ -62,6 +62,7 @@ class Cas1ApplicationCas1DomainEventServiceTest {
     apAndOASysClient = mockk(),
     hmppsTierApiClient = mockk(),
     sentryService = mockk(),
+    oaSysSuitabilityService = mockk(),
   )
 
   private val service = Cas1ApplicationDomainEventService(


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-850

**Changes:**
- Gate `OffenderRisksService` RoSH ratings behind `OASysSuitabilityService` using the `CompletedInLastSixMonths` strategy.
- Add unit test coverage ensuring RoSH becomes `NotFound` when suitability fails, while other risk envelopes still return as expected.
- Refactor OASys assessment date conversion into a shared `AssessmentInfo.toAssessmentDates` extension (removing the duplicated private helper in `OASysService`).