### PR TITLE
FM-851 Refactor `getRoshRisksEnvelope` to use `OffenderRisksService` in `Cas2HdcOffenderService`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcOffenderService.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApAndOASysClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
@@ -23,8 +22,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import java.util.stream.Collectors
 
@@ -44,8 +43,8 @@ import java.util.stream.Collectors
 class Cas2HdcOffenderService(
   private val prisonsApiClient: PrisonsApiClient,
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
-  private val apAndOASysClient: ApAndOASysClient,
   private val offenderDetailsDataSource: OffenderDetailsDataSource,
+  private val offenderRisksService: OffenderRisksService,
   @Value("\${cas2.crn-search-limit:400}") private val numberOfCrn: Int,
 ) {
 
@@ -264,7 +263,7 @@ class Cas2HdcOffenderService(
       val risks = PersonRisks(
         // Note that Tier, Mappa and Flags are all hardcoded to NotFound
         // and these unused 'envelopes' will be removed.
-        roshRisks = getRoshRisksEnvelope(crn),
+        roshRisks = offenderRisksService.getRoshRisksEnvelope(crn),
         mappa = RiskWithStatus(status = RiskStatus.NotFound),
         tier = RiskWithStatus(status = RiskStatus.NotFound),
         flags = RiskWithStatus(status = RiskStatus.NotFound),
@@ -272,51 +271,6 @@ class Cas2HdcOffenderService(
 
       AuthorisableActionResult.Success(
         risks,
-      )
-    }
-  }
-
-  private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> {
-    when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
-      is ClientResult.Success -> {
-        val summary = roshRisksResponse.body.rosh
-
-        if (summary.anyRisksAreNull()) {
-          return RiskWithStatus(
-            status = RiskStatus.NotFound,
-            value = null,
-          )
-        }
-
-        return RiskWithStatus(
-          status = RiskStatus.Retrieved,
-          value = RoshRisks(
-            overallRisk = summary.determineOverallRiskLevel().text,
-            riskToChildren = summary.riskChildrenCommunity!!.text,
-            riskToPublic = summary.riskPublicCommunity!!.text,
-            riskToKnownAdult = summary.riskKnownAdultCommunity!!.text,
-            riskToStaff = summary.riskStaffCommunity!!.text,
-            lastUpdated = roshRisksResponse.body.dateCompleted?.toLocalDate()
-              ?: roshRisksResponse.body.initiationDate.toLocalDate(),
-          ),
-        )
-      }
-
-      is ClientResult.Failure.StatusCode -> return if (roshRisksResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
-        RiskWithStatus(
-          status = RiskStatus.NotFound,
-          value = null,
-        )
-      } else {
-        RiskWithStatus(
-          status = RiskStatus.Error,
-          value = null,
-        )
-      }
-
-      is ClientResult.Failure -> return RiskWithStatus(
-        status = RiskStatus.Error,
-        value = null,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
@@ -37,7 +37,7 @@ class OffenderRisksService(
     )
   }
 
-  private fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> = when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
+  fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> = when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
     is ClientResult.Success -> {
       val summary = roshRisksResponse.body.rosh
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderRisksService.kt
@@ -37,7 +37,7 @@ class OffenderRisksService(
     )
   }
 
-  fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> = when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
+  internal fun getRoshRisksEnvelope(crn: String): RiskWithStatus<RoshRisks> = when (val roshRisksResponse = apAndOASysClient.getRoshRatings(crn)) {
     is ClientResult.Success -> {
       val summary = roshRisksResponse.body.rosh
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonRisksTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class Cas2PersonRisksTest : IntegrationTestBase() {
@@ -77,12 +76,13 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
 
   @Test
   fun `Getting risks for a CRN returns OK with correct body`() {
+    val dateTimeCompleted = OffsetDateTime.now().minusMonths(1)
     givenACas2PomUser { userEntity, jwt ->
       givenAnOffender { offenderDetails, inmateDetails ->
         apAndOASysMockSuccessfulRoshRatingsCall(
           offenderDetails.otherIds.crn,
           RoshRatingsFactory().apply {
-            withDateCompleted(OffsetDateTime.parse("2022-09-06T15:15:15Z"))
+            withDateCompleted(dateTimeCompleted)
             withAssessmentId(34853487)
             withRiskChildrenCommunity(RiskLevel.LOW)
             withRiskPublicCommunity(RiskLevel.MEDIUM)
@@ -110,7 +110,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
                     riskToPublic = "Medium",
                     riskToKnownAdult = "High",
                     riskToStaff = "Very High",
-                    lastUpdated = LocalDate.parse("2022-09-06"),
+                    lastUpdated = dateTimeCompleted.toLocalDate(),
                   ),
                 ),
                 tier = RiskTierEnvelopeDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/Cas2OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/Cas2OffenderServiceTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult.Failure.StatusCode
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummaries
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.AssignedLivingUnit
@@ -30,11 +29,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.OffenderD
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
 import java.time.LocalDate
-import java.time.OffsetDateTime
 
 @SuppressWarnings("UnusedPrivateProperty")
 class Cas2OffenderServiceTest {
@@ -42,12 +42,13 @@ class Cas2OffenderServiceTest {
   private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
   private val mockApOASysContextApiClient = mockk<ApAndOASysClient>()
   private val mockOffenderDetailsDataSource = mockk<OffenderDetailsDataSource>()
+  private val mockOffenderRisksService = mockk<OffenderRisksService>()
 
   private val offenderService = Cas2HdcOffenderService(
     mockPrisonsApiClient,
     mockApDeliusContextApiClient,
-    mockApOASysContextApiClient,
     mockOffenderDetailsDataSource,
+    offenderRisksService = mockOffenderRisksService,
     2,
   )
 
@@ -78,6 +79,8 @@ class Cas2OffenderServiceTest {
       mockExistingNonLaoOffender()
       mock404RoSH(crn)
 
+      every { mockOffenderRisksService.getRoshRisksEnvelope(crn) } returns RiskWithStatus(status = RiskStatus.NotFound)
+
       val result = offenderService.getRiskByCrn(crn)
       assertThat(result is AuthorisableActionResult.Success).isTrue
       result as AuthorisableActionResult.Success
@@ -93,7 +96,8 @@ class Cas2OffenderServiceTest {
       val crn = "a-crn"
 
       mockExistingNonLaoOffender()
-      mock500RoSH(crn)
+
+      every { mockOffenderRisksService.getRoshRisksEnvelope(crn) } returns RiskWithStatus(status = RiskStatus.Error)
 
       val result = offenderService.getRiskByCrn(crn)
       assertThat(result is AuthorisableActionResult.Success).isTrue
@@ -111,17 +115,16 @@ class Cas2OffenderServiceTest {
 
       mockExistingNonLaoOffender()
 
-      mock200RoSH(
-        crn,
-        RoshRatingsFactory().apply {
-          withDateCompleted(OffsetDateTime.parse("2022-09-06T13:45:00Z"))
-          withAssessmentId(34853487)
-          withRiskChildrenCommunity(RiskLevel.LOW)
-          withRiskPublicCommunity(RiskLevel.MEDIUM)
-          withRiskKnownAdultCommunity(RiskLevel.HIGH)
-          withRiskStaffCommunity(RiskLevel.VERY_HIGH)
-        }.produce(),
+      val riskStatus = RoshRisks(
+        overallRisk = "Very High",
+        riskToChildren = "Low",
+        riskToPublic = "Medium",
+        riskToKnownAdult = "High",
+        riskToStaff = "Very High",
+        lastUpdated = LocalDate.parse("2022-09-06"),
       )
+
+      every { mockOffenderRisksService.getRoshRisksEnvelope(crn) } returns RiskWithStatus(value = riskStatus)
 
       val result = offenderService.getRiskByCrn(crn)
       assertThat(result is AuthorisableActionResult.Success).isTrue


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/FM-851:

Refactor `getRoshRisksEnvelope` to use `OffenderRisksService` in `Cas2HdcOffenderService` and update tests accordingly.