### PR TITLE
Update Gradle Spring Boot plugin to version 10.5.4.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.4"
   kotlin("plugin.spring") version "2.4.0"
   kotlin("plugin.jpa") version "2.4.0"
   id("dev.detekt") version "2.0.0-alpha.5"


### PR DESCRIPTION
[Kotlin template](https://github.com/ministryofjustice/hmpps-template-kotlin/blob/e3a9f5a6fd2232e166218560a9a84aeaab566383/build.gradle.kts#L2) uses spring boot plugin version 10.5.4, we currently user version 10.5.3.

Spring boot plugin version 10.5.4 also pins tomcat version to 11.0.23 (was 11.0.22) see https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/10.x.md#upgrade-tomcat-to-11023

Critical vulnerabilities associated with using Tomcat version 11.0.22 will also therefore be resolved as a result of this upgrade.

**CVE-2026-55276** - CRITICAL (9.1) - critical severity - CVE-2026-55276 Always-Incorrect Control Flow Implementation vulnerability

**Solution - upgrade Tomcat.  Users are recommended to upgrade to version 11.0.23, 10.1.56 or 9.0.119 which fixes the issue.  https://nvd.nist.gov/vuln/detail/CVE-2026-55276**


**CVE-2026-53434** - CRITICAL (9.1) - critical severity - CVE-2026-53434 Detection of Error Condition Without Action vulnerability

**Solution - upgrade Tomcat.  Users are recommended to upgrade to version 11.0.23, 10.1.56 or 9.0.119, which fixes the issue.  https://nvd.nist.gov/vuln/detail/CVE-2026-53434**