### PR TITLE
Add url-template endpoints.

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -61,6 +61,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-dev.hmpps.service.justice.gov.uk/assessments/#id
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION-START: https://approved-premises-dev.hmpps.service.justice.gov.uk/applications/start
     URL-TEMPLATES_FRONTEND_CAS1_CRU-DASHBOARD: https://approved-premises-dev.hmpps.service.justice.gov.uk/admin/cru-dashboard
     URL-TEMPLATES_FRONTEND_CAS1_CRU-OPEN-CHANGE-REQUESTS: https://approved-premises-dev.hmpps.service.justice.gov.uk/admin/cru-dashboard/change-requests
     URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises-dev.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
@@ -72,6 +73,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-dev.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-dev.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-FULL: https://transitional-accommodation-dev.hmpps.service.justice.gov.uk/referrals/#applicationId/full
+    URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-START: https://transitional-accommodation-dev.hmpps.service.justice.gov.uk/referrals/start
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-dev.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -52,6 +52,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-preprod.hmpps.service.justice.gov.uk/assessments/#id
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION-START: https://approved-premises-preprod.hmpps.service.justice.gov.uk/applications/start
     URL-TEMPLATES_FRONTEND_CAS1_CRU-DASHBOARD: https://approved-premises-preprod.hmpps.service.justice.gov.uk/admin/cru-dashboard
     URL-TEMPLATES_FRONTEND_CAS1_CRU-OPEN-CHANGE-REQUESTS: https://approved-premises-preprod.hmpps.service.justice.gov.uk/admin/cru-dashboard/change-requests
     URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises-preprod.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
@@ -63,6 +64,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-preprod.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-preprod.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-FULL: https://transitional-accommodation-preprod.hmpps.service.justice.gov.uk/referrals/#applicationId/full
+    URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-START: https://transitional-accommodation-preprod.hmpps.service.justice.gov.uk/referrals/start
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-preprod.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -52,6 +52,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises.hmpps.service.justice.gov.uk/assessments/#id
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION-START: https://approved-premises.hmpps.service.justice.gov.uk/applications/start
     URL-TEMPLATES_FRONTEND_CAS1_CRU-DASHBOARD: https://approved-premises.hmpps.service.justice.gov.uk/admin/cru-dashboard
     URL-TEMPLATES_FRONTEND_CAS1_CRU-OPEN-CHANGE-REQUESTS: https://approved-premises.hmpps.service.justice.gov.uk/admin/cru-dashboard/change-requests
     URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
@@ -63,6 +64,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2-bail.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://short-term-accommodation-cas-2-bail.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-FULL: https://transitional-accommodation.hmpps.service.justice.gov.uk/referrals/#applicationId/full
+    URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-START: https://transitional-accommodation.hmpps.service.justice.gov.uk/referrals/start
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -53,6 +53,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_APPLICATION-APPEAL: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId/appeals/#appealId
     URL-TEMPLATES_FRONTEND_APPLICATION-TIMELINE: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/#applicationId?tab=timeline
     URL-TEMPLATES_FRONTEND_ASSESSMENT: https://approved-premises-test.hmpps.service.justice.gov.uk/assessments/#id
+    URL-TEMPLATES_FRONTEND_CAS1_APPLICATION-START: https://approved-premises-test.hmpps.service.justice.gov.uk/applications/start
     URL-TEMPLATES_FRONTEND_CAS1_CRU-DASHBOARD: https://approved-premises-test.hmpps.service.justice.gov.uk/admin/cru-dashboard
     URL-TEMPLATES_FRONTEND_CAS1_CRU-OPEN-CHANGE-REQUESTS: https://approved-premises-test.hmpps.service.justice.gov.uk/admin/cru-dashboard/change-requests
     URL-TEMPLATES_FRONTEND_CAS1_SPACE-BOOKING: https://approved-premises-test.hmpps.service.justice.gov.uk/manage/premises/#premisesId/placements/#bookingId
@@ -64,6 +65,7 @@ generic-service:
     URL-TEMPLATES_FRONTEND_CAS2V2_APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-test.hmpps.service.justice.gov.uk/applications/#id/overview
     URL-TEMPLATES_FRONTEND_CAS2V2_SUBMITTED-APPLICATION-OVERVIEW: https://community-accommodation-tier-2-bail-test.hmpps.service.justice.gov.uk/assess/applications/#applicationId/overview
     URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-FULL: https://transitional-accommodation-test.hmpps.service.justice.gov.uk/referrals/#applicationId/full
+    URL-TEMPLATES_FRONTEND_CAS3_REFERRAL-START: https://transitional-accommodation-test.hmpps.service.justice.gov.uk/referrals/start
     URL-TEMPLATES_API_CAS1_APPLICATION-SUBMITTED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-submitted/#eventId
     URL-TEMPLATES_API_CAS1_APPLICATION-ASSESSED-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/application-assessed/#eventId
     URL-TEMPLATES_API_CAS1_BOOKING-MADE-EVENT-DETAIL: https://approved-premises-api-test.hmpps.service.justice.gov.uk/events/booking-made/#eventId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalUrlTemplateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalUrlTemplateController.kt
@@ -14,4 +14,4 @@ class Cas1ExternalUrlTemplateController(private val cas1UrlTemplates: Cas1UrlTem
 }
 
 @Component
-data class Cas1UrlTemplates(@Value($$"${url-templates.frontend.cas1.application-start}") var cas1ApplicationStart: String)
+data class Cas1UrlTemplates(@Value($$"${url-templates.frontend.cas1.application-start}") val cas1ApplicationStart: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalUrlTemplateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalUrlTemplateController.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.controller.external
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.GetMapping
+
+@Cas1ExternalController
+class Cas1ExternalUrlTemplateController(private val cas1UrlTemplates: Cas1UrlTemplates) {
+  @PreAuthorize("hasRole('APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE')")
+  @GetMapping("/url-templates")
+  fun getCas1Links(): ResponseEntity<Cas1UrlTemplates> = ResponseEntity.ok(cas1UrlTemplates)
+}
+
+@Component
+data class Cas1UrlTemplates(@Value($$"${url-templates.frontend.cas1.application-start}") var cas1ApplicationStart: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/external/Cas3ExternalUrlTemplateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/external/Cas3ExternalUrlTemplateController.kt
@@ -15,5 +15,5 @@ class Cas3ExternalUrlTemplateController(private val cas3UrlTemplates: Cas3UrlTem
 
 @Component
 data class Cas3UrlTemplates(
-  @Value($$"${url-templates.frontend.cas3.referral-start}") var cas3ReferralStart: String,
+  @Value($$"${url-templates.frontend.cas3.referral-start}") val cas3ReferralStart: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/external/Cas3ExternalUrlTemplateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/external/Cas3ExternalUrlTemplateController.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller.external
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.GetMapping
+
+@Cas3ExternalController
+class Cas3ExternalUrlTemplateController(private val cas3UrlTemplates: Cas3UrlTemplates) {
+  @PreAuthorize("hasRole('APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE')")
+  @GetMapping("/url-templates")
+  fun getCas1Links(): ResponseEntity<Cas3UrlTemplates> = ResponseEntity.ok(cas3UrlTemplates)
+}
+
+@Component
+data class Cas3UrlTemplates(
+  @Value($$"${url-templates.frontend.cas3.referral-start}") var cas3ReferralStart: String,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -310,6 +310,7 @@ url-templates:
     assessment: http://localhost:3000/assessments/#id
     booking: http://localhost:3000/premises/#premisesId/bookings/#bookingId
     cas1:
+      application-start: http://localhost:3000/applications/start
       cru-dashboard: http://localhost:3000/admin/cru-dashboard
       cru-open-change-requests: http://localhost:3000/admin/cru-dashboard/change-requests
       space-booking: http://localhost:3000/manage/premises/#premisesId/placements/#bookingId
@@ -324,7 +325,7 @@ url-templates:
       submitted-application-overview: http://localhost:3000/assess/applications/#applicationId/overview
     cas3:
       referral-full: http://localhost:3000/referrals/#applicationId/full
-
+      referral-start: http://localhost:3000/applications/start
 
 preemptive-cache-enabled: true
 preemptive-cache-key-prefix: ""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.external
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.external
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalReferralsTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.external
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.external
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalUrlTemplateControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalUrlTemplateControllerTest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 class Cas1ExternalUrlTemplateControllerTest : IntegrationTestBase() {
 
   @Test
-  fun `Get all referrals returns ok`() {
+  fun `Returns expected cas1 UI template links`() {
     givenAUser { _, _ ->
       givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalUrlTemplateControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalUrlTemplateControllerTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.external
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+
+class Cas1ExternalUrlTemplateControllerTest : IntegrationTestBase() {
+
+  @Test
+  fun `Get all referrals returns ok`() {
+    givenAUser { _, _ ->
+      givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+        webTestClient.get()
+          .uri("/cas1/external/url-templates")
+          .header("Authorization", "Bearer $clientCredentialsJwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .consumeWith { result ->
+            println(String(result.responseBody ?: ByteArray(0)))
+          }
+          .jsonPath("$.cas1ApplicationStart").isEqualTo("http://frontend.cas1/applications/start")
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalUrlTemplateControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalUrlTemplateControllerTest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 class Cas3ExternalUrlTemplateControllerTest : Cas3IntegrationTestBase() {
 
   @Test
-  fun `Get `() {
+  fun `Returns expected cas3 UI template links`() {
     givenAUser { _, _ ->
       givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
         webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalUrlTemplateControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalUrlTemplateControllerTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.external
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.Cas3IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+
+class Cas3ExternalUrlTemplateControllerTest : Cas3IntegrationTestBase() {
+
+  @Test
+  fun `Get `() {
+    givenAUser { _, _ ->
+      givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+        webTestClient.get()
+          .uri("/cas3/external/url-templates")
+          .header("Authorization", "Bearer $clientCredentialsJwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .jsonPath("$.cas3ReferralStart").isEqualTo("http://frontend.cas3/applications/start")
+      }
+    }
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -204,13 +204,15 @@ url-templates:
     application-timeline: http://frontend/applications/#applicationId?tab=timeline
     assessment: http://frontend/assessments/#id
     booking: http://frontend/premises/#premisesId/bookings/#bookingId
+    cas1:
+      application-start: http://frontend.cas1/applications/start
     cas2:
       application: http://cas2.frontend/applications/#id
       application-overview: http://cas2.frontend/applications/#id/overview
       submitted-application-overview: http://cas2.frontend/assess/applications/#applicationId/overview
     cas3:
-      referral-full:  http://frontend.cas3/referrals/#applicationId/full
-
+      referral-full: http://frontend.cas3/referrals/#applicationId/full
+      referral-start: http://frontend.cas3/applications/start
 preemptive-cache-enabled: false
 
 arrived-departed-domain-events-disabled: false


### PR DESCRIPTION
SAS needs to redirect users to CAS endpoints for various application / referral reasons, so this endpoint surfaces them. They will be kept in a long cache in SAS so requests will be minimal.