### PR TITLE
FM-848 Rename Cas3v2ConfirmationEntity and Repository

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/Cas3BookingEntity.kt
@@ -22,7 +22,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -53,7 +53,7 @@ data class Cas3BookingEntity(
   @Fetch(FetchMode.SUBSELECT)
   var cancellations: MutableList<Cas3CancellationEntity>,
   @OneToOne(mappedBy = "booking", fetch = FetchType.LAZY)
-  var confirmation: Cas3v2ConfirmationEntity?,
+  var confirmation: Cas3ConfirmationEntity?,
   @OneToOne
   @JoinColumn(name = "application_id")
   var application: ApplicationEntity?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/v2/Cas3ConfirmationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/jpa/entity/v2/Cas3ConfirmationEntity.kt
@@ -14,11 +14,11 @@ import java.util.Objects
 import java.util.UUID
 
 @Repository
-interface Cas3v2ConfirmationRepository : JpaRepository<Cas3v2ConfirmationEntity, UUID>
+interface Cas3ConfirmationRepository : JpaRepository<Cas3ConfirmationEntity, UUID>
 
 @Entity
 @Table(name = "cas3_confirmations")
-data class Cas3v2ConfirmationEntity(
+data class Cas3ConfirmationEntity(
   @Id
   val id: UUID,
   val dateTime: OffsetDateTime,
@@ -31,7 +31,7 @@ data class Cas3v2ConfirmationEntity(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is Cas3v2ConfirmationEntity) return false
+    if (other !is Cas3ConfirmationEntity) return false
 
     if (id != other.id) return false
     if (dateTime != other.dateTime) return false
@@ -43,5 +43,5 @@ data class Cas3v2ConfirmationEntity(
 
   override fun hashCode() = Objects.hash(dateTime, notes, createdAt)
 
-  override fun toString() = "Cas3v2ConfirmationEntity:$id"
+  override fun toString() = "Cas3ConfirmationEntity:$id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/v2/Cas3v2BookingService.kt
@@ -21,8 +21,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Over
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
@@ -64,7 +64,7 @@ class Cas3v2BookingService(
   private val offenderService: OffenderService,
   private val cas3DomainEventService: Cas3v2DomainEventService,
   private val cas3VoidBedspacesRepository: Cas3VoidBedspacesRepository,
-  private val cas3v2ConfirmationRepository: Cas3v2ConfirmationRepository,
+  private val cas3ConfirmationRepository: Cas3ConfirmationRepository,
   private val cas3ExtensionRepository: Cas3ExtensionRepository,
   private val cas3OverstayRepository: Cas3OverstayRepository,
   private val workingDayService: WorkingDayService,
@@ -379,13 +379,13 @@ class Cas3v2BookingService(
     dateTime: OffsetDateTime,
     notes: String?,
     user: UserEntity,
-  ) = validatedCasResult<Cas3v2ConfirmationEntity> {
+  ) = validatedCasResult<Cas3ConfirmationEntity> {
     if (booking.confirmation != null) {
-      return CasResult.GeneralValidationError<Cas3v2ConfirmationEntity>("This Booking already has a Confirmation set")
+      return CasResult.GeneralValidationError<Cas3ConfirmationEntity>("This Booking already has a Confirmation set")
     }
 
-    val cas3ConfirmationEntity = cas3v2ConfirmationRepository.save(
-      Cas3v2ConfirmationEntity(
+    val cas3ConfirmationEntity = cas3ConfirmationRepository.save(
+      Cas3ConfirmationEntity(
         id = UUID.randomUUID(),
         dateTime = dateTime,
         notes = notes,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3ConfirmationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3ConfirmationTransformer.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer
 
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Confirmation
 
 @Component
 class Cas3ConfirmationTransformer {
 
-  fun transformJpaToApi(jpa: Cas3v2ConfirmationEntity?) = jpa?.let {
+  fun transformJpaToApi(jpa: Cas3ConfirmationEntity?) = jpa?.let {
     Cas3Confirmation(
       id = it.id,
       bookingId = it.booking.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BookingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3BookingEntityFactory.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Exte
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3OverstayEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
@@ -38,7 +38,7 @@ class Cas3BookingEntityFactory : Factory<Cas3BookingEntity> {
   private var departures: Yielded<MutableList<Cas3DepartureEntity>>? = null
   private var nonArrival: Yielded<Cas3NonArrivalEntity>? = null
   private var cancellations: Yielded<MutableList<Cas3CancellationEntity>>? = null
-  private var confirmation: Yielded<Cas3v2ConfirmationEntity>? = null
+  private var confirmation: Yielded<Cas3ConfirmationEntity>? = null
   private var extensions: Yielded<MutableList<Cas3ExtensionEntity>>? = null
   private var overstays: Yielded<MutableList<Cas3OverstayEntity>>? = null
   private var dateChanges: Yielded<MutableList<DateChangeEntity>>? = null
@@ -109,11 +109,11 @@ class Cas3BookingEntityFactory : Factory<Cas3BookingEntity> {
     this.cancellations = { cancellations }
   }
 
-  fun withYieldedConfirmation(confirmation: Yielded<Cas3v2ConfirmationEntity>) = apply {
+  fun withYieldedConfirmation(confirmation: Yielded<Cas3ConfirmationEntity>) = apply {
     this.confirmation = confirmation
   }
 
-  fun withConfirmation(confirmation: Cas3v2ConfirmationEntity) = apply {
+  fun withConfirmation(confirmation: Cas3ConfirmationEntity) = apply {
     this.confirmation = { confirmation }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3ConfirmationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/factory/Cas3ConfirmationEntityFactory.kt
@@ -1,15 +1,15 @@
-package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class Cas3v2ConfirmationEntityFactory : Factory<Cas3v2ConfirmationEntity> {
+class Cas3ConfirmationEntityFactory : Factory<Cas3ConfirmationEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
   private var dateTime: Yielded<OffsetDateTime> = { OffsetDateTime.now().randomDateTimeBefore(14) }
   private var notes: Yielded<String> = { randomStringMultiCaseWithNumbers(20) }
@@ -37,7 +37,7 @@ class Cas3v2ConfirmationEntityFactory : Factory<Cas3v2ConfirmationEntity> {
   }
 
   @Suppress("TooGenericExceptionThrown")
-  override fun produce() = Cas3v2ConfirmationEntity(
+  override fun produce() = Cas3ConfirmationEntity(
     id = this.id(),
     notes = this.notes(),
     dateTime = this.dateTime(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/MigrateBookingStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/MigrateBookingStatusTest.kt
@@ -242,7 +242,7 @@ class MigrateBookingStatusTest : MigrationJobTestBase() {
 
   private fun createCAS3ConfirmedBooking(userEntity: UserEntity): Cas3BookingEntity {
     val booking = createCas3Booking(userEntity, null)
-    booking.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+    booking.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
       withBooking(booking)
     }
     return booking

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceOccupancyReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceOccupancyReportTest.kt
@@ -626,7 +626,7 @@ class Cas3v2BedspaceOccupancyReportTest : IntegrationTestBase() {
           withDepartureDate(LocalDate.parse("2023-04-10"))
         }
 
-        cas3v2ConfirmationEntityFactory.produceAndPersist {
+        cas3ConfirmationEntityFactory.produceAndPersist {
           withBooking(booking)
         }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingSearchTest.kt
@@ -424,7 +424,7 @@ class Cas3v2BookingSearchTest : IntegrationTestBase() {
                 withStatus(Cas3BookingStatus.confirmed)
                 withServiceName(ServiceName.temporaryAccommodation)
               }
-              val confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+              val confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
                 withBooking(booking)
               }
               booking.confirmation = confirmation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
@@ -2068,7 +2068,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(20),
           )
           bookingFour.let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2098,7 +2098,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(40),
           )
           bookingFive.let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2122,7 +2122,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(90),
             reportEndDate.plusDays(120),
           ).let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2135,7 +2135,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(70),
             reportEndDate.plusDays(85),
           ).let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2360,7 +2360,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(20),
           )
           bookingFour.let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2390,7 +2390,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.randomDateAfter(40),
           )
           bookingFive.let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2414,7 +2414,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(90),
             reportEndDate.plusDays(120),
           ).let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }
@@ -2427,7 +2427,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             reportEndDate.plusDays(70),
             reportEndDate.plusDays(85),
           ).let {
-            it.confirmation = cas3v2ConfirmationEntityFactory.produceAndPersist {
+            it.confirmation = cas3ConfirmationEntityFactory.produceAndPersist {
               withBooking(it)
             }
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/Cas3ConfirmationTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/repository/Cas3ConfirmationTestRepository.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import java.util.UUID
 
 @Repository
-interface Cas3v2ConfirmationTestRepository : JpaRepository<Cas3v2ConfirmationEntity, UUID>
+interface Cas3ConfirmationTestRepository : JpaRepository<Cas3ConfirmationEntity, UUID>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/BedspaceOccupancyReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/BedspaceOccupancyReportGeneratorTest.kt
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ArrivalEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBedspaceReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator.BedspaceOccupancyReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BedspaceOccupancyReportData
@@ -374,7 +374,7 @@ class BedspaceOccupancyReportGeneratorTest {
         .withArrivalDate(LocalDate.parse("2023-03-28"))
         .withDepartureDate(LocalDate.parse("2023-04-04"))
         .produce().apply {
-          confirmation = Cas3v2ConfirmationEntityFactory().withBooking(this).produce()
+          confirmation = Cas3ConfirmationEntityFactory().withBooking(this).produce()
         }
 
     val relevantBookingStraddlingEndOfMonth =
@@ -384,7 +384,7 @@ class BedspaceOccupancyReportGeneratorTest {
         .withArrivalDate(LocalDate.parse("2023-04-28"))
         .withDepartureDate(LocalDate.parse("2023-05-04"))
         .produce().apply {
-          confirmation = Cas3v2ConfirmationEntityFactory().withBooking(this).produce()
+          confirmation = Cas3ConfirmationEntityFactory().withBooking(this).produce()
         }
 
     val bedspaceOccupancyBedspaceReportData = convertToCas3BedspaceOccupancyBedspaceReportData(cas3Bedspace)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/BookingsReportGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/reporting/generator/BookingsReportGeneratorTest.kt
@@ -8,12 +8,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3OverstayEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.generator.BookingsReportGenerator
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.reporting.model.BookingsReportRow
@@ -92,7 +92,7 @@ class BookingsReportGeneratorTest {
   fun `The 'offer accepted' column is true in the report if the booking was confirmed`() {
     val booking = createBooking().produce()
 
-    booking.confirmation = Cas3v2ConfirmationEntityFactory()
+    booking.confirmation = Cas3ConfirmationEntityFactory()
       .withBooking(booking)
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/v2/Cas3v2BookingServiceTest.kt
@@ -21,12 +21,12 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3Arrival
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationAssessmentEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ArrivalRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspacesEntity
@@ -44,8 +44,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Prem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspacesRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3v2BookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
@@ -94,7 +94,7 @@ class Cas3v2BookingServiceTest {
   private val mockCancellationRepository = mockk<Cas3CancellationRepository>()
   private val mockCancellationReasonRepository = mockk<CancellationReasonRepository>()
   private val mockCas3v2TurnaroundRepository = mockk<Cas3v2TurnaroundRepository>()
-  private val mockCas3v2ConfirmationRepository = mockk<Cas3v2ConfirmationRepository>()
+  private val mockCas3ConfirmationRepository = mockk<Cas3ConfirmationRepository>()
   private val mockCas3VoidBedspacesRepository = mockk<Cas3VoidBedspacesRepository>()
   private val mockAssessmentRepository = mockk<AssessmentRepository>()
   private val mockUserAccessService = mockk<UserAccessService>()
@@ -114,7 +114,7 @@ class Cas3v2BookingServiceTest {
     cas3ArrivalRepository = mockArrivalRepository,
     cas3DepartureRepository = mockDepartureRepository,
     departureReasonRepository = mockDepartureReasonRepository,
-    cas3v2ConfirmationRepository = mockCas3v2ConfirmationRepository,
+    cas3ConfirmationRepository = mockCas3ConfirmationRepository,
     moveOnCategoryRepository = mockMoveOnCategoryRepository,
     cas3v2TurnaroundRepository = mockCas3v2TurnaroundRepository,
     assessmentRepository = mockAssessmentRepository,
@@ -2024,7 +2024,7 @@ class Cas3v2BookingServiceTest {
 
     @Test
     fun `createConfirmation returns GeneralValidationError with correct message when Booking already has a Confirmation`() {
-      val confirmationEntity = Cas3v2ConfirmationEntityFactory()
+      val confirmationEntity = Cas3ConfirmationEntityFactory()
         .withBooking(bookingEntity)
         .produce()
 
@@ -2041,7 +2041,7 @@ class Cas3v2BookingServiceTest {
 
     @Test
     fun `createConfirmation returns Success with correct result when validation passes and emits domain event`() {
-      every { mockCas3v2ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3v2ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(Cas3BookingEntity::class), user) } just Runs
 
@@ -2069,7 +2069,7 @@ class Cas3v2BookingServiceTest {
 
     @Test
     fun `createConfirmation returns Success with correct result and does not close the referral when booking is done without application`() {
-      every { mockCas3v2ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3v2ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(Cas3BookingEntity::class), user) } just Runs
 
@@ -2114,7 +2114,7 @@ class Cas3v2BookingServiceTest {
 
       val bookingEntity = createCas3Booking(application = application)
 
-      every { mockCas3v2ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3v2ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(Cas3BookingEntity::class), user) } just Runs
       every { mockAssessmentRepository.findByApplicationIdAndReallocatedAtNull(bookingEntity.application!!.id) } returns assessment
@@ -2162,7 +2162,7 @@ class Cas3v2BookingServiceTest {
           .produce(),
       )
 
-      every { mockCas3v2ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3v2ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(Cas3BookingEntity::class), user) } just Runs
       every { mockAssessmentRepository.findByApplicationIdAndReallocatedAtNull(bookingEntity.application!!.id) } returns null
@@ -2208,7 +2208,7 @@ class Cas3v2BookingServiceTest {
 
       val bookingEntity = createCas3Booking(application = application)
 
-      every { mockCas3v2ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3v2ConfirmationEntity }
+      every { mockCas3ConfirmationRepository.save(any()) } answers { it.invocation.args[0] as Cas3ConfirmationEntity }
       every { mockBookingRepository.save(any()) } answers { it.invocation.args[0] as Cas3BookingEntity }
       every { mockCas3DomainEventService.saveBookingConfirmedEvent(any(Cas3BookingEntity::class), user) } just Runs
       every { mockAssessmentRepository.findByApplicationIdAndReallocatedAtNull(bookingEntity.application!!.id) } returns assessment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BookingTransformerTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Canc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3DepartureEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3NonArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3PremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3BedspaceSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3PremisesStatus
@@ -170,7 +170,7 @@ class Cas3BookingTransformerTest {
     .produce()
 
   private val nullDepartureEntity: Cas3DepartureEntity? = null
-  private val nullConfirmationEntity: Cas3v2ConfirmationEntity? = null
+  private val nullConfirmationEntity: Cas3ConfirmationEntity? = null
 
   private val bedspaceSummaryModel = Cas3BedspaceSummary(
     id = bedspaceEntity.id,
@@ -1426,7 +1426,7 @@ class Cas3BookingTransformerTest {
       id = UUID.fromString("1c29a729-6059-4939-8641-1caa61a38815"),
       service = ServiceName.temporaryAccommodation.value,
     ).apply {
-      confirmation = Cas3v2ConfirmationEntity(
+      confirmation = Cas3ConfirmationEntity(
         id = UUID.fromString("69fc6350-b2ec-4e99-9a2f-e829e83535e8"),
         dateTime = OffsetDateTime.parse("2022-11-23T12:34:56.789Z"),
         notes = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3ConfirmationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3ConfirmationTransformerTest.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3PremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3Confirmation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3ConfirmationTransformer
 import java.time.OffsetDateTime
@@ -16,7 +16,7 @@ class Cas3ConfirmationTransformerTest {
   private val cas3ConfirmationTransformer = Cas3ConfirmationTransformer()
 
   @Test
-  fun `transformJpaToApi transforms the Cas3v2ConfirmationEntity into a Cas3Confirmation`() {
+  fun `transformJpaToApi transforms the Cas3ConfirmationEntity into a Cas3Confirmation`() {
     val premises = Cas3PremisesEntityFactory()
       .withDefaults()
       .produce()
@@ -32,7 +32,7 @@ class Cas3ConfirmationTransformerTest {
       .produce()
 
     val confirmationId = UUID.randomUUID()
-    val cas3ConfirmationEntity = Cas3v2ConfirmationEntity(
+    val cas3ConfirmationEntity = Cas3ConfirmationEntity(
       id = confirmationId,
       dateTime = OffsetDateTime.parse("2025-04-08T00:00:00Z"),
       notes = "Test notes",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3Bedspac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BedspaceEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3BookingEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3CancellationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3DepartureEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3ExtensionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3NonArrivalEntityFactory
@@ -77,7 +78,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.Cas3VoidBed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.TemporaryAccommodationPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2ConfirmationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.factory.v2.Cas3v2TurnaroundEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3ArrivalEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3BedspaceCharacteristicEntity
@@ -98,13 +98,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3Turn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceCancellationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2ConfirmationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3ConfirmationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.v2.Cas3v2TurnaroundRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3ArrivalTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3BedspaceTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3BookingTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3CancellationTestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3DepartureTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3ExtensionTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3NonArrivalTestRepository
@@ -113,7 +114,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3Turn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3VoidBedspaceCancellationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3VoidBedspaceReasonTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3VoidBedspacesTestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.Cas3v2ConfirmationTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.repository.TemporaryAccommodationAssessmentTestRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.StaffMember
@@ -411,7 +411,7 @@ abstract class IntegrationTestBase {
   lateinit var arrivalRepository: ArrivalTestRepository
 
   @Autowired
-  lateinit var cas3v2ConfirmationRepository: Cas3v2ConfirmationTestRepository
+  lateinit var cas3ConfirmationRepository: Cas3ConfirmationTestRepository
 
   @Autowired
   lateinit var departureRepository: DepartureTestRepository
@@ -661,7 +661,7 @@ abstract class IntegrationTestBase {
   lateinit var cas3PremisesEntityFactory: PersistedFactory<Cas3PremisesEntity, UUID, Cas3PremisesEntityFactory>
   lateinit var bookingEntityFactory: PersistedFactory<BookingEntity, UUID, BookingEntityFactory>
   lateinit var arrivalEntityFactory: PersistedFactory<ArrivalEntity, UUID, ArrivalEntityFactory>
-  lateinit var cas3v2ConfirmationEntityFactory: PersistedFactory<Cas3v2ConfirmationEntity, UUID, Cas3v2ConfirmationEntityFactory>
+  lateinit var cas3ConfirmationEntityFactory: PersistedFactory<Cas3ConfirmationEntity, UUID, Cas3ConfirmationEntityFactory>
   lateinit var departureEntityFactory: PersistedFactory<DepartureEntity, UUID, DepartureEntityFactory>
   lateinit var destinationProviderEntityFactory: PersistedFactory<DestinationProviderEntity, UUID, DestinationProviderEntityFactory>
   lateinit var departureReasonEntityFactory: PersistedFactory<DepartureReasonEntity, UUID, DepartureReasonEntityFactory>
@@ -788,7 +788,7 @@ abstract class IntegrationTestBase {
     cas3PremisesEntityFactory = PersistedFactory({ Cas3PremisesEntityFactory() }, cas3PremisesRepository)
     bookingEntityFactory = PersistedFactory({ BookingEntityFactory() }, bookingRepository)
     arrivalEntityFactory = PersistedFactory({ ArrivalEntityFactory() }, arrivalRepository)
-    cas3v2ConfirmationEntityFactory = PersistedFactory({ Cas3v2ConfirmationEntityFactory() }, cas3v2ConfirmationRepository)
+    cas3ConfirmationEntityFactory = PersistedFactory({ Cas3ConfirmationEntityFactory() }, cas3ConfirmationRepository)
     departureEntityFactory = PersistedFactory({ DepartureEntityFactory() }, departureRepository)
     destinationProviderEntityFactory = PersistedFactory({ DestinationProviderEntityFactory() }, destinationProviderRepository)
     departureReasonEntityFactory = PersistedFactory({ DepartureReasonEntityFactory() }, departureReasonRepository)


### PR DESCRIPTION
This [PR FM-848](https://dsdmoj.atlassian.net/browse/FM-848) is to  Rename Cas3v2ConfirmationEntity and Cas3v2ConfirmationRepository to Cas3ConfirmationEntity and Cas3ConfirmationRepository respectively and move them to the main package