### PR TITLE
Make PersonTransformer function names consistent

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2ApplicationsTransformer.kt
@@ -29,7 +29,7 @@ class Cas2ApplicationsTransformer(
   private val offenderManagementUnitRepository: OffenderManagementUnitRepository,
 ) {
 
-  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2Application = transformJpaAndFullPersonToApi(jpa, personTransformer.transformModelToPersonApi(personInfo))
+  fun transformJpaToApi(jpa: Cas2ApplicationEntity, personInfo: PersonInfoResult): Cas2Application = transformJpaAndFullPersonToApi(jpa, personTransformer.personInfoResultToPerson(personInfo))
 
   fun transformJpaAndFullPersonToApi(jpa: Cas2ApplicationEntity, fullPerson: Person) = Cas2Application(
     id = jpa.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2SubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2SubmissionsTransformer.kt
@@ -25,7 +25,7 @@ class Cas2SubmissionsTransformer(
       .Success,
   ): Cas2SubmittedApplication = Cas2SubmittedApplication(
     id = jpa.id,
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     submittedBy = cas2UserTransformer.transformJpaToApi(jpa.createdByUser),
     createdAt = jpa.createdAt.toInstant(),
     submittedAt = jpa.submittedAt?.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/controller/Cas2HdcPeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/controller/Cas2HdcPeopleController.kt
@@ -45,7 +45,7 @@ class Cas2HdcPeopleController(
           ?: RuntimeException("Could not retrieve person info for Prison Number: $nomsNumber")
 
       is ProbationOffenderSearchResult.Success.Full -> return ResponseEntity.ok(
-        personTransformer.transformProbationOffenderToPersonApi(probationOffenderResult),
+        personTransformer.transformProbationOffenderToFullPerson(probationOffenderResult),
       )
 
       null -> throw NotFoundProblem(nomsNumber, "Offender")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/transformer/Cas2HdcApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/transformer/Cas2HdcApplicationsTransformer.kt
@@ -36,7 +36,7 @@ class Cas2HdcApplicationsTransformer(
     val omu = jpa.currentPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it) }
     return Cas2HdcApplication(
       id = jpa.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       createdBy = cas2HdcNomisUserTransformer.transformJpaToApi(jpa),
       createdAt = jpa.createdAt.toInstant(),
       submittedAt = jpa.submittedAt?.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/transformer/Cas2HdcSubmissionsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/transformer/Cas2HdcSubmissionsTransformer.kt
@@ -31,7 +31,7 @@ class Cas2HdcSubmissionsTransformer(
     val omu = jpa.currentPrisonCode?.let { offenderManagementUnitRepository.findByPrisonCode(it) }
     return Cas2HdcSubmittedApplication(
       id = jpa.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       submittedBy = cas2HdcNomisUserTransformer.transformJpaToApi(jpa),
       createdAt = jpa.createdAt.toInstant(),
       submittedAt = jpa.submittedAt?.toInstant(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3ApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3ApplicationTransformer.kt
@@ -52,7 +52,7 @@ class Cas3ApplicationTransformer(
 
     return Cas3Application(
       id = applicationEntity.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       createdByUserId = applicationEntity.createdByUser.id,
       createdAt = applicationEntity.createdAt.toInstant(),
       submittedAt = applicationEntity.submittedAt?.toInstant(),
@@ -83,7 +83,7 @@ class Cas3ApplicationTransformer(
 
     return Cas3ApplicationSummary(
       id = domain.getId(),
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       createdByUserId = domain.getCreatedByUserId(),
       createdAt = domain.getCreatedAt(),
       submittedAt = domain.getSubmittedAt(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -80,7 +80,7 @@ class Cas3AssessmentTransformer(
         ase.crn,
       )
     },
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     probationDeliveryUnitName = ase.probationDeliveryUnitName,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3BookingTransformer.kt
@@ -29,7 +29,7 @@ class Cas3BookingTransformer(
     val hasNonZeroDayTurnaround = jpa.hasNonZeroDayTurnaround()
     return Cas3Booking(
       id = jpa.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       arrivalDate = jpa.arrivalDate,
       departureDate = jpa.departureDate,
       status = determineStatus(jpa),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3FutureBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3FutureBookingTransformer.kt
@@ -14,7 +14,7 @@ class Cas3FutureBookingTransformer(
 ) {
   fun transformJpaToApi(jpa: BookingEntity, personSummaryInfo: PersonSummaryInfoResult): FutureBooking = FutureBooking(
     id = jpa.id,
-    person = personTransformer.transformSummaryToPersonApi(personSummaryInfo),
+    person = personTransformer.personSummaryInfoResultToPerson(personSummaryInfo),
     arrivalDate = jpa.arrivalDate,
     departureDate = jpa.departureDate,
     bed = jpa.bed?.let { bedTransformer.transformJpaToApi(it) },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/PeopleController.kt
@@ -58,7 +58,7 @@ class PeopleController(
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
       is PersonInfoResult.Unknown -> throw personInfo.throwable ?: RuntimeException("Could not retrieve person info for CRN: $crn")
       is PersonInfoResult.Success -> return ResponseEntity.ok(
-        personTransformer.transformModelToPersonApi(personInfo),
+        personTransformer.personInfoResultToPerson(personInfo),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderDetailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderDetailService.kt
@@ -67,14 +67,14 @@ class OffenderDetailService(
               else -> null
             }
           }
-          personTransformer.transformPersonSummaryInfoToPersonInfo(it, inmateDetails)
+          personTransformer.personSummaryInfoResultToPersonInfoResult(it, inmateDetails)
         }
 
         is PersonSummaryInfoResult.Success.Restricted,
         is PersonSummaryInfoResult.NotFound,
         is PersonSummaryInfoResult.Unknown,
         ->
-          personTransformer.transformPersonSummaryInfoToPersonInfo(it, null)
+          personTransformer.personSummaryInfoResultToPersonInfoResult(it, null)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/ApplicationsTransformer.kt
@@ -50,7 +50,7 @@ class ApplicationsTransformer(
 
       is DomainTemporaryAccommodationApplicationEntity -> TemporaryAccommodationApplication(
         id = applicationEntity.id,
-        person = personTransformer.transformModelToPersonApi(personInfo),
+        person = personTransformer.personInfoResultToPerson(personInfo),
         createdByUserId = applicationEntity.createdByUser.id,
         createdAt = applicationEntity.createdAt.toInstant(),
         submittedAt = applicationEntity.submittedAt?.toInstant(),
@@ -84,7 +84,7 @@ class ApplicationsTransformer(
 
     return ApprovedPremisesApplication(
       id = applicationEntity.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       createdByUserId = applicationEntity.createdByUser.id,
       createdByUserName = applicationEntity.createdByUser.name,
       createdAt = applicationEntity.createdAt.toInstant(),
@@ -143,7 +143,7 @@ class ApplicationsTransformer(
 
     return Cas1ApplicationSummary(
       id = domain.getId(),
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       createdByUserId = domain.getCreatedByUserId(),
       createdAt = domain.getCreatedAt(),
       submittedAt = domain.getSubmittedAt(),
@@ -166,7 +166,7 @@ class ApplicationsTransformer(
 
     return Cas1Application(
       id = applicationEntity.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       createdByUserId = applicationEntity.createdByUser.id,
       createdAt = applicationEntity.createdAt.toInstant(),
       submittedAt = applicationEntity.submittedAt?.toInstant(),
@@ -203,7 +203,7 @@ class ApplicationsTransformer(
 
   fun transformJpaToApi(jpa: OfflineApplicationEntity, personInfo: PersonInfoResult) = OfflineApplication(
     id = jpa.id,
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     createdAt = jpa.createdAt.toInstant(),
     type = "Offline",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/AssessmentTransformer.kt
@@ -74,7 +74,7 @@ class AssessmentTransformer(
           ase.crn,
         )
       },
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       dueAt = ase.dueAt!!,
     )
 
@@ -92,7 +92,7 @@ class AssessmentTransformer(
           ase.crn,
         )
       },
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       probationDeliveryUnitName = ase.probationDeliveryUnitName,
     )
 
@@ -118,7 +118,7 @@ class AssessmentTransformer(
         ase.crn,
       )
     },
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     dueAt = ase.dueAt!!,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -138,6 +138,8 @@ class PersonTransformer {
     )
   }
 
+  // ideally the caller would use personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult,null) and then convert that
+  // removing the need for this function. This may change the output for sex and gender, so that would need addressing
   fun personSummaryInfoResultToPerson(personSummaryInfoResult: PersonSummaryInfoResult): Person = when (personSummaryInfoResult) {
     is PersonSummaryInfoResult.Success.Full -> {
       val caseSummary = personSummaryInfoResult.summary
@@ -154,7 +156,7 @@ class PersonTransformer {
         religionOrBelief = caseSummary.profile?.religion,
         genderIdentity = caseSummary.profile?.genderIdentity,
         prisonName = null,
-        isRestricted = (caseSummary.currentRestriction == true || caseSummary.currentExclusion == true),
+        isRestricted = (caseSummary.currentRestriction || caseSummary.currentExclusion),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -24,6 +24,28 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getNameFromPersonSu
 @Component
 class PersonTransformer {
 
+  fun personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult: PersonSummaryInfoResult, inmateStatus: InmateDetail?): PersonInfoResult = when (personSummaryInfoResult) {
+    is PersonSummaryInfoResult.NotFound -> PersonInfoResult.NotFound(
+      crn = personSummaryInfoResult.crn,
+    )
+
+    is PersonSummaryInfoResult.Success.Full -> PersonInfoResult.Success.Full(
+      crn = personSummaryInfoResult.crn,
+      offenderDetailSummary = personSummaryInfoResult.summary.asOffenderDetailSummary(),
+      inmateDetail = inmateStatus,
+    )
+
+    is PersonSummaryInfoResult.Success.Restricted -> PersonInfoResult.Success.Restricted(
+      crn = personSummaryInfoResult.crn,
+      nomsNumber = personSummaryInfoResult.nomsNumber,
+    )
+
+    is PersonSummaryInfoResult.Unknown -> PersonInfoResult.Unknown(
+      crn = personSummaryInfoResult.crn,
+      throwable = personSummaryInfoResult.throwable,
+    )
+  }
+
   fun personInfoResultToPersonSummaryInfoResult(
     personInfo: PersonInfoResult,
   ): PersonSummaryInfoResult = when (personInfo) {
@@ -46,7 +68,7 @@ class PersonTransformer {
     )
   }
 
-  fun personSummaryInfoToPersonSummary(
+  fun personSummaryInfoResultToPersonSummary(
     personSummaryInfo: PersonSummaryInfoResult,
   ): PersonSummary {
     when (personSummaryInfo) {
@@ -75,7 +97,7 @@ class PersonTransformer {
     }
   }
 
-  fun transformModelToPersonApi(personInfoResult: PersonInfoResult): Person = when (personInfoResult) {
+  fun personInfoResultToPerson(personInfoResult: PersonInfoResult): Person = when (personInfoResult) {
     is PersonInfoResult.Success.Full -> {
       val offenderDetailSummary = personInfoResult.offenderDetailSummary
       val inmateDetail = personInfoResult.inmateDetail
@@ -116,12 +138,12 @@ class PersonTransformer {
     )
   }
 
-  fun transformSummaryToPersonApi(personInfoResult: PersonSummaryInfoResult): Person = when (personInfoResult) {
+  fun personSummaryInfoResultToPerson(personSummaryInfoResult: PersonSummaryInfoResult): Person = when (personSummaryInfoResult) {
     is PersonSummaryInfoResult.Success.Full -> {
-      val caseSummary = personInfoResult.summary
+      val caseSummary = personSummaryInfoResult.summary
       FullPerson(
         type = PersonType.fullPerson,
-        crn = personInfoResult.crn,
+        crn = personSummaryInfoResult.crn,
         name = "${caseSummary.name.forename} ${caseSummary.name.surname}",
         dateOfBirth = caseSummary.dateOfBirth,
         sex = caseSummary.gender ?: "Not Found",
@@ -138,23 +160,16 @@ class PersonTransformer {
 
     is PersonSummaryInfoResult.Success.Restricted -> RestrictedPerson(
       type = PersonType.restrictedPerson,
-      crn = personInfoResult.crn,
+      crn = personSummaryInfoResult.crn,
     )
 
     is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> UnknownPerson(
       type = PersonType.unknownPerson,
-      crn = personInfoResult.crn,
+      crn = personSummaryInfoResult.crn,
     )
   }
 
-  fun transformPersonSummaryInfoToPersonInfo(personSummaryInfoResult: PersonSummaryInfoResult, inmateStatus: InmateDetail?): PersonInfoResult = when (personSummaryInfoResult) {
-    is PersonSummaryInfoResult.Success.Full -> PersonInfoResult.Success.Full(personSummaryInfoResult.crn, personSummaryInfoResult.summary.asOffenderDetailSummary(), inmateStatus)
-    is PersonSummaryInfoResult.Success.Restricted -> PersonInfoResult.Success.Restricted(personSummaryInfoResult.crn, personSummaryInfoResult.nomsNumber)
-    is PersonSummaryInfoResult.NotFound -> PersonInfoResult.NotFound(personSummaryInfoResult.crn)
-    is PersonSummaryInfoResult.Unknown -> PersonInfoResult.Unknown(personSummaryInfoResult.crn, personSummaryInfoResult.throwable)
-  }
-
-  fun transformProbationOffenderToPersonApi(probationOffenderResult: ProbationOffenderSearchResult.Success.Full): FullPerson {
+  fun transformProbationOffenderToFullPerson(probationOffenderResult: ProbationOffenderSearchResult.Success.Full): FullPerson {
     val caseSummary = probationOffenderResult.caseSummary
     val inmateDetail = probationOffenderResult.inmateDetail
     return FullPerson(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PlacementRequestTransformer.kt
@@ -38,7 +38,7 @@ class PlacementRequestTransformer(
     location = jpa.placementRequirements.postcodeDistrict.outcode,
     radius = jpa.placementRequirements.radius,
     essentialCriteria = jpa.placementRequirements.essentialCriteria.mapNotNull { characteristicToCriteria(it) },
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     risks = risksTransformer.transformDomainToApi(jpa.application.riskRatings!!, jpa.application.crn),
     applicationId = jpa.application.id,
     assessmentId = jpa.assessment.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/TaskTransformer.kt
@@ -86,7 +86,7 @@ class TaskTransformer(
     apType = placementApplication.application.apType.asApiType(),
   )
 
-  private fun getPersonSummary(application: ApplicationEntity, offenderSummaries: List<PersonSummaryInfoResult>): PersonSummary = personTransformer.personSummaryInfoToPersonSummary(
+  private fun getPersonSummary(application: ApplicationEntity, offenderSummaries: List<PersonSummaryInfoResult>): PersonSummary = personTransformer.personSummaryInfoResultToPersonSummary(
     offenderSummaries.first { it.crn == application.crn },
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
@@ -78,7 +78,7 @@ class Cas1AssessmentTransformer(
         ase.crn,
       )
     },
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     dueAt = ase.dueAt!!,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ChangeRequestTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1ChangeRequestTransformer.kt
@@ -8,11 +8,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ChangeReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ChangeRequestType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ChangeRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestType
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 
 @Service
 class Cas1ChangeRequestTransformer(
-  private val personTransformer: PersonTransformer,
   private val jsonMapper: JsonMapper,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PersonalTimelineTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PersonalTimelineTransformer.kt
@@ -21,7 +21,7 @@ class Cas1PersonalTimelineTransformer(
     personInfoResult: PersonInfoResult,
     applicationTimelineModels: List<Cas1ApplicationTimelineModel>,
   ) = Cas1PersonalTimeline(
-    person = personTransformer.transformModelToPersonApi(personInfoResult),
+    person = personTransformer.personInfoResultToPerson(personInfoResult),
     applications = applicationTimelineModels.map { transformApplication(it.application, it.cas1TimelineEvents) },
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PlacementRequestSummaryTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1PlacementRequestSummaryTransformer.kt
@@ -19,7 +19,7 @@ class Cas1PlacementRequestSummaryTransformer(
     requestedPlacementDuration = jpa.getRequestedPlacementDuration(),
     requestedPlacementArrivalDate = jpa.getRequestedPlacementArrivalDate(),
     id = jpa.getId(),
-    person = personTransformer.transformModelToPersonApi(personInfo),
+    person = personTransformer.personInfoResultToPerson(personInfo),
     placementRequestStatus = jpa.getPlacementRequestStatus(),
     isParole = jpa.getIsParole(),
     personTier = jpa.getPersonTier(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1SpaceBookingTransformer.kt
@@ -51,7 +51,7 @@ class Cas1SpaceBookingTransformer(
       id = jpa.id,
       applicationId = applicationId,
       assessmentId = placementRequest?.assessment?.id,
-      person = personTransformer.transformModelToPersonApi(person),
+      person = personTransformer.personInfoResultToPerson(person),
       premises = NamedId(
         id = jpa.premises.id,
         name = jpa.premises.name,
@@ -202,7 +202,7 @@ class Cas1SpaceBookingTransformer(
     val openChangeRequestsForBooking = cas1ChangeRequestRepository.findAllBySpaceBookingAndResolvedIsFalse(spaceBooking)
     return Cas1SpaceBookingSummary(
       id = spaceBooking.id,
-      person = personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo),
+      person = personTransformer.personSummaryInfoResultToPersonSummary(personSummaryInfo),
       premises = NamedId(
         spaceBooking.premises.id,
         spaceBooking.premises.name,
@@ -237,7 +237,7 @@ class Cas1SpaceBookingTransformer(
     personSummaryInfo: PersonSummaryInfoResult,
   ) = Cas1SpaceBookingSummary(
     id = searchResult.id,
-    person = personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo),
+    person = personTransformer.personSummaryInfoResultToPersonSummary(personSummaryInfo),
     premises = NamedId(
       id = premises.id,
       name = premises.name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2ApplicationTransformerTest.kt
@@ -65,7 +65,7 @@ class Cas2v2ApplicationTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
     every { mockCas2UserTransformer.transformJpaToApi(any()) } returns Cas2User(
       id = user.id,
       name = user.name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/transformer/Cas2v2SubmissionsTransformerTest.kt
@@ -70,7 +70,7 @@ class Cas2v2SubmissionsTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
     every { mockCas2UserTransformer.transformJpaToApi(any()) } returns mockCas2User
     every { mockCas2TimelineEventsTransformer.transformApplicationToTimelineEvents(any()) } returns listOf(mockk<Cas2TimelineEvent>())
     every { mockCas2AssessmentsTransformer.transformJpaToApiRepresentation(any()) } returns mockAssessment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/transformer/Cas2ApplicationsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/transformer/Cas2ApplicationsTransformerTest.kt
@@ -74,7 +74,7 @@ class Cas2ApplicationsTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
     every {
       mockCas2HdcNomisUserTransformer.transformJpaToApi(
         nomisUserEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/transformer/SubmissionsTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/transformer/SubmissionsTransformerTest.kt
@@ -71,7 +71,7 @@ class SubmissionsTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
     every {
       mockCas2HdcNomisUserTransformer.transformJpaToApi(
         nomisUserEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3ApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3ApplicationTransformerTest.kt
@@ -80,7 +80,7 @@ class Cas3ApplicationTransformerTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
     every { mockRisksTransformer.transformDomainToApi(any<PersonRisks>(), any<String>()) } returns mockk()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3BookingTransformerTest.kt
@@ -186,7 +186,7 @@ class Cas3BookingTransformerTest {
     every { mockBedspaceTransformer.transformJpaToCas3BedspaceSummary(bedspaceEntity) } returns bedspaceSummaryModel
     every { mockDepartureTransformer.transformJpaToApi(nullDepartureEntity) } returns null
 
-    every { mockPersonTransformer.transformModelToPersonApi(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) } returns FullPerson(
+    every { mockPersonTransformer.personInfoResultToPerson(PersonInfoResult.Success.Full("crn", offenderDetails, inmateDetail)) } returns FullPerson(
       type = PersonType.fullPerson,
       crn = "crn",
       name = "first last",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3FutureBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/transformer/Cas3FutureBookingTransformerTest.kt
@@ -81,7 +81,7 @@ class Cas3FutureBookingTransformerTest {
       .produce()
 
     every { mockBedTransformer.transformJpaToApi(bedEntity) } returns bed
-    every { mockPersonTransformer.transformSummaryToPersonApi(fullPersonSummaryInfo) } returns person
+    every { mockPersonTransformer.personSummaryInfoResultToPerson(fullPersonSummaryInfo) } returns person
 
     val result = cas3FutureBookingTransformer.transformJpaToApi(bookingEntity, fullPersonSummaryInfo)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
@@ -141,7 +141,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
               .json(
                 jsonMapper.writeValueAsString(
                   Cas1PersonalTimeline(
-                    person = personTransformer.transformModelToPersonApi(personInfoResult),
+                    person = personTransformer.personInfoResultToPerson(personInfoResult),
                     applications = listOf(
                       Cas1ApplicationTimeline(
                         id = submittedApplication.id,
@@ -309,7 +309,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
             .json(
               jsonMapper.writeValueAsString(
                 Cas1PersonalTimeline(
-                  person = personTransformer.transformModelToPersonApi(personInfoResult),
+                  person = personTransformer.personInfoResultToPerson(personInfoResult),
                   applications = emptyList(),
                 ),
               ),
@@ -354,7 +354,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
               .json(
                 jsonMapper.writeValueAsString(
                   Cas1PersonalTimeline(
-                    person = personTransformer.transformModelToPersonApi(personInfoResult),
+                    person = personTransformer.personInfoResultToPerson(personInfoResult),
                     applications = listOf(
                       Cas1ApplicationTimeline(
                         id = application.id,
@@ -460,7 +460,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
             .json(
               jsonMapper.writeValueAsString(
                 Cas1PersonalTimeline(
-                  person = personTransformer.transformModelToPersonApi(personInfoResult),
+                  person = personTransformer.personInfoResultToPerson(personInfoResult),
                   applications = listOf(
                     Cas1ApplicationTimeline(
                       id = offlineApplication.id,
@@ -524,7 +524,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
             .json(
               jsonMapper.writeValueAsString(
                 Cas1PersonalTimeline(
-                  person = personTransformer.transformModelToPersonApi(personInfoResult),
+                  person = personTransformer.personInfoResultToPerson(personInfoResult),
                   applications = emptyList(),
                 ),
               ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -1199,7 +1199,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
       requestedPlacementDuration = jpa.duration,
       requestedPlacementArrivalDate = jpa.expectedArrival,
       id = jpa.id,
-      person = personTransformer.transformModelToPersonApi(personInfo),
+      person = personTransformer.personInfoResultToPerson(personInfo),
       placementRequestStatus = PlacementRequestStatus.notMatched,
       isParole = jpa.isParole,
       personTier = jpa.application.riskRatings?.tier?.value?.level,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderDetailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderDetailServiceTest.kt
@@ -153,7 +153,7 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = inmateDetails,
         )
@@ -190,7 +190,7 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = inmateDetails,
         )
@@ -243,21 +243,21 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult1Success,
           inmateStatus = inmateDetails1,
         )
       } returns mockPersonInfoResult1
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult2Restricted,
           inmateStatus = null,
         )
       } returns mockPersonInfoResult2
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult3Success,
           inmateStatus = inmateDetails3,
         )
@@ -286,7 +286,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -315,7 +315,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -344,7 +344,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -387,7 +387,7 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = inmateDetails,
         )
@@ -423,7 +423,7 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = inmateDetails,
         )
@@ -449,7 +449,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -477,7 +477,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -505,7 +505,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -547,7 +547,7 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = inmateDetails,
         )
@@ -584,7 +584,7 @@ class OffenderDetailServiceTest {
       )
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = inmateDetails,
         )
@@ -611,7 +611,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -640,7 +640,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )
@@ -669,7 +669,7 @@ class OffenderDetailServiceTest {
       } returns listOf(personSummaryInfoResult)
 
       every {
-        mockPersonTransformer.transformPersonSummaryInfoToPersonInfo(
+        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
           personSummaryInfoResult = personSummaryInfoResult,
           inmateStatus = null,
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/ApplicationsTransformersTest.kt
@@ -106,7 +106,7 @@ class ApplicationsTransformersTest {
 
   @BeforeEach
   fun setup() {
-    every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
     every { mockPersonTransformer.inmateStatusToPersonInfoApiStatus(any()) } returns PersonStatus.inCommunity
     every { mockRisksTransformer.transformDomainToApi(any<PersonRisks>(), any<String>()) } returns mockk()
   }
@@ -405,7 +405,7 @@ class ApplicationsTransformersTest {
       override fun getReleaseType(): String = ReleaseTypeOption.licence.toString()
       override fun getHasRequestsForPlacement(): Boolean = true
     }
-    every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockPerson
+    every { mockPersonTransformer.personInfoResultToPerson(mockPersonInfoResult) } returns mockPerson
 
     val result = applicationsTransformer.transformDomainToCas1ApplicationSummary(
       application,
@@ -450,7 +450,7 @@ class ApplicationsTransformersTest {
       override fun getReleaseType(): String = ReleaseTypeOption.licence.toString()
       override fun getHasRequestsForPlacement(): Boolean = true
     }
-    every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockPerson
+    every { mockPersonTransformer.personInfoResultToPerson(mockPersonInfoResult) } returns mockPerson
 
     val result = applicationsTransformer.transformDomainToCas1ApplicationSummary(
       application,
@@ -484,7 +484,7 @@ class ApplicationsTransformersTest {
       override fun getReleaseType(): String = ReleaseTypeOption.licence.toString()
       override fun getHasRequestsForPlacement(): Boolean = true
     }
-    every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockPerson
+    every { mockPersonTransformer.personInfoResultToPerson(mockPersonInfoResult) } returns mockPerson
 
     val result = applicationsTransformer.transformDomainToCas1ApplicationSummary(
       application,
@@ -521,7 +521,7 @@ class ApplicationsTransformersTest {
       override fun getHasRequestsForPlacement(): Boolean = true
     }
 
-    every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockPerson
+    every { mockPersonTransformer.personInfoResultToPerson(mockPersonInfoResult) } returns mockPerson
 
     val result = applicationsTransformer.transformDomainToCas1ApplicationSummary(
       application,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/AssessmentTransformerTest.kt
@@ -118,7 +118,7 @@ class AssessmentTransformerTest {
         probationDeliveryUnitName = "test pdu name",
       )
 
-      every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+      every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
       val apiSummary = assessmentTransformer.transformDomainToApiSummary(domainSummary, mockk())
 
       assertThat(apiSummary).isInstanceOf(TemporaryAccommodationAssessmentSummary::class.java)
@@ -156,7 +156,7 @@ class AssessmentTransformerTest {
         probationDeliveryUnitName = null,
       )
 
-      every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+      every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
       val apiSummary = assessmentTransformer.transformDomainToApiSummary(domainSummary, mockk())
 
       assertThat(apiSummary).isInstanceOf(ApprovedPremisesAssessmentSummary::class.java)
@@ -223,7 +223,7 @@ class AssessmentTransformerTest {
         probationDeliveryUnitName = null,
       )
 
-      every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+      every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
       val apiSummary = assessmentTransformer.transformDomainToCas1AssessmentSummary(domainSummary, mockk())
 
       assertThat(apiSummary).isInstanceOf(Cas1AssessmentSummary::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -105,7 +105,7 @@ class PersonTransformerTest {
 
     @Test
     fun `map full person`() {
-      val result = personTransformer.personSummaryInfoToPersonSummary(
+      val result = personTransformer.personSummaryInfoResultToPersonSummary(
         PersonSummaryInfoResult.Success.Full(
           crn = "the crn",
           summary = CaseSummaryFactory()
@@ -131,7 +131,7 @@ class PersonTransformerTest {
       hasRestriction: Boolean,
       expectedIsRestricted: Boolean,
     ) {
-      val result = personTransformer.personSummaryInfoToPersonSummary(
+      val result = personTransformer.personSummaryInfoResultToPersonSummary(
         PersonSummaryInfoResult.Success.Full(
           crn = "the crn",
           summary = CaseSummaryFactory()
@@ -146,7 +146,7 @@ class PersonTransformerTest {
 
     @Test
     fun `map restricted person`() {
-      val result = personTransformer.personSummaryInfoToPersonSummary(
+      val result = personTransformer.personSummaryInfoResultToPersonSummary(
         PersonSummaryInfoResult.Success.Restricted(
           crn = "the crn",
           nomsNumber = "the noms number",
@@ -160,7 +160,7 @@ class PersonTransformerTest {
 
     @Test
     fun `map not found person`() {
-      val result = personTransformer.personSummaryInfoToPersonSummary(
+      val result = personTransformer.personSummaryInfoResultToPersonSummary(
         PersonSummaryInfoResult.NotFound(
           crn = "the crn",
         ),
@@ -173,7 +173,7 @@ class PersonTransformerTest {
 
     @Test
     fun `map unknown person`() {
-      val result = personTransformer.personSummaryInfoToPersonSummary(
+      val result = personTransformer.personSummaryInfoResultToPersonSummary(
         PersonSummaryInfoResult.Unknown(
           crn = "the crn",
         ),
@@ -194,7 +194,7 @@ class PersonTransformerTest {
 
       val personInfoResult = PersonInfoResult.Success.Restricted(crn, null)
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result is RestrictedPerson).isTrue
       assertThat(result.crn).isEqualTo(crn)
@@ -206,7 +206,7 @@ class PersonTransformerTest {
 
       val personInfoResult = PersonInfoResult.NotFound(crn)
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result is UnknownPerson).isTrue
       assertThat(result.crn).isEqualTo(crn)
@@ -218,7 +218,7 @@ class PersonTransformerTest {
 
       val personInfoResult = PersonInfoResult.Unknown(crn)
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result is UnknownPerson).isTrue
       assertThat(result.crn).isEqualTo(crn)
@@ -282,7 +282,7 @@ class PersonTransformerTest {
         inmateDetail = null,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -376,7 +376,7 @@ class PersonTransformerTest {
         inmateDetail = inmateDetail,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -470,7 +470,7 @@ class PersonTransformerTest {
         inmateDetail = inmateDetail,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -509,7 +509,7 @@ class PersonTransformerTest {
         inmateDetail = null,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -532,7 +532,7 @@ class PersonTransformerTest {
         inmateDetail = null,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -555,7 +555,7 @@ class PersonTransformerTest {
         inmateDetail = null,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -578,7 +578,7 @@ class PersonTransformerTest {
         inmateDetail = null,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -602,7 +602,7 @@ class PersonTransformerTest {
         inmateDetail = null,
       )
 
-      val result = personTransformer.transformModelToPersonApi(personInfoResult)
+      val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is FullPerson).isTrue
@@ -620,7 +620,7 @@ class PersonTransformerTest {
 
       val personInfoResult = PersonSummaryInfoResult.Success.Full(caseSummary.crn, caseSummary)
 
-      val result = personTransformer.transformSummaryToPersonApi(personInfoResult)
+      val result = personTransformer.personSummaryInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(caseSummary.crn)
       assertThat(result is FullPerson).isTrue
@@ -649,7 +649,7 @@ class PersonTransformerTest {
       val crn = "CRN123"
       val personInfoResult = PersonSummaryInfoResult.Success.Restricted(crn, null)
 
-      val result = personTransformer.transformSummaryToPersonApi(personInfoResult)
+      val result = personTransformer.personSummaryInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is RestrictedPerson).isTrue
@@ -660,7 +660,7 @@ class PersonTransformerTest {
       val crn = "CRN123"
       val personInfoResult = PersonSummaryInfoResult.NotFound(crn)
 
-      val result = personTransformer.transformSummaryToPersonApi(personInfoResult)
+      val result = personTransformer.personSummaryInfoResultToPerson(personInfoResult)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is UnknownPerson).isTrue
@@ -687,7 +687,7 @@ class PersonTransformerTest {
 
       val probationOffenderSearchResult = ProbationOffenderSearchResult.Success.Full(nomsNumber, caseSummary, inmateDetail)
 
-      val result = personTransformer.transformProbationOffenderToPersonApi(probationOffenderSearchResult)
+      val result = personTransformer.transformProbationOffenderToFullPerson(probationOffenderSearchResult)
 
       assertThat(result.crn).isEqualTo(crn)
 
@@ -725,7 +725,7 @@ class PersonTransformerTest {
 
       val probationOffenderSearchResult = ProbationOffenderSearchResult.Success.Full(nomsNumber, caseSummary, inmateDetail)
 
-      val result = personTransformer.transformProbationOffenderToPersonApi(probationOffenderSearchResult)
+      val result = personTransformer.transformProbationOffenderToFullPerson(probationOffenderSearchResult)
 
       assertThat(result.crn).isEqualTo(crn)
 
@@ -810,7 +810,7 @@ class PersonTransformerTest {
       val inmateDetail = InmateDetailFactory()
         .withCustodyStatus(InmateStatus.IN)
         .produce()
-      val result = personTransformer.transformPersonSummaryInfoToPersonInfo(personSummaryInfoResult, inmateDetail)
+      val result = personTransformer.personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult, inmateDetail)
 
       assertThat(result.crn).isEqualTo(caseSummary.crn)
       assertThat(result is PersonInfoResult.Success.Full).isTrue
@@ -824,7 +824,7 @@ class PersonTransformerTest {
 
       val personSummaryInfoResult = PersonSummaryInfoResult.Success.Restricted(crn, nomsNumber)
 
-      val result = personTransformer.transformPersonSummaryInfoToPersonInfo(personSummaryInfoResult, null)
+      val result = personTransformer.personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult, null)
 
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result is PersonInfoResult.Success.Restricted).isTrue
@@ -837,7 +837,7 @@ class PersonTransformerTest {
 
       val personSummaryInfoResult = PersonSummaryInfoResult.NotFound(crn)
 
-      val result = personTransformer.transformPersonSummaryInfoToPersonInfo(personSummaryInfoResult, null)
+      val result = personTransformer.personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult, null)
 
       assertThat(result is PersonInfoResult.NotFound).isTrue
       assertThat(result.crn).isEqualTo(crn)
@@ -851,7 +851,7 @@ class PersonTransformerTest {
 
       val personSummaryInfoResult = PersonSummaryInfoResult.Unknown(crn, throwable)
 
-      val result = personTransformer.transformPersonSummaryInfoToPersonInfo(personSummaryInfoResult, null)
+      val result = personTransformer.personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult, null)
 
       assertThat(result is PersonInfoResult.Unknown).isTrue
       assertThat(result.crn).isEqualTo(crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestDetailTransformerTest.kt
@@ -269,7 +269,7 @@ class PlacementRequestDetailTransformerTest {
     )
 
     every { mockAssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns AssessmentDecision.accepted
-    every { mockPersonTransformer.transformModelToPersonApi(mockPersonInfoResult) } returns mockk<Person>()
+    every { mockPersonTransformer.personInfoResultToPerson(mockPersonInfoResult) } returns mockk<Person>()
     every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockk<PersonRisks>()
     every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockk<ApprovedPremisesUser>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PlacementRequestTransformerTest.kt
@@ -121,7 +121,7 @@ class PlacementRequestTransformerTest {
   @BeforeEach
   fun setup() {
     every { mockAssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns decision
-    every { mockPersonTransformer.transformModelToPersonApi(personInfo) } returns mockPersonInfo
+    every { mockPersonTransformer.personInfoResultToPerson(personInfo) } returns mockPersonInfo
     every { mockRisksTransformer.transformDomainToApi(application.riskRatings!!, application.crn) } returns mockRisks
     every { mockUserTransformer.transformJpaToApi(user, ServiceName.approvedPremises) } returns mockUser
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
@@ -270,7 +270,7 @@ class Cas1AssessmentTransformerTest {
         probationDeliveryUnitName = null,
       )
 
-      every { mockPersonTransformer.transformModelToPersonApi(any()) } returns mockk<Person>()
+      every { mockPersonTransformer.personInfoResultToPerson(any()) } returns mockk<Person>()
       val apiSummary = cas1AssessmentTransformer.transformDomainToCas1AssessmentSummary(domainSummary, mockk())
 
       assertThat(apiSummary).isInstanceOf(Cas1AssessmentSummary::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1ChangeRequestTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1ChangeRequestTransformerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1
 
-import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
@@ -10,13 +9,10 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ChangeReque
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1ChangeRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ChangeRequestDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1ChangeRequestTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.JsonMapperFactory
 
 class Cas1ChangeRequestTransformerTest {
-  private val mockPersonTransformer = mockk<PersonTransformer>()
-
   private val jsonMapper = JsonMapperFactory.createJackson3JsonMapper()
 
   val offenderDetailSummary = OffenderDetailsSummaryFactory().produce()
@@ -25,7 +21,7 @@ class Cas1ChangeRequestTransformerTest {
     .withDecision(ChangeRequestDecision.APPROVED)
     .produce()
 
-  private val cas1ChangeRequestTransformer = Cas1ChangeRequestTransformer(mockPersonTransformer, jsonMapper)
+  private val cas1ChangeRequestTransformer = Cas1ChangeRequestTransformer(jsonMapper)
 
   @Test
   fun `transformEntityToCas1ChangeRequest transforms correctly`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PersonalTimelineTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1PersonalTimelineTransformerTest.kt
@@ -127,7 +127,7 @@ class Cas1PersonalTimelineTransformerTest {
     every { userTransformer.transformJpaToApi(application2.createdByUser, ServiceName.approvedPremises) } returns user2
     every { userTransformer.transformJpaToApi(application3.createdByUser, ServiceName.approvedPremises) } returns user3
 
-    every { personTransformer.transformModelToPersonApi(personInfoResult) } returns mockPerson
+    every { personTransformer.personInfoResultToPerson(personInfoResult) } returns mockPerson
 
     val transformedPersonalTimeline = cas1PersonalTimelineTransformer
       .transformApplicationTimelineModels(personInfoResult, applicationTimelineModels)
@@ -142,6 +142,6 @@ class Cas1PersonalTimelineTransformerTest {
 
     assertThat(transformedPersonalTimeline.person).isEqualTo(mockPerson)
 
-    verify(exactly = 1) { personTransformer.transformModelToPersonApi(personInfoResult) }
+    verify(exactly = 1) { personTransformer.personInfoResultToPerson(personInfoResult) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1SpaceBookingTransformerTest.kt
@@ -196,7 +196,7 @@ class Cas1SpaceBookingTransformerTest {
         ),
       )
 
-      every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
+      every { personTransformer.personInfoResultToPerson(personInfo) } returns expectedPerson
       every {
         userTransformer.transformJpaToApi(
           spaceBooking.createdBy!!,
@@ -329,7 +329,7 @@ class Cas1SpaceBookingTransformerTest {
 
       val expectedUser = ApprovedPremisesUserFactory().produce()
 
-      every { personTransformer.transformModelToPersonApi(personInfo) } returns expectedPerson
+      every { personTransformer.personInfoResultToPerson(personInfo) } returns expectedPerson
       every {
         userTransformer.transformJpaToApi(
           spaceBooking.createdBy!!,
@@ -370,7 +370,7 @@ class Cas1SpaceBookingTransformerTest {
       )
 
       val cas1ChangeRequests = listOf(Cas1ChangeRequestEntityFactory().withType(ChangeRequestType.PLACEMENT_APPEAL).produce())
-      every { personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
+      every { personTransformer.personSummaryInfoResultToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
       every { cas1ChangeRequestRepository.findAllBySpaceBookingAndResolvedIsFalse(any()) } returns cas1ChangeRequests
 
       val premises = ApprovedPremisesEntityFactory().withDefaults().withName("The booking's premise").produce()
@@ -470,7 +470,7 @@ class Cas1SpaceBookingTransformerTest {
 
       val premises = ApprovedPremisesEntityFactory().withDefaults().withName("the premise").produce()
 
-      every { personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
+      every { personTransformer.personSummaryInfoResultToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
 
       val keyWorkerId = UUID.randomUUID()
       val result = transformer.transformSearchResultToSummary(
@@ -542,7 +542,7 @@ class Cas1SpaceBookingTransformerTest {
         PersonSummaryDiscriminator.restrictedPersonSummary,
       )
 
-      every { personTransformer.personSummaryInfoToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
+      every { personTransformer.personSummaryInfoResultToPersonSummary(personSummaryInfo) } returns expectedPersonSummary
 
       val result = transformer.transformSearchResultToSummary(
         Cas1SpaceBookingSearchResultImpl(


### PR DESCRIPTION
This commit re-orders and renames all functions in `PersonTransformer` for consistency, ensuring summary conversions and presented before full conversions

It also reformats `personSummaryInfoToPersonInfoResult` to match the format used for `personSummaryInfoResultToPersonSummary `

There are no functional changes