### PR TITLE
FM-819 Add tierV2 and tierV3

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1RequestsForPlacementDurationsCalculationRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1RequestsForPlacementDurationsCalculationRequestDto.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOp
 
 data class Cas1RequestsForPlacementDurationsCalculationRequestDto(
   val apType: ApType,
-  val tier: Cas1TierDto,
+  val tier: TierDto,
   val isWomensApplication: Boolean,
   val sentenceType: SentenceTypeOption,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/TierDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/TierDto.kt
@@ -2,14 +2,14 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 
 import java.time.LocalDateTime
 
-data class Cas1TierDto(
+data class TierDto(
   val tierScore: String,
   val calculationDate: LocalDateTime,
   val provisional: Boolean? = null,
-  val version: Cas1TierVersionDto,
+  val version: TierVersionDto,
 )
 
-enum class Cas1TierVersionDto {
+enum class TierVersionDto {
   V2,
   V3,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/hmppstier/Tier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/client/hmppstier/Tier.kt
@@ -7,4 +7,5 @@ data class Tier(
   val tierScore: String,
   val calculationId: UUID,
   val calculationDate: LocalDateTime,
+  val changeReason: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/dto/CaseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/dto/CaseDto.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierDto
 import java.time.OffsetDateTime
 
 data class CaseDto(
   var crn: String,
   var nomsNumber: String?,
   var name: String,
-  var tier: String?,
+  var tier: TierDto?,
   val createdAt: OffsetDateTime,
   var lastUpdatedAt: OffsetDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/entity/CaseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/entity/CaseEntity.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.PreUpdate
 import jakarta.persistence.Table
 import jakarta.persistence.Version
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.BackfillCaseSummaryMigrationDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.asHibernateProxy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.getHibernateClass
 import java.time.OffsetDateTime
@@ -71,9 +75,11 @@ data class CaseEntity(
    * will consider any LAO restrictions
    */
   var name: String,
-  var tier: String?,
   val createdAt: OffsetDateTime,
   var lastUpdatedAt: OffsetDateTime,
+  @Column(name = "tier_v2", columnDefinition = "jsonb")
+  @JdbcTypeCode(SqlTypes.JSON)
+  var tierV2: Tier?,
   @Version
   var version: Long = 1,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/entity/model/Tier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/entity/model/Tier.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * JSONB representation stored in cases.tier_v2 and cases.tier_v3
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Tier(
+  val tierScore: String,
+  val calculationId: UUID,
+  val calculationDate: LocalDateTime,
+  val changeReason: String?,
+  val provisional: Boolean? = null,
+  val version: TierVersion,
+)
+
+enum class TierVersion {
+  V2,
+  V3,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/migration/BackfillCasesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/migration/BackfillCasesJob.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClien
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.BackfillCaseSummaryMigrationDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonSummaryInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
@@ -15,6 +17,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Component
+@SuppressWarnings("MaxLineLength")
 class BackfillCasesJob(
   private val caseRepository: CaseRepository,
   private val offenderService: OffenderService,
@@ -96,15 +99,24 @@ class BackfillCasesJob(
         crn = dto.crn,
         name = name,
         nomsNumber = nomsNumber,
-        tier = retrieveTierForCrn(dto),
+        tierV2 = retrieveTierForCrn(dto)?.let {
+          Tier(
+            tierScore = it.tierScore,
+            changeReason = it.changeReason,
+            calculationId = it.calculationId,
+            calculationDate = it.calculationDate,
+            provisional = null,
+            version = TierVersion.V2,
+          )
+        },
         createdAt = now,
         lastUpdatedAt = now,
       ),
     )
   }
 
-  private fun BackfillCasesJob.retrieveTierForCrn(dto: BackfillCaseSummaryMigrationDto): String? = when (val tierResponse = hmppsTierApiClient.getTier(dto.crn)) {
-    is ClientResult.Success -> tierResponse.body.tierScore
+  private fun BackfillCasesJob.retrieveTierForCrn(dto: BackfillCaseSummaryMigrationDto): uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier? = when (val tierResponse = hmppsTierApiClient.getTier(dto.crn)) {
+    is ClientResult.Success -> tierResponse.body
     is ClientResult.Failure -> {
       log.warn("Could not retrieve tier for CRN ${dto.crn}")
       null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
@@ -9,6 +11,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.CaseDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundProblem
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -24,19 +28,30 @@ class CaseService(
   fun ensureCaseExists(crn: String): CaseEntity {
     val caseSummary = getCaseSummary(crn)
     val riskTier = getRiskTierOrNull(crn)
-    val caseEntity = caseRepository.findByCrn(caseSummary.crn)?.apply {
-      name = "${caseSummary.name.forename.uppercase()} ${caseSummary.name.surname.uppercase()}".trim()
-      tier = riskTier
+
+    val fullName =
+      "${caseSummary.name.forename} ${caseSummary.name.surname}"
+        .uppercase()
+        .trim()
+
+    fun toTier() = riskTier?.toTier()
+
+    val existing = caseRepository.findByCrn(caseSummary.crn)
+
+    val caseEntity = existing?.apply {
+      name = fullName
       nomsNumber = caseSummary.nomsId
+      tierV2 = toTier()
     } ?: CaseEntity(
       id = UUID.randomUUID(),
       crn = caseSummary.crn,
-      name = "${caseSummary.name.forename.uppercase()} ${caseSummary.name.surname.uppercase()}".trim(),
-      tier = riskTier,
+      name = fullName,
       nomsNumber = caseSummary.nomsId,
       createdAt = OffsetDateTime.now(),
       lastUpdatedAt = OffsetDateTime.now(),
+      tierV2 = toTier(),
     )
+
     return caseRepository.saveAndFlush(caseEntity)
   }
 
@@ -45,33 +60,46 @@ class CaseService(
       crn = it.crn,
       nomsNumber = it.nomsNumber,
       name = it.name,
-      tier = it.tier,
       createdAt = it.createdAt,
       lastUpdatedAt = it.lastUpdatedAt,
+      tier = it.tierV2?.let {
+        TierDto(
+          tierScore = it.tierScore,
+          calculationDate = it.calculationDate,
+          provisional = it.provisional,
+          version = TierVersionDto.valueOf(it.version.name),
+        )
+      },
     )
   }
 
   fun reviseTier(crn: String): Boolean {
-    val case = caseRepository.findByCrn(crn)
-
-    if (case == null) {
-      return false
-    }
+    val case = caseRepository.findByCrn(crn) ?: return false
 
     val tier = when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
-      is ClientResult.Success -> tierResponse.body.tierScore
+      is ClientResult.Success -> tierResponse.body
       is ClientResult.Failure -> throw tierResponse.toException()
     }
 
-    case.tier = tier
+    case.tierV2 = tier.toTier()
+
     caseRepository.save(case)
 
     log.info("Have updated tier for $crn to $tier")
     return true
   }
 
-  private fun getRiskTierOrNull(crn: String): String? = when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
-    is ClientResult.Success -> tierResponse.body.tierScore
+  private fun uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier.toTier() = Tier(
+    tierScore = tierScore,
+    calculationId = calculationId,
+    calculationDate = calculationDate,
+    changeReason = changeReason,
+    provisional = null,
+    version = TierVersion.V2,
+  )
+
+  private fun getRiskTierOrNull(crn: String): uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier? = when (val tierResponse = hmppsTierApiClient.getTier(crn)) {
+    is ClientResult.Success -> tierResponse.body
     is ClientResult.Failure -> null
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationRequestDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
@@ -47,7 +47,7 @@ class Cas1RequestForPlacementService(
   fun defaultDurations(
     requestDto: Cas1RequestsForPlacementDurationsCalculationRequestDto,
   ): CasResult<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
-    if (requestDto.tier.version == Cas1TierVersionDto.V3) return CasResult.GeneralValidationError("Tier version V3 is not supported for duration calculations")
+    if (requestDto.tier.version == TierVersionDto.V3) return CasResult.GeneralValidationError("Tier version V3 is not supported for duration calculations")
     val responseDto = when (requestDto.apType) {
       ApType.pipe -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null)
       ApType.esap -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(52).days, maxDurationDays = null)

--- a/src/main/resources/db/migration/all/20260703132923__add_tier2_tier3_to_case.sql
+++ b/src/main/resources/db/migration/all/20260703132923__add_tier2_tier3_to_case.sql
@@ -1,0 +1,6 @@
+ALTER TABLE cases DROP COLUMN tier;
+
+ALTER TABLE cases
+ADD COLUMN tier_v2 jsonb,
+ADD COLUMN tier_v3 jsonb;
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/factory/Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/factory/Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory.kt
@@ -5,11 +5,12 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationRequestDto
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
 
 class Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory : Factory<Cas1RequestsForPlacementDurationsCalculationRequestDto> {
   private var apType: Yielded<ApType> = { ApType.normal }
-  private var tier: Yielded<Cas1TierDto> = { Cas1TierDtoFactory().produce() }
+  private var tier: Yielded<TierDto> = { TierDtoFactory().produce() }
   private var isWomensApplication: Yielded<Boolean> = { false }
   private var sentenceType: Yielded<SentenceTypeOption> = { SentenceTypeOption.standardDeterminate }
 
@@ -17,7 +18,7 @@ class Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory : Factory<Ca
     this.apType = { apType }
   }
 
-  fun withTier(tier: Cas1TierDto) = apply {
+  fun withTier(tier: TierDto) = apply {
     this.tier = { tier }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ValidationError
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1TierDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
@@ -39,7 +39,7 @@ class Cas1RequestsForPlacementIT : IntegrationTestBase() {
 
       val requestDto = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory()
         .withApType(ApType.mhapElliottHouse)
-        .withTier(Cas1TierDtoFactory().withVersion(Cas1TierVersionDto.V3).produce())
+        .withTier(TierDtoFactory().withVersion(TierVersionDto.V3).produce())
         .produce()
 
       val response = webTestClient.post()
@@ -63,7 +63,7 @@ class Cas1RequestsForPlacementIT : IntegrationTestBase() {
 
       val requestDto = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory()
         .withApType(ApType.mhapElliottHouse)
-        .withTier(Cas1TierDtoFactory().withVersion(Cas1TierVersionDto.V2).produce())
+        .withTier(TierDtoFactory().withVersion(TierVersionDto.V2).produce())
         .produce()
 
       val response = webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/TierDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/TierDtoFactory.kt
@@ -1,23 +1,23 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierDto
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
 import java.time.LocalDateTime
 
-class Cas1TierDtoFactory : Factory<Cas1TierDto> {
+class TierDtoFactory : Factory<TierDto> {
   private var tierScore: Yielded<String> = { randomStringLowerCase(8) }
   private var calculationDate: Yielded<LocalDateTime> = { LocalDateTime.now() }
   private var provisional: Yielded<Boolean?> = { null }
-  private var version: Yielded<Cas1TierVersionDto> = { Cas1TierVersionDto.V2 }
+  private var version: Yielded<TierVersionDto> = { TierVersionDto.V2 }
 
-  fun withVersion(version: Cas1TierVersionDto) = apply {
+  fun withVersion(version: TierVersionDto) = apply {
     this.version = { version }
   }
 
-  override fun produce(): Cas1TierDto = Cas1TierDto(
+  override fun produce(): TierDto = TierDto(
     tierScore = this.tierScore(),
     calculationDate = this.calculationDate(),
     provisional = this.provisional(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/TierCalculationChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/TierCalculationChangedTest.kt
@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.InboxEventDispatcher
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.listener.TierCalculationChangedHandler.Companion.TIER_CALCULATION_EVENT_TYPE
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.HmppsDomainEventFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock404TierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock500TierCall
@@ -45,15 +46,18 @@ class TierCalculationChangedTest : IntegrationTestBase() {
   fun `case exists, update tier, inbox event is PROCESSED`() {
     caseEntityFactory.produceAndPersist {
       withCrn(CRN)
-      withTier(OLD_TIER)
+      withTierV2(
+        TierFactory().withTierScore(OLD_TIER).produce(),
+      )
     }
 
     hmppsTierMockSuccessfulTierCall(
       CRN,
-      Tier(
+      uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier(
         tierScore = NEW_TIER,
         calculationId = UUID.randomUUID(),
         calculationDate = LocalDateTime.now(),
+        changeReason = "reason",
       ),
     )
 
@@ -65,7 +69,7 @@ class TierCalculationChangedTest : IntegrationTestBase() {
 
     inboxAsserter.assertProcessedCount(1)
 
-    assertThat(caseService.getCase(CRN)!!.tier).isEqualTo(NEW_TIER)
+    assertThat(caseService.getCase(CRN)!!.tier!!.tierScore).isEqualTo(NEW_TIER)
   }
 
   @Test
@@ -83,7 +87,11 @@ class TierCalculationChangedTest : IntegrationTestBase() {
   fun `case exists, tier not found, alert, inbox event is FAILED`() {
     caseEntityFactory.produceAndPersist {
       withCrn(CRN)
-      withTier(OLD_TIER)
+      withTierV2(
+        TierFactory()
+          .withTierScore(OLD_TIER)
+          .produce(),
+      )
     }
 
     hmppsTierMock404TierCall(CRN)
@@ -101,7 +109,11 @@ class TierCalculationChangedTest : IntegrationTestBase() {
   fun `case exists, upstream error, FAILED`() {
     caseEntityFactory.produceAndPersist {
       withCrn(CRN)
-      withTier(OLD_TIER)
+      withTierV2(
+        TierFactory()
+          .withTierScore(OLD_TIER)
+          .produce(),
+      )
     }
 
     hmppsTierMock500TierCall(CRN)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseDtoFactory.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.CaseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -12,14 +14,14 @@ class CaseDtoFactory : Factory<CaseDto> {
   private var crn: Yielded<String> = { randomStringUpperCase(7) }
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
-  private var tier: Yielded<String?> = { listOf("A", "B", "C", "D").random() }
+  private var tier: Yielded<TierDto?> = { TierDtoFactory().produce() }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(randomInt(0, 365).toLong()) }
   private var lastUpdatedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
 
   fun withCrn(crn: String) = apply { this.crn = { crn } }
   fun withNomsNumber(nomsNumber: String?) = apply { this.nomsNumber = { nomsNumber } }
   fun withName(name: String) = apply { this.name = { name } }
-  fun withTier(tier: String?) = apply { this.tier = { tier } }
+  fun withTier(tier: TierDto?) = apply { this.tier = { tier } }
   fun withCreatedAt(createdAt: OffsetDateTime) = apply { this.createdAt = { createdAt } }
   fun withLastUpdatedAt(lastUpdatedAt: OffsetDateTime) = apply { this.lastUpdatedAt = { lastUpdatedAt } }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/CaseEntityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomInt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringUpperCase
@@ -14,7 +15,7 @@ class CaseEntityFactory : Factory<CaseEntity> {
   private var crn: Yielded<String> = { randomStringUpperCase(7) }
   private var nomsNumber: Yielded<String?> = { randomStringUpperCase(6) }
   private var name: Yielded<String> = { randomStringMultiCaseWithNumbers(10) }
-  private var tier: Yielded<String?> = { listOf("A", "B", "C", "D").random() }
+  private var tierV2: Yielded<Tier?> = { TierFactory().produce() }
   private var createdAt: Yielded<OffsetDateTime> = { OffsetDateTime.now().minusDays(randomInt(0, 365).toLong()) }
   private var lastUpdatedAt: Yielded<OffsetDateTime> = { OffsetDateTime.now() }
   private var version: Yielded<Long> = { 1L }
@@ -23,7 +24,7 @@ class CaseEntityFactory : Factory<CaseEntity> {
   fun withCrn(crn: String) = apply { this.crn = { crn } }
   fun withNomsNumber(nomsNumber: String?) = apply { this.nomsNumber = { nomsNumber } }
   fun withName(name: String) = apply { this.name = { name } }
-  fun withTier(tier: String?) = apply { this.tier = { tier } }
+  fun withTierV2(tierV2: Tier?) = apply { this.tierV2 = { tierV2 } }
   fun withCreatedAt(createdAt: OffsetDateTime) = apply { this.createdAt = { createdAt } }
   fun withLastUpdatedAt(lastUpdatedAt: OffsetDateTime) = apply { this.lastUpdatedAt = { lastUpdatedAt } }
   fun withVersion(version: Long) = apply { this.version = { version } }
@@ -33,7 +34,7 @@ class CaseEntityFactory : Factory<CaseEntity> {
     crn = this.crn(),
     nomsNumber = this.nomsNumber(),
     name = this.name(),
-    tier = this.tier(),
+    tierV2 = this.tierV2(),
     createdAt = this.createdAt(),
     lastUpdatedAt = this.lastUpdatedAt(),
     version = this.version(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TierFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/TierFactory.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringLowerCase
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TierFactory : Factory<Tier> {
+  private var tierScore: Yielded<String> = { randomStringLowerCase(8) }
+  private var calculationDate: Yielded<LocalDateTime> = { LocalDateTime.now() }
+  private var calculationId: Yielded<UUID> = { UUID.randomUUID() }
+  private var provisional: Yielded<Boolean?> = { null }
+  private var version: Yielded<TierVersion> = { TierVersion.V2 }
+  private var changeReason: Yielded<String?> = { null }
+
+  fun withVersion(version: TierVersion) = apply {
+    this.version = { version }
+  }
+
+  fun withTierScore(tierScore: String) = apply {
+    this.tierScore = { tierScore }
+  }
+
+  fun withChangeReason(changeReason: String) = apply {
+    this.changeReason = { changeReason }
+  }
+
+  fun withCalculationDate(calculationDate: LocalDateTime) = apply {
+    this.calculationDate = { calculationDate }
+  }
+  fun withCalculationId(calculationId: UUID) = apply {
+    this.calculationId = { calculationId }
+  }
+  fun withProvisional(provisional: Boolean) = apply {
+    this.provisional = { provisional }
+  }
+
+  override fun produce(): Tier = Tier(
+    tierScore = this.tierScore(),
+    calculationDate = this.calculationDate(),
+    provisional = this.provisional(),
+    version = this.version(),
+    calculationId = this.calculationId(),
+    changeReason = this.changeReason(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
@@ -564,7 +564,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
         )
         .produce()
       val roshRatings = RoshRatingsFactory().produce()
-      val tier = Tier(tierScore = "A1", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now())
+      val tier = Tier(tierScore = "A1", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "Change Reason")
       val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
       givenAnOffender { offenderDetails, _ ->
         apDeliusContextMockSuccessfulCaseDetailCall(offenderDetails.otherIds.crn, caseDetail)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/BackfillCasesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/BackfillCasesJobTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
@@ -65,26 +66,26 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
 
     apDeliusContextAddListCaseSummaryToBulkResponse(listOf(case1, case2, case3))
 
-    hmppsTierMockSuccessfulTierCall("CRN1", Tier("A1", UUID.randomUUID(), LocalDateTime.now()))
-    hmppsTierMockSuccessfulTierCall("CRN2", Tier("B2", UUID.randomUUID(), LocalDateTime.now()))
-    hmppsTierMockSuccessfulTierCall("CRN3", Tier("C3", UUID.randomUUID(), LocalDateTime.now()))
+    hmppsTierMockSuccessfulTierCall("CRN1", Tier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
+    hmppsTierMockSuccessfulTierCall("CRN2", Tier("B2", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason2"))
+    hmppsTierMockSuccessfulTierCall("CRN3", Tier("C3", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason3"))
 
     migrationJobService.runMigrationJob(MigrationJobType.backfillCases, 10)
 
     val c1 = caseRepository.findByCrn("CRN1")!!
     assertThat(c1.name).isEqualTo("DELIUS ONE")
     assertThat(c1.nomsNumber).isEqualTo("NOMS1")
-    assertThat(c1.tier).isEqualTo("A1")
+    assertThat(c1.tierV2!!.tierScore).isEqualTo("A1")
 
     val c2 = caseRepository.findByCrn("CRN2")!!
     assertThat(c2.name).isEqualTo("DELIUS TWO")
     assertThat(c2.nomsNumber).isEqualTo("NOMS2")
-    assertThat(c2.tier).isEqualTo("B2")
+    assertThat(c2.tierV2!!.tierScore).isEqualTo("B2")
 
     val c3 = caseRepository.findByCrn("CRN3")!!
     assertThat(c3.name).isEqualTo("DELIUS THREE")
     assertThat(c3.nomsNumber).isEqualTo("NOMS3")
-    assertThat(c3.tier).isEqualTo("C3")
+    assertThat(c3.tierV2!!.tierScore).isEqualTo("C3")
   }
 
   @Test
@@ -101,7 +102,7 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
         crn = "EXISTING_CRN",
         name = "Existing Name",
         nomsNumber = "NOMS_EXISTING",
-        tier = "B1",
+        tierV2 = uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier("B1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1", version = TierVersion.V2),
         createdAt = java.time.OffsetDateTime.now(),
         lastUpdatedAt = java.time.OffsetDateTime.now(),
       ),
@@ -119,7 +120,7 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
 
     val caseNew = CaseSummaryFactory().withCrn("NEW_CRN").withName(NameFactory().withForename("New").withSurname("Name").produce()).withNomsId("NOMS_NEW").produce()
     apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseNew))
-    hmppsTierMockSuccessfulTierCall("NEW_CRN", Tier("A1", UUID.randomUUID(), LocalDateTime.now()))
+    hmppsTierMockSuccessfulTierCall("NEW_CRN", Tier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
 
     migrationJobService.runMigrationJob(MigrationJobType.backfillCases, 10)
 
@@ -148,13 +149,13 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
 
     apDeliusContextMockUnsuccessfulCaseSummaryCall(500)
 
-    hmppsTierMockSuccessfulTierCall("CRN_FALLBACK", Tier("D4", UUID.randomUUID(), LocalDateTime.now()))
+    hmppsTierMockSuccessfulTierCall("CRN_FALLBACK", Tier("D4", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason 2"))
 
     migrationJobService.runMigrationJob(MigrationJobType.backfillCases, 10)
 
     val c = caseRepository.findByCrn("CRN_FALLBACK")!!
     assertThat(c.name).isEqualTo("PERSISTED NAME")
     assertThat(c.nomsNumber).isEqualTo("NOMS_PERSISTED")
-    assertThat(c.tier).isEqualTo("D4")
+    assertThat(c.tierV2!!.tierScore).isEqualTo("D4")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderRisksServiceTest.kt
@@ -135,6 +135,7 @@ class OffenderRisksServiceTest {
         tierScore = "M2",
         calculationId = UUID.randomUUID(),
         calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+        changeReason = null,
       ),
     )
 
@@ -202,6 +203,7 @@ class OffenderRisksServiceTest {
         tierScore = "M2",
         calculationId = UUID.randomUUID(),
         calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+        changeReason = "reason",
       ),
     )
 
@@ -289,6 +291,7 @@ class OffenderRisksServiceTest {
         tierScore = "M2",
         calculationId = UUID.randomUUID(),
         calculationDate = LocalDateTime.parse("2022-09-06T14:59:00"),
+        changeReason = "reason",
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -29,6 +29,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -71,6 +73,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.Clock
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -169,7 +172,7 @@ class Cas1ApplicationCreationServiceTest {
         crn = "CRN345",
         name = "name",
         nomsNumber = "nomsNo",
-        tier = "level",
+        tierV2 = Tier(tierScore = "level", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason", version = TierVersion.V2),
         id = cas1OffenderEntityId,
         createdAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
         lastUpdatedAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -16,9 +16,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.factory.Cas1TierDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
@@ -306,7 +306,7 @@ class Cas1RequestForPlacementServiceTest {
     @Test
     fun `returns error when tier version is v3`() {
       val request = Cas1RequestsForPlacementDurationsCalculationRequestDtoFactory().withApType(ApType.esap).withTier(
-        Cas1TierDtoFactory().withVersion(Cas1TierVersionDto.V3).produce(),
+        TierDtoFactory().withVersion(TierVersionDto.V3).produce(),
       ).produce()
 
       val result = cas1RequestForPlacementService.defaultDurations(request)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ManagerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -40,7 +41,6 @@ class CaseServiceTest {
       .withCrn(crn)
       .withName("NAME")
       .withNomsNumber("NOMS123")
-      .withTier("tier")
       .produce()
 
     val caseSummary = CaseSummary(
@@ -76,6 +76,7 @@ class CaseServiceTest {
         tierScore = "low",
         calculationId = UUID.randomUUID(),
         calculationDate = LocalDateTime.now(),
+        changeReason = "reason",
       ),
       status = HttpStatus.OK,
     )
@@ -92,7 +93,7 @@ class CaseServiceTest {
       .withCrn(crn)
       .withName("NAME")
       .withNomsNumber("NOMS123")
-      .withTier("tier")
+      .withTierV2(TierFactory().withTierScore("tier").produce())
       .produce()
 
     val caseSummary = CaseSummary(
@@ -127,6 +128,7 @@ class CaseServiceTest {
         tierScore = "tier",
         calculationId = UUID.randomUUID(),
         calculationDate = LocalDateTime.now(),
+        changeReason = "reason",
       ),
       status = HttpStatus.OK,
     )
@@ -142,7 +144,7 @@ class CaseServiceTest {
       .withCrn(crn)
       .withName("NAME")
       .withNomsNumber("NOMS123")
-      .withTier(null)
+      .withTierV2(null)
       .produce()
 
     val caseSummary = CaseSummary(


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/FM-819

 Removed the `tier` column and added `tierV2` and `tierV3` columns.
 Removed `tier` from the case entity and added `tierV2`.
 Refactored the code to remove `tier` references and populate `tierV2` data.

