### PR TITLE
SAS-798: Use dateApplied

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1ReferralHistory.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
-import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
 
 data class Cas1ReferralHistory(
@@ -12,7 +12,7 @@ data class Cas1ReferralHistory(
   val applicationId: UUID,
   val applicationStatus: ApprovedPremisesApplicationStatus,
   val requestForPlacementStatus: RequestForPlacementStatus?,
-  val createdAt: Instant,
+  val date: LocalDate,
   val referralRejectionReason: String?,
   val localAuthorityArea: String?,
   val pdu: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3ReferralHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3ReferralHistory.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationSta
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3BookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationAssessmentStatus
-import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
 
 data class Cas3ReferralHistory(
@@ -13,7 +13,7 @@ data class Cas3ReferralHistory(
   val applicationId: UUID,
   val applicationStatus: ApplicationStatus,
   val assessmentStatus: TemporaryAccommodationAssessmentStatus?,
-  val createdAt: Instant,
+  val date: LocalDate,
   val referralRejectionReason: String?,
   val referralRejectionReasonDetail: String?,
   val localAuthorityArea: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -92,7 +92,7 @@ class Cas3AssessmentTransformer(
     val referralHistory = Cas3ReferralHistory(
       id = a.id,
       applicationId = application.id,
-      createdAt = a.createdAt.toInstant(),
+      date = a.submittedAt?.toLocalDate() ?: a.createdAt.toLocalDate(),
       applicationStatus = application.getStatus(),
       assessmentStatus = a.deriveAssessmentStatus(),
       type = ServiceType.CAS3,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
@@ -88,7 +88,7 @@ class Cas1AssessmentTransformer(
     val referralHistory = Cas1ReferralHistory(
       id = entity.id,
       applicationId = entity.application.id,
-      createdAt = entity.createdAt.toInstant(),
+      date = entity.submittedAt?.toLocalDate() ?: entity.createdAt.toLocalDate(),
       applicationStatus = application.status,
       type = ServiceType.CAS1,
       referralRejectionReason = entity.rejectionRationale,
@@ -103,6 +103,7 @@ class Cas1AssessmentTransformer(
 
     return placementHistories.map {
       referralHistory.copy(
+        date = it.dateApplied,
         placementAddress = toPlacementAddress(it.premises),
         placementStatus = it.placementStatus,
         requestForPlacementStatus = it.requestForPlacementStatus,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalReferralsTest.kt
@@ -78,7 +78,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
             Cas1ReferralHistory(
               id = assessment1.id,
               applicationId = assessment1.application.id,
-              createdAt = assessment1.createdAt.toInstant(),
+              date = assessment1.createdAt.toLocalDate(),
               applicationStatus = (assessment1.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
@@ -93,7 +93,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
             Cas1ReferralHistory(
               id = assessment2.id,
               applicationId = assessment2.application.id,
-              createdAt = assessment2.createdAt.toInstant(),
+              date = assessment2.createdAt.toLocalDate(),
               applicationStatus = (assessment2.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
@@ -108,7 +108,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
             Cas1ReferralHistory(
               id = assessment3.id,
               applicationId = assessment3.application.id,
-              createdAt = assessment3.createdAt.toInstant(),
+              date = assessment3.createdAt.toLocalDate(),
               applicationStatus = (assessment3.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
@@ -123,7 +123,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
             Cas1ReferralHistory(
               id = assessment4.id,
               applicationId = assessment4.application.id,
-              createdAt = assessment4.createdAt.toInstant(),
+              date = assessment4.createdAt.toLocalDate(),
               applicationStatus = (assessment4.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",
@@ -138,7 +138,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
             Cas1ReferralHistory(
               id = assessment5.id,
               applicationId = assessment5.application.id,
-              createdAt = assessment5.createdAt.toInstant(),
+              date = assessment5.createdAt.toLocalDate(),
               applicationStatus = (assessment5.application as ApprovedPremisesApplicationEntity).status,
               type = ServiceType.CAS1,
               referralRejectionReason = "Not suitable",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
@@ -74,7 +74,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
             Cas3ReferralHistory(
               id = assessment1.id,
               applicationId = assessment1.application.id,
-              createdAt = assessment1.createdAt.toInstant(),
+              date = assessment1.createdAt.toLocalDate(),
               applicationStatus = ApplicationStatus.submitted,
               assessmentStatus = assessment1.deriveAssessmentStatus(),
               type = ServiceType.CAS3,
@@ -90,7 +90,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
             Cas3ReferralHistory(
               id = assessment2.id,
               applicationId = assessment2.application.id,
-              createdAt = assessment2.createdAt.toInstant(),
+              date = assessment2.createdAt.toLocalDate(),
               applicationStatus = ApplicationStatus.submitted,
               assessmentStatus = assessment2.deriveAssessmentStatus(),
               type = ServiceType.CAS3,
@@ -106,7 +106,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
             Cas3ReferralHistory(
               id = assessment3.id,
               applicationId = assessment3.application.id,
-              createdAt = assessment3.createdAt.toInstant(),
+              date = assessment3.createdAt.toLocalDate(),
               applicationStatus = ApplicationStatus.submitted,
               assessmentStatus = assessment3.deriveAssessmentStatus(),
               type = ServiceType.CAS3,
@@ -122,7 +122,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
             Cas3ReferralHistory(
               id = assessment4.id,
               applicationId = assessment4.application.id,
-              createdAt = assessment4.createdAt.toInstant(),
+              date = assessment4.createdAt.toLocalDate(),
               applicationStatus = ApplicationStatus.submitted,
               assessmentStatus = assessment4.deriveAssessmentStatus(),
               type = ServiceType.CAS3,
@@ -138,7 +138,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
             Cas3ReferralHistory(
               id = assessment5.id,
               applicationId = assessment5.application.id,
-              createdAt = assessment5.createdAt.toInstant(),
+              date = assessment5.createdAt.toLocalDate(),
               applicationStatus = ApplicationStatus.submitted,
               assessmentStatus = assessment5.deriveAssessmentStatus(),
               type = ServiceType.CAS3,


### PR DESCRIPTION
This Pull Request updates data models and associated logic to replace Instant with LocalDate for date-related fields in Cas1ReferralHistory and Cas3ReferralHistory. Corresponding changes are also made in transformers and test files to align with this update.

Main changes:
Data model changes:

- In Cas1ReferralHistory and Cas3ReferralHistory, the createdAt: Instant field has been replaced with date: LocalDate.

Transformer updates:
- Logic in Cas1AssessmentTransformer and Cas3AssessmentTransformer has been updated to calculate date as submittedAt?.toLocalDate() ?: createdAt.toLocalDate() to ensure correct date assignment.

Test file updates:
- In test cases within Cas1ExternalReferralsTest and Cas3ExternalReferralTest, the usage of createdAt.toInstant() has been updated to createdAt.toLocalDate() to match the new LocalDate type.

This adjustment ensures better alignment with the intended use of date-only fields, improving readability and consistency.