### PR TITLE
Add uiUrl property to suitable applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
@@ -11,6 +11,7 @@ data class Cas1SuitableApplication(
   val requestForPlacementStatus: RequestForPlacementStatus?,
   val placementStatus: Cas1SpaceBookingStatus?,
   val premises: Cas1ExternalPremisesDto?,
+  val uiUrl: String,
 )
 
 data class Cas1ExternalPremisesDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3SuitableApplication.kt
@@ -12,6 +12,7 @@ data class Cas3SuitableApplication(
   val assessmentStatus: TemporaryAccommodationAssessmentStatus?,
   val bookingStatus: Cas3BookingStatus?,
   val premises: Cas3ExternalPremisesDto?,
+  val uiUrl: String,
 )
 
 data class Cas3ExternalPremisesDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3ApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3ApplicationTransformer.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.readValue
@@ -23,6 +24,7 @@ class Cas3ApplicationTransformer(
   private val jsonMapper: JsonMapper,
   private val personTransformer: PersonTransformer,
   private val risksTransformer: RisksTransformer,
+  @Value($$"${url-templates.frontend.cas3.referral-full}") private val cas3ApplicationFullUrlTemplate: String,
 ) {
   fun transformToCas3SuitableApplication(application: TemporaryAccommodationApplicationEntity, booking: Cas3BookingEntity?) = Cas3SuitableApplication(
     id = application.id,
@@ -32,6 +34,7 @@ class Cas3ApplicationTransformer(
     premises = booking?.premises?.let {
       transformToCas3PremisesSummary(booking)
     },
+    uiUrl = cas3ApplicationFullUrlTemplate.replace("#applicationId", application.id.toString()),
   )
 
   fun transformToCas3PremisesSummary(booking: Cas3BookingEntity) = Cas3ExternalPremisesDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
@@ -20,6 +21,7 @@ class Cas1ExternalApplicationService(
   private val approvedPremisesApplicationRepository: ApprovedPremisesApplicationRepository,
   private val cas1RequestForPlacementService: Cas1RequestForPlacementService,
   private val cas1PremisesService: Cas1PremisesService,
+  @Value($$"${url-templates.frontend.application}") private val cas1ApplicationUrlTemplate: String,
 ) {
 
   private val mostSuitableApplication = compareBy<ApprovedPremisesApplicationEntity> { suitableStatusesAsc[it.status] }
@@ -82,6 +84,7 @@ class Cas1ExternalApplicationService(
         requestForPlacementStatus = suitablePlacement?.requestForPlacementStatus,
         placementStatus = suitablePlacement?.placementStatus,
         premises = suitablePlacement?.premises,
+        uiUrl = cas1ApplicationUrlTemplate.replace("#id", application.id.toString()),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
@@ -106,6 +106,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 town = premises.town,
                 postcode = premises.postcode,
               ),
+              uiUrl = "http://frontend/applications/${application.id}",
             )
 
             val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalApplicationsTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.extern
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3ExternalPremisesDto
@@ -57,6 +58,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             assessmentStatus = null,
             bookingStatus = null,
             premises = null,
+            uiUrl = "http://frontend.cas3/referrals/${application.id}/full",
           )
 
           val response = webTestClient.get()
@@ -65,7 +67,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(Cas3SuitableApplication::class.java)
+            .expectBody<Cas3SuitableApplication>()
             .returnResult()
             .responseBody
 
@@ -91,6 +93,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             null,
             bookingStatus = null,
             premises = null,
+            uiUrl = "http://frontend.cas3/referrals/${application.id}/full",
           )
 
           val response = webTestClient.get()
@@ -99,7 +102,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(Cas3SuitableApplication::class.java)
+            .expectBody<Cas3SuitableApplication>()
             .returnResult()
             .responseBody
 
@@ -153,6 +156,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
               town = premises.town,
               postcode = premises.postcode,
             ),
+            uiUrl = "http://frontend.cas3/referrals/${application.id}/full",
           )
 
           val response = webTestClient.get()
@@ -161,7 +165,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(Cas3SuitableApplication::class.java)
+            .expectBody<Cas3SuitableApplication>()
             .returnResult()
             .responseBody
 
@@ -285,7 +289,7 @@ class Cas3ExternalApplicationsTest : IntegrationTestBase() {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBody(Cas3ExternalPremisesDto::class.java)
+            .expectBody<Cas3ExternalPremisesDto>()
             .returnResult()
             .responseBody
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
@@ -72,7 +72,6 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import kotlin.collections.listOf
 
 class Cas3ApplicationServiceTest {
   private val now = OffsetDateTime.now()
@@ -112,6 +111,8 @@ class Cas3ApplicationServiceTest {
     mockCas3ApplicationTransformer,
     mockCaseService,
   )
+
+  private val uiUrl = "http://localhost/applications/#applicationId"
 
   val user = UserEntityFactory()
     .withUnitTestControlProbationRegion()
@@ -169,6 +170,7 @@ class Cas3ApplicationServiceTest {
         null,
         bookingStatus = null,
         premises = null,
+        uiUrl = uiUrl.replace("#applicationId", inProgressApplicationNewer.id.toString()),
       )
 
       every { mockTemporaryAccommodationApplicationRepository.findByCrnOrderByCreatedAtDesc(crn) } returns listOf(
@@ -245,6 +247,7 @@ class Cas3ApplicationServiceTest {
         null,
         bookingStatus = null,
         premises = null,
+        uiUrl = uiUrl.replace("#applicationId", submittedApplication2.id.toString()),
       )
 
       every { mockCas3v2BookingService.getLatestBooking(submittedApplication2.id) } returns null
@@ -295,6 +298,7 @@ class Cas3ApplicationServiceTest {
         null,
         bookingStatus = null,
         premises = null,
+        uiUrl = uiUrl.replace("#applicationId", submittedApplication2.id.toString()),
       )
 
       every { mockCas3v2BookingService.getLatestBooking(submittedApplication2.id) } returns null
@@ -336,6 +340,8 @@ class Cas3ApplicationServiceTest {
         TemporaryAccommodationAssessmentStatus.readyToPlace,
         bookingStatus = null,
         premises = null,
+        uiUrl = uiUrl.replace("#applicationId", submittedApplication.id.toString()),
+
       )
 
       every { mockCas3v2BookingService.getLatestBooking(submittedApplication.id) } returns null
@@ -396,6 +402,8 @@ class Cas3ApplicationServiceTest {
           town = booking.premises.town,
           postcode = booking.premises.postcode,
         ),
+        uiUrl = uiUrl.replace("#applicationId", submittedApplication.id.toString()),
+
       )
 
       every { mockCas3v2BookingService.getLatestBooking(submittedApplication.id) } returns booking

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3ApplicationTransformerTest.kt
@@ -73,7 +73,10 @@ class Cas3ApplicationTransformerTest {
   private val assessmentFactory = TemporaryAccommodationAssessmentEntityFactory()
     .withAllocatedToUser(allocatedToUser)
 
-  private val cas3ApplicationsTransformer = Cas3ApplicationTransformer(jsonMapper, mockPersonTransformer, mockRisksTransformer)
+  private val uiUrl = "http://localhost/applications/#applicationId"
+
+  private val cas3ApplicationsTransformer =
+    Cas3ApplicationTransformer(jsonMapper, mockPersonTransformer, mockRisksTransformer, uiUrl)
 
   @BeforeEach
   fun setup() {
@@ -108,6 +111,7 @@ class Cas3ApplicationTransformerTest {
       assessmentStatus = TemporaryAccommodationAssessmentStatus.readyToPlace,
       bookingStatus = null,
       premises = null,
+      uiUrl = uiUrl.replace("#applicationId", application.id.toString()),
     )
 
     val result = cas3ApplicationsTransformer.transformToCas3SuitableApplication(application, null)
@@ -157,6 +161,7 @@ class Cas3ApplicationTransformerTest {
         town = premises.town,
         postcode = premises.postcode,
       ),
+      uiUrl = uiUrl.replace("#applicationId", application.id.toString()),
     )
 
     val result = cas3ApplicationsTransformer.transformToCas3SuitableApplication(application, booking)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
@@ -49,6 +49,8 @@ class Cas1ExternalApplicationServiceTest {
   @MockK
   private lateinit var cas1PremisesService: Cas1PremisesService
 
+  private val cas1ApplicationUrlTemplate: String = "http://localhost:3000/applications/#id"
+
   @InjectMockKs
   private lateinit var service: Cas1ExternalApplicationService
 
@@ -373,6 +375,7 @@ class Cas1ExternalApplicationServiceTest {
           requestForPlacementStatus = requestForPlacement2.status,
           placementStatus = null,
           premises = null,
+          uiUrl = "http://localhost:3000/applications/${awaitingPlacementApplication.id}",
         ),
       )
     }
@@ -500,7 +503,9 @@ class Cas1ExternalApplicationServiceTest {
             town = premisesEntity.town,
             postcode = premisesEntity.postcode,
           ),
+          uiUrl = "http://localhost:3000/applications/${awaitingPlacementApplication.id}",
         ),
+
       )
     }
 
@@ -587,6 +592,7 @@ class Cas1ExternalApplicationServiceTest {
         requestForPlacementStatus = requestForPlacement.status,
         placementStatus = placement.status,
         premises = premises,
+        uiUrl = "http://localhost:3000/applications/${application.id}",
       )
       val result = service.getSuitableApplicationByCrn(application.crn)
 
@@ -606,6 +612,7 @@ class Cas1ExternalApplicationServiceTest {
         premises = null,
         requestForPlacementStatus = null,
         placementStatus = null,
+        uiUrl = "http://localhost:3000/applications/${suitableApprovedPremisesApplication.id}",
       )
 
       every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(suitableApplication.id, null) } returns CasResult.Success(emptyList())
@@ -657,6 +664,7 @@ class Cas1ExternalApplicationServiceTest {
         premises = null,
         requestForPlacementStatus = null,
         placementStatus = null,
+        uiUrl = "http://localhost:3000/applications/${latestAwaitingPlacementApplication.id}",
       )
       val result = service.getSuitableApplicationByCrn(crn)
 
@@ -706,6 +714,7 @@ class Cas1ExternalApplicationServiceTest {
         premises = null,
         requestForPlacementStatus = null,
         placementStatus = null,
+        uiUrl = "http://localhost:3000/applications/${latestStartedApplication.id}",
       )
 
       val result = service.getSuitableApplicationByCrn(crn)


### PR DESCRIPTION
This PR adds a uiUrl property to the cas1 and cas3 suitable applications fields, so that SAS can give deep links to the user.