### PR TITLE
FM-866 fix case and case access progressive mocks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -135,7 +135,7 @@ class CaseService(
     val caseSummariesResponse = apDeliusContextApiClient.getCaseSummaries(listOf(crn))
   ) {
     is ClientResult.Success ->
-      caseSummariesResponse.body.cases.firstOrNull() ?: throw NotFoundProblem(crn, "Offender")
+      caseSummariesResponse.body.cases.firstOrNull { it.crn == crn } ?: throw NotFoundProblem(crn, "Offender")
 
     is ClientResult.Failure -> caseSummariesResponse.throwException()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ApplicationTest.kt
@@ -39,9 +39,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUnsuccessfulCaseSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesErrorResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateAfter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateBefore
@@ -587,7 +587,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
       givenACas2v2DeliusUser { userEntity, jwt ->
         val crn = "X1234"
 
-        apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+        apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
         produceAndPersistBasicApplication(crn, userEntity)
 
@@ -1128,7 +1128,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             },
           ) { offenderDetails, _ ->
 
-            apDeliusContextAddSingleCaseSummaryToBulkResponse(
+            apDeliusContextCaseSummariesSingleCase(
               caseSummary = CaseSummaryFactory()
                 .withCrn(crn)
                 .withNomsId(nomsNumber)
@@ -1182,7 +1182,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
             },
           ) { offenderDetails, _ ->
 
-            apDeliusContextAddSingleCaseSummaryToBulkResponse(
+            apDeliusContextCaseSummariesSingleCase(
               caseSummary = CaseSummaryFactory()
                 .withCrn(crn)
                 .withNomsId(nomsNumber)
@@ -1278,7 +1278,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
               },
             ) { offenderDetails, _ ->
 
-              apDeliusContextAddSingleCaseSummaryToBulkResponse(
+              apDeliusContextCaseSummariesSingleCase(
                 caseSummary = CaseSummaryFactory()
                   .withCrn(crn)
                   .withNomsId(nomsNumber)
@@ -1458,7 +1458,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
 
     @Test
     fun `Create new application for cas2v2 as a Noms user returns 201 with correct body and Location header`() {
-      apDeliusContextAddSingleCaseSummaryToBulkResponse(
+      apDeliusContextCaseSummariesSingleCase(
         caseSummary = CaseSummaryFactory()
           .withCrn(crn)
           .withNomsId(nomsNumber)
@@ -1472,7 +1472,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
     @Test
     fun `Create new cas2v2 application as a Noms user returns 404 when a person cannot be found`() {
       givenACas2v2NomisUser { _, jwt ->
-        apDeliusContextMockUnsuccessfulCaseSummaryCall(404)
+        apDeliusContextCaseSummariesErrorResponse(404)
         createNewApplicationForCas2v2Returns404WhenAPersonIsNotFound(jwt)
       }
     }
@@ -1562,7 +1562,7 @@ class Cas2v2ApplicationTest : IntegrationTestBase() {
         },
       ) { offenderDetails, _ ->
 
-        apDeliusContextAddSingleCaseSummaryToBulkResponse(
+        apDeliusContextCaseSummariesSingleCase(
           caseSummary = CaseSummaryFactory()
             .withCrn(crn)
             .withNomsId(nomsNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2PersonSearchTest.kt
@@ -18,9 +18,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2DeliusUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2NomisUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockCaseSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUnsuccessfulCaseSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesErrorResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonAPIMockSuccessfulInmateDetailsCall
 import java.time.LocalDate
 
@@ -75,7 +75,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
         @Test
         fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized by the API`() {
           givenACas2v2NomisUser { _, jwt ->
-            apDeliusContextMockUnsuccessfulCaseSummaryCall(403)
+            apDeliusContextCaseSummariesErrorResponse(403)
 
             webTestClient.get()
               .uri("/cas2/people/search-by-noms/NOMS321")
@@ -89,7 +89,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
         @Test
         fun `Searching for a NOMIS ID returns 404 error when it is not found`() {
           givenACas2v2DeliusUser { _, jwt ->
-            apDeliusContextMockUnsuccessfulCaseSummaryCall(404)
+            apDeliusContextCaseSummariesErrorResponse(404)
 
             webTestClient.get()
               .uri("/cas2/people/search-by-noms/NOMS321")
@@ -103,7 +103,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
         @Test
         fun `Searching for a NOMIS ID returns server error when there is a server error`() {
           givenACas2v2NomisUser { _, jwt ->
-            apDeliusContextMockUnsuccessfulCaseSummaryCall()
+            apDeliusContextCaseSummariesErrorResponse()
 
             webTestClient.get()
               .uri("/cas2/people/search-by-noms/NOMS321")
@@ -144,7 +144,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
               )
               .produce()
 
-            apDeliusContextMockCaseSummary(caseSummary)
+            apDeliusContextCaseSummariesSingleCase(caseSummary)
             prisonAPIMockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
 
             webTestClient.get()
@@ -236,9 +236,7 @@ class Cas2v2PersonSearchTest : IntegrationTestBase() {
 
         @Test
         fun `Searching for a CRN that does not exist returns 404`() {
-          apDeliusContextAddCaseSummaryToBulkResponse(
-            CaseSummaryFactory().produce(),
-          )
+          apDeliusContextCaseSummariesEmptyResponseForCrn("CRN")
 
           givenACas2v2DeliusUser { _, jwt ->
             wiremockServer.stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2SubmissionTest.kt
@@ -39,7 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2DeliusUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2v2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.manageUsersMockSuccessfulExternalUsersCall
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -358,7 +358,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
     fun `Assessor can view single submitted application`() {
       val crn = "CRN321"
       val nomsNumber = "NOMS321"
-      apDeliusContextAddSingleCaseSummaryToBulkResponse(
+      apDeliusContextCaseSummariesSingleCase(
         caseSummary = CaseSummaryFactory()
           .withCrn(crn)
           .withNomsId(nomsNumber)
@@ -490,7 +490,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
     fun `Assessor cannot view single submitted application on a restricted offender`() {
       val crn = "CRN321"
       val nomsNumber = "NOMS321"
-      apDeliusContextAddSingleCaseSummaryToBulkResponse(
+      apDeliusContextCaseSummariesSingleCase(
         caseSummary = CaseSummaryFactory()
           .withCrn(crn)
           .withNomsId(nomsNumber)
@@ -537,7 +537,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
     fun `Assessor can view single submitted application on an excluded offender`() {
       val crn = "CRN321"
       val nomsNumber = "NOMS321"
-      apDeliusContextAddSingleCaseSummaryToBulkResponse(
+      apDeliusContextCaseSummariesSingleCase(
         caseSummary = CaseSummaryFactory()
           .withCrn(crn)
           .withNomsId(nomsNumber)
@@ -695,7 +695,7 @@ class Cas2v2SubmissionTest : IntegrationTestBase() {
       fun `Admin can view single submitted application`() {
         val crn = "CRN321"
         val nomsNumber = "NOMS321"
-        apDeliusContextAddSingleCaseSummaryToBulkResponse(
+        apDeliusContextCaseSummariesSingleCase(
           caseSummary = CaseSummaryFactory()
             .withCrn(crn)
             .withNomsId(nomsNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2ApplicationTest.kt
@@ -42,8 +42,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2LicenceCaseAdminUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonAPIMockNotFoundInmateDetailsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsListOfObjects
@@ -709,7 +709,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
       givenACas2PomUser { userEntity, jwt ->
         val crn = "X1234"
 
-        apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+        apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
         produceAndPersistBasicApplication(crn, userEntity)
         webTestClient.get()
@@ -1642,7 +1642,7 @@ class Cas2ApplicationTest : IntegrationTestBase() {
               .withCurrentExclusion(true).produce()
 
           val caseDetail = offenderDetails.asCaseSummary()
-          apDeliusContextMockCaseSummary(caseDetail)
+          apDeliusContextCaseSummariesSingleCase(caseDetail)
           mockInmateDetailPrisonsApiCall(InmateDetail(caseDetail.nomsId!!, InmateStatus.IN, null, bookingId = null))
 
           webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonOASysRiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonOASysRiskToSelfTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockUnsuccessfulRisksToTheIndividualCallWithDelay
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 
 class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
   @Autowired
@@ -60,7 +60,7 @@ class Cas2PersonOASysRiskToSelfTest : IntegrationTestBase() {
     givenACas2PomUser { _, jwt ->
       val crn = "CRN123"
 
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       webTestClient.get()
         .uri("/cas2-hdc/people/$crn/oasys/risk-to-self")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonOASysRoshTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonOASysRoshTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockUnsuccessfulRoshCallWithDelay
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 
 class Cas2PersonOASysRoshTest : IntegrationTestBase() {
   @Autowired
@@ -60,7 +60,7 @@ class Cas2PersonOASysRoshTest : IntegrationTestBase() {
     givenACas2PomUser { _, jwt ->
       val crn = "CRN123"
 
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       webTestClient.get()
         .uri("/cas2-hdc/people/$crn/oasys/rosh")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonRisksTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import java.time.OffsetDateTime
 
 class Cas2PersonRisksTest : IntegrationTestBase() {
@@ -63,7 +63,7 @@ class Cas2PersonRisksTest : IntegrationTestBase() {
     givenACas2PomUser { userEntity, jwt ->
       val crn = "CRN123"
 
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       webTestClient.get()
         .uri("/cas2-hdc/people/$crn/risks")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2PersonSearchTest.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas2PomUser
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockCaseSummary
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUnsuccessfulCaseSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesErrorResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonAPIMockSuccessfulInmateDetailsCall
 import java.time.LocalDate
 
@@ -66,7 +66,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
       @Test
       fun `Searching for a NOMIS ID returns Unauthorised error when it is unauthorized by the API`() {
         givenACas2PomUser { userEntity, jwt ->
-          apDeliusContextMockUnsuccessfulCaseSummaryCall(403)
+          apDeliusContextCaseSummariesErrorResponse(403)
 
           webTestClient.get()
             .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
@@ -106,7 +106,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
             )
             .produce()
 
-          apDeliusContextMockCaseSummary(caseSummary)
+          apDeliusContextCaseSummariesSingleCase(caseSummary)
           prisonAPIMockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
 
           webTestClient.get()
@@ -121,7 +121,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
       @Test
       fun `Searching for a NOMIS ID returns 404 error when it is not found`() {
         givenACas2PomUser { userEntity, jwt ->
-          apDeliusContextMockUnsuccessfulCaseSummaryCall(404)
+          apDeliusContextCaseSummariesErrorResponse(404)
 
           webTestClient.get()
             .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
@@ -135,7 +135,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
       @Test
       fun `Searching for a NOMIS ID returns server error when there is a server error`() {
         givenACas2PomUser { userEntity, jwt ->
-          apDeliusContextMockUnsuccessfulCaseSummaryCall()
+          apDeliusContextCaseSummariesErrorResponse()
 
           webTestClient.get()
             .uri("/cas2-hdc/people/search?nomsNumber=NOMS321")
@@ -177,7 +177,7 @@ class Cas2PersonSearchTest : IntegrationTestBase() {
             )
             .produce()
 
-          apDeliusContextMockCaseSummary(caseSummary)
+          apDeliusContextCaseSummariesSingleCase(caseSummary)
           prisonAPIMockSuccessfulInmateDetailsCall(inmateDetail = inmateDetail)
 
           webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3ApplicationTest.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
@@ -99,7 +99,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               val anotherUsersApplication =
                 createApplicationEntity(otherUser, offenderDetails, probationRegion, null)
 
-              apDeliusContextAddResponseToUserAccessCall(
+              apDeliusContextUserAccessAddCase(
                 listOf(
                   CaseAccessFactory()
                     .withCrn(offenderDetails.otherIds.crn)
@@ -189,7 +189,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
             )
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -223,7 +223,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               )
             }
 
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -258,7 +258,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               )
             }
 
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -293,7 +293,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               )
             }
 
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -330,7 +330,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               )
             }
 
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -369,7 +369,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
             )
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -450,7 +450,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               )
             }
 
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -487,7 +487,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
               )
             }
 
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -523,7 +523,7 @@ class Cas3ApplicationTest : InitialiseDatabasePerClassTestBase() {
             )
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3AssessmentTest.kt
@@ -37,7 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForTemporaryAccommodation
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenSomeOffenders
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -340,7 +340,7 @@ class Cas3AssessmentTest : IntegrationTestBase() {
       givenAUser { user, jwt ->
         givenSomeOffenders { offenderSequence ->
           val offenders = offenderSequence.take(5).toList()
-          apDeliusContextAddListCaseSummaryToBulkResponse(offenders.map { (offenderDetails, _) -> offenderDetails.asCaseSummary() })
+          apDeliusContextCaseSummariesMultipleCases(offenders.map { (offenderDetails, _) -> offenderDetails.asCaseSummary() })
 
           data class AssessmentParams(
             val assessment: TemporaryAccommodationAssessmentEntity,
@@ -516,7 +516,7 @@ class Cas3AssessmentTest : IntegrationTestBase() {
             .sortedBy { (it.assessment.application as TemporaryAccommodationApplicationEntity).arrivalDate }
             .map { assessmentSummaryMapper(it.offenderDetails, it.inmateDetails).toCas3Summary(it.assessment) }
 
-          apDeliusContextAddListCaseSummaryToBulkResponse(offenders.map { (offenderDetails, _) -> offenderDetails.asCaseSummary() })
+          apDeliusContextCaseSummariesMultipleCases(offenders.map { (offenderDetails, _) -> offenderDetails.asCaseSummary() })
 
           assertResponseForUrl(
             jwt,
@@ -683,7 +683,7 @@ class Cas3AssessmentTest : IntegrationTestBase() {
           val otherAssessment =
             produceAndPersistAssessmentEntity(user, otherApplication)
 
-          apDeliusContextAddListCaseSummaryToBulkResponse(
+          apDeliusContextCaseSummariesMultipleCases(
             listOf(
               offender.first.asCaseSummary(),
               otherOffender.first.asCaseSummary(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateApplicationOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateApplicationOffenderNameJobTest.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 
@@ -51,7 +51,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
           .produce()
       }
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(cases)
+      apDeliusContextCaseSummariesMultipleCases(cases)
 
       migrationJobService.runMigrationJob(MigrationJobType.updateCas3ApplicationOffenderName, 10)
 
@@ -96,7 +96,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
           .produce()
       }
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(cases)
+      apDeliusContextCaseSummariesMultipleCases(cases)
 
       migrationJobService.runMigrationJob(MigrationJobType.updateCas3ApplicationOffenderName, 10)
 
@@ -130,7 +130,7 @@ class Cas3UpdateApplicationOffenderNameJobTest : MigrationJobTestBase() {
         withCrn(crn)
       }
 
-      apDeliusContextEmptyCaseSummaryToBulkResponse(offenderDetails.otherIds.crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(offenderDetails.otherIds.crn)
 
       migrationJobService.runMigrationJob(MigrationJobType.updateCas3ApplicationOffenderName, 10)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateBookingOffenderNameJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/migration/Cas3UpdateBookingOffenderNameJobTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.migration.MigrationJobTestBase
 
 class Cas3UpdateBookingOffenderNameJobTest : MigrationJobTestBase() {
@@ -47,8 +47,8 @@ class Cas3UpdateBookingOffenderNameJobTest : MigrationJobTestBase() {
           .produce()
       }
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(cases1)
-      apDeliusContextAddListCaseSummaryToBulkResponse(cases2)
+      apDeliusContextCaseSummariesMultipleCases(cases1)
+      apDeliusContextCaseSummariesMultipleCases(cases2)
 
       migrationJobService.runMigrationJob(MigrationJobType.updateCas3BookingOffenderName, 10)
 
@@ -80,7 +80,7 @@ class Cas3UpdateBookingOffenderNameJobTest : MigrationJobTestBase() {
           .produce()
       }
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(cases)
+      apDeliusContextCaseSummariesMultipleCases(cases)
 
       listOf(approvedPremises, cas2, cas2v2).forEach { serviceName ->
         bookingEntityFactory.produceAndPersistMultiple(2) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BedspaceSearchTest.kt
@@ -39,8 +39,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenCas3PremisesAndBedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenSomeOffenders
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository.Constants.CAS3_PROPERTY_NAME_SHARED_PROPERTY
@@ -474,9 +474,9 @@ class Cas3v2BedspaceSearchTest : IntegrationTestBase() {
             withId(UUID.randomUUID())
           }
 
-          apDeliusContextAddListCaseSummaryToBulkResponse(listOf(fullPersonCaseSummary, userExcludedCaseSummary, currentRestrictionCaseSummary))
+          apDeliusContextCaseSummariesMultipleCases(listOf(fullPersonCaseSummary, userExcludedCaseSummary, currentRestrictionCaseSummary))
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(userExcludedCaseSummary.crn)
@@ -641,7 +641,7 @@ class Cas3v2BedspaceSearchTest : IntegrationTestBase() {
             withReason(cancellationReasonEntityFactory.produceAndPersist())
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -846,7 +846,7 @@ class Cas3v2BedspaceSearchTest : IntegrationTestBase() {
             }
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1559,7 +1559,7 @@ class Cas3v2BedspaceSearchTest : IntegrationTestBase() {
             withCrn(offenderDetailsThree.otherIds.crn)
           }
 
-          apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseSummaryTwo))
+          apDeliusContextCaseSummariesMultipleCases(listOf(caseSummaryTwo))
 
           webTestClient.post()
             .uri("cas3/v2/bedspaces/search")
@@ -1741,7 +1741,7 @@ class Cas3v2BedspaceSearchTest : IntegrationTestBase() {
             withCrn(offenderDetailsThree.otherIds.crn)
           }
 
-          apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseSummaryTwo))
+          apDeliusContextCaseSummariesMultipleCases(listOf(caseSummaryTwo))
 
           webTestClient.post()
             .uri("cas3/v2/bedspaces/search")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingSearchTest.kt
@@ -26,8 +26,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenSomeOffenders
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -78,8 +78,8 @@ class Cas3v2BookingSearchTest : IntegrationTestBase() {
         )
         val expectedResponse = getExpectedResponse(expectedBookingSearchResult, crn, personName = "Unknown")
 
-        apDeliusContextAddListCaseSummaryToBulkResponse(casesSummary = emptyList(), crns = listOf("S121978"))
-        apDeliusContextAddResponseToUserAccessCall(casesAccess = emptyList(), username = userEntity.deliusUsername)
+        apDeliusContextCaseSummariesMultipleCases(casesSummary = emptyList(), crns = listOf("S121978"))
+        apDeliusContextUserAccessAddCase(casesAccess = emptyList(), username = userEntity.deliusUsername)
 
         // when CRN is upper case
         callApiAndAssertResponse("/cas3/v2/bookings/search?crnOrName=$crn", jwt, expectedResponse, true)
@@ -111,9 +111,9 @@ class Cas3v2BookingSearchTest : IntegrationTestBase() {
           .withCurrentExclusion(true)
           .produce()
 
-        apDeliusContextAddListCaseSummaryToBulkResponse(listOf(userExcludedCaseSummary))
+        apDeliusContextCaseSummariesMultipleCases(listOf(userExcludedCaseSummary))
 
-        apDeliusContextAddResponseToUserAccessCall(
+        apDeliusContextUserAccessAddCase(
           listOf(
             CaseAccessFactory()
               .withCrn(userExcludedCaseSummary.crn)
@@ -357,7 +357,7 @@ class Cas3v2BookingSearchTest : IntegrationTestBase() {
         for (page in 0..<totalPages) {
           val currentPageSize = if (page == totalPages - 1) totalResults % pageSize else pageSize
 
-          apDeliusContextAddListCaseSummaryToBulkResponse(
+          apDeliusContextCaseSummariesMultipleCases(
             casesSummary = offendersSorted.drop(page * pageSize)
               .take(pageSize)
               .map { it.first.asCaseSummary() },
@@ -1209,8 +1209,8 @@ class Cas3v2BookingSearchTest : IntegrationTestBase() {
       }
     }
 
-    apDeliusContextAddListCaseSummaryToBulkResponse(cases)
-    apDeliusContextAddResponseToUserAccessCall(
+    apDeliusContextCaseSummariesMultipleCases(cases)
+    apDeliusContextUserAccessAddCase(
       casesAccess = cases.map { CaseAccessFactory().withCrn(it.crn).withAccess().produce() },
       username = username,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2BookingTest.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenCas3ApplicationAndAssessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenCas3PremiseBedspace
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenCas3PremisesAndBedspace
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withConflictMessage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.withNotFoundMessage
@@ -254,7 +254,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
           withServiceName(ServiceName.temporaryAccommodation)
         }
 
-        apDeliusContextEmptyCaseSummaryToBulkResponse("SOME-CRN")
+        apDeliusContextCaseSummariesEmptyResponseForCrn("SOME-CRN")
 
         webTestClient.get()
           .uri("/cas3/v2/premises/${premises.id}/bookings/${booking.id}")
@@ -467,7 +467,7 @@ class Cas3v2BookingTest : IntegrationTestBase() {
         ),
       )
 
-      apDeliusContextEmptyCaseSummaryToBulkResponse("SOME-CRN")
+      apDeliusContextCaseSummariesEmptyResponseForCrn("SOME-CRN")
 
       webTestClient.get()
         .uri("/cas3/v2/premises/${premises.id}/bookings")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/v2/Cas3v2ReportsTest.kt
@@ -55,7 +55,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision.ACCEPTED
@@ -83,9 +83,7 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import kotlin.collections.get
 import kotlin.collections.listOf
-import kotlin.text.get
 
 class Cas3v2ReportsTest : IntegrationTestBase() {
   @ParameterizedTest
@@ -342,7 +340,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -415,7 +413,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -492,7 +490,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -564,7 +562,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -629,7 +627,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             LocalDate.parse("2023-12-15"),
           )
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -731,7 +729,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -818,7 +816,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -908,7 +906,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
               withAccommodationRequiredFromDate(LocalDate.now().plusDays(10))
             }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -988,7 +986,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1063,7 +1061,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1140,7 +1138,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1243,7 +1241,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1326,7 +1324,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1409,7 +1407,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1543,7 +1541,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1626,7 +1624,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1718,7 +1716,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1810,7 +1808,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             .withPnc(offenderDetails.otherIds.pncNumber)
             .produce()
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -2140,7 +2138,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             }
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -2432,7 +2430,7 @@ class Cas3v2ReportsTest : IntegrationTestBase() {
             }
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/CaseNotesTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.PageMe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseNoteFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.caseNotesAPIMockSuccessfulCaseNotesCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PrisonCaseNoteTransformer
 import java.time.LocalDate
@@ -64,7 +64,7 @@ class CaseNotesTest : IntegrationTestBase() {
   fun `Getting case notes for a CRN that does not exist returns 404`() {
     givenAUser { userEntity, jwt ->
       val crn = "CRN345"
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       wiremockServer.stubFor(
         WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/$crn"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonAdjudicationsTest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AdjudicationsPag
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AgencyFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonAPIMockSuccessfulAdjudicationsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.AdjudicationTransformer
 import java.time.LocalDateTime
@@ -60,7 +60,7 @@ class PersonAdjudicationsTest : InitialiseDatabasePerClassTestBase() {
   fun `Getting adjudications for a CRN that does not exist returns 404`() {
     givenAUser { userEntity, jwt ->
       val crn = "CRN123"
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       webTestClient.get()
         .uri("/people/$crn/adjudications")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOASysSectionsTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskToTheIndividualCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoSHSummaryCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockUnsuccessfulNeedsDetailsCallWithDelay
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
 
 class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
@@ -67,7 +67,7 @@ class PersonOASysSectionsTest : InitialiseDatabasePerClassTestBase() {
     givenAUser { userEntity, jwt ->
       val crn = "CRN123"
 
-      apDeliusContextAddSingleResponseToUserAccessCall(
+      apDeliusContextUserAccessSingleCase(
         CaseAccessFactory()
           .withUserRestricted(true)
           .withCrn(crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonOffencesTest.kt
@@ -8,8 +8,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailOffenc
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.from
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleResponseToUserAccessCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OffenceTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.asCaseDetail
 import java.time.LocalDate
@@ -62,7 +62,7 @@ class PersonOffencesTest : InitialiseDatabasePerClassTestBase() {
     givenAUser { userEntity, jwt ->
       val crn = "CRN123"
 
-      apDeliusContextAddSingleResponseToUserAccessCall(
+      apDeliusContextUserAccessSingleCase(
         CaseAccessFactory()
           .withUserRestricted(true)
           .withCrn(crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PersonSearchTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import java.time.LocalDate
 
 class PersonSearchTest : IntegrationTestBase() {
@@ -94,7 +94,7 @@ class PersonSearchTest : IntegrationTestBase() {
   @Test
   fun `Searching for a CRN that does not exist returns 404`() {
     givenAUser { _, jwt ->
-      apDeliusContextEmptyCaseSummaryToBulkResponse("CRN1")
+      apDeliusContextCaseSummariesEmptyResponseForCrn("CRN1")
 
       webTestClient.get()
         .uri("/people/search?crn=CRN1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PrisonerAcctAlertsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/PrisonerAcctAlertsTest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisoneralertsapi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PrisonerAlertFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonerAlertsAPIMockSuccessfulAlertsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PrisonerAlertTransformer
 
@@ -59,7 +59,7 @@ class PrisonerAcctAlertsTest : InitialiseDatabasePerClassTestBase() {
   fun `Getting ACCT alerts for a CRN that does not exist returns 404`() {
     givenAUser { _, jwt ->
       val crn = "CRN123"
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       webTestClient.get()
         .uri("/people/$crn/acct-alerts")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -64,11 +64,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
@@ -1365,7 +1365,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
         ) { offenderDetails, _ ->
           val application = produceAndPersistBasicApplication(offenderDetails.otherIds.crn, userEntity, "TEAM1")
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1452,7 +1452,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             withData("{}")
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1497,7 +1497,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             withCrn(offenderDetails.otherIds.crn)
           }
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(offenderDetails.otherIds.crn)
@@ -1545,7 +1545,7 @@ class Cas1ApplicationTest : IntegrationTestBase() {
       givenAUser { _, jwt ->
         val crn = "X1234"
 
-        apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+        apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
         webTestClient.post()
           .uri("/cas1/applications")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1AssessmentTest.kt
@@ -45,7 +45,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAPlacementApplicationPlaceholder
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -548,7 +548,7 @@ class Cas1AssessmentTest : IntegrationTestBase() {
         })
         val assessBagatha = createApprovedPremisesAssessmentForStatus(user, offender4.asCaseSummary(), cas1InProgress)
 
-        apDeliusContextAddListCaseSummaryToBulkResponse(listOf(offender1.asCaseSummary(), offender2.asCaseSummary(), offender3.asCaseSummary(), offender4.asCaseSummary()))
+        apDeliusContextCaseSummariesMultipleCases(listOf(offender1.asCaseSummary(), offender2.asCaseSummary(), offender3.asCaseSummary(), offender4.asCaseSummary()))
 
         assertAssessmentsReturnedGivenStatus(
           jwt,
@@ -579,7 +579,7 @@ class Cas1AssessmentTest : IntegrationTestBase() {
         val (offender4, inmate4) = givenAnOffender({ withCrn("CRN3") })
         val assessCrn3 = createApprovedPremisesAssessmentForStatus(user, offender4.asCaseSummary(), cas1InProgress)
 
-        apDeliusContextAddListCaseSummaryToBulkResponse(listOf(offender1.asCaseSummary(), offender2.asCaseSummary(), offender3.asCaseSummary(), offender4.asCaseSummary()))
+        apDeliusContextCaseSummariesMultipleCases(listOf(offender1.asCaseSummary(), offender2.asCaseSummary(), offender3.asCaseSummary(), offender4.asCaseSummary()))
 
         assertAssessmentsReturnedGivenStatus(
           jwt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PeopleTest.kt
@@ -48,11 +48,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextEmptyCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUnsuccesfullCaseDetailCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.healthAndMedicationMockForbiddenDietAndAllergyCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.healthAndMedicationMockNotFoundDietAndAllergyCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.healthAndMedicationMockSuccessfulDietAndAllergyCall
@@ -93,7 +93,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
     @Test
     fun `Getting a personal timeline for a CRN that does not exist returns 404`() {
       givenAUser { _, jwt ->
-        apDeliusContextEmptyCaseSummaryToBulkResponse("CRN1")
+        apDeliusContextCaseSummariesEmptyResponseForCrn("CRN1")
 
         webTestClient.get()
           .uri("/cas1/people/CRN1/timeline")
@@ -682,8 +682,8 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
         .withUserRestricted(false)
         .produce()
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseSummary))
-      apDeliusContextAddResponseToUserAccessCall(listOf(caseAccess), user.deliusUsername)
+      apDeliusContextCaseSummariesMultipleCases(listOf(caseSummary))
+      apDeliusContextUserAccessAddCase(listOf(caseAccess), user.deliusUsername)
       prisonAPIMockSuccessfulCsraSummariesCall(nomsNumber, csraSummaries)
 
       webTestClient.get()
@@ -714,8 +714,8 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
         .withUserRestricted(true)
         .produce()
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseSummary))
-      apDeliusContextAddResponseToUserAccessCall(listOf(caseAccess), user.deliusUsername)
+      apDeliusContextCaseSummariesMultipleCases(listOf(caseSummary))
+      apDeliusContextUserAccessAddCase(listOf(caseAccess), user.deliusUsername)
 
       webTestClient.get()
         .uri("/cas1/people/$crn/csra-summaries")
@@ -730,7 +730,7 @@ class Cas1PeopleTest : InitialiseDatabasePerClassTestBase() {
       val (_, jwt) = givenAUser(roles = listOf(UserRole.CAS1_FUTURE_MANAGER))
       val crn = "NOT_FOUND_CRN"
 
-      apDeliusContextEmptyCaseSummaryToBulkResponse(crn)
+      apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
 
       webTestClient.get()
         .uri("/cas1/people/$crn/csra-summaries")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementApplicationsTest.kt
@@ -30,7 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -272,7 +272,7 @@ class Cas1PlacementApplicationsTest : IntegrationTestBase() {
             crn = offenderDetails.otherIds.crn,
             createdByUser = user,
           ) { placementApplicationEntity ->
-            apDeliusContextAddResponseToUserAccessCall(
+            apDeliusContextUserAccessAddCase(
               listOf(
                 CaseAccessFactory()
                   .withCrn(offenderDetails.otherIds.crn)
@@ -344,7 +344,7 @@ class Cas1PlacementApplicationsTest : IntegrationTestBase() {
           createdByUser = user,
         ) { placementApplicationEntity ->
 
-          apDeliusContextAddResponseToUserAccessCall(
+          apDeliusContextUserAccessAddCase(
             listOf(
               CaseAccessFactory()
                 .withCrn(placementApplicationEntity.application.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestSearchPaginationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestSearchPaginationTest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenSomeOffenders
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -30,7 +30,7 @@ class Cas1PlacementRequestSearchPaginationTest : IntegrationTestBase() {
         val createdAt = OffsetDateTime.parse("2024-01-01T10:00:00Z")
         val offenders = offenderSequence.take(15).toList()
 
-        apDeliusContextAddListCaseSummaryToBulkResponse(offenders.map { it.first.asCaseSummary() })
+        apDeliusContextCaseSummariesMultipleCases(offenders.map { it.first.asCaseSummary() })
 
         offenders.forEach { (offender, _) ->
           createPlacementRequest(offender.asCaseSummary(), user, createdAt = createdAt, applicationDate = createdAt)
@@ -96,7 +96,7 @@ class Cas1PlacementRequestSearchPaginationTest : IntegrationTestBase() {
         val b1Offenders = allOffenders.take(15)
         val c1Offenders = allOffenders.drop(15).take(5)
 
-        apDeliusContextAddListCaseSummaryToBulkResponse((b1Offenders + c1Offenders).map { it.first.asCaseSummary() })
+        apDeliusContextCaseSummariesMultipleCases((b1Offenders + c1Offenders).map { it.first.asCaseSummary() })
 
         // Create 15 placement requests with the same tier and createdAt
         b1Offenders.forEach { (offender, _) ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
@@ -1456,7 +1456,7 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
               createdByUser = otherUser,
               crn = offenderDetails.otherIds.crn,
             ) { placementRequest, _ ->
-              apDeliusContextAddResponseToUserAccessCall(
+              apDeliusContextUserAccessAddCase(
                 listOf(
                   CaseAccessFactory()
                     .withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PremisesTest.kt
@@ -38,7 +38,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOutOfServiceBed
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
@@ -1061,7 +1061,7 @@ class Cas1PremisesTest : IntegrationTestBase() {
         },
       ).first.asCaseSummary()
 
-      apDeliusContextAddListCaseSummaryToBulkResponse(listOf(offenderA, offenderB, offenderOffline))
+      apDeliusContextCaseSummariesMultipleCases(listOf(offenderA, offenderB, offenderOffline))
 
       givenAPlacementRequest(
         assessmentAllocatedTo = user,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1SpaceBookingTest.kt
@@ -56,9 +56,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOfflineApplication
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddSingleResponseToUserAccessCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulStaffDetailByCodeCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
@@ -255,7 +255,7 @@ class Cas1SpaceBookingTest {
 
           val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
-          apDeliusContextAddSingleCaseSummaryToBulkResponse(
+          apDeliusContextCaseSummariesSingleCase(
             CaseSummaryFactory()
               .withCrn(application.crn)
               .produce(),
@@ -350,7 +350,7 @@ class Cas1SpaceBookingTest {
 
           val premises = givenAnApprovedPremises(supportsSpaceBookings = true)
 
-          apDeliusContextAddSingleCaseSummaryToBulkResponse(
+          apDeliusContextCaseSummariesSingleCase(
             CaseSummaryFactory()
               .withCrn(application.crn)
               .produce(),
@@ -458,7 +458,7 @@ class Cas1SpaceBookingTest {
             )
           }
 
-          apDeliusContextAddSingleCaseSummaryToBulkResponse(
+          apDeliusContextCaseSummariesSingleCase(
             CaseSummaryFactory()
               .withCrn(application.crn)
               .produce(),
@@ -580,7 +580,7 @@ class Cas1SpaceBookingTest {
             )
           }
 
-          apDeliusContextAddSingleCaseSummaryToBulkResponse(
+          apDeliusContextCaseSummariesSingleCase(
             CaseSummaryFactory()
               .withCrn(application.crn)
               .produce(),
@@ -1032,7 +1032,7 @@ class Cas1SpaceBookingTest {
     fun `Filter on CRN, RestrictedPerson`() {
       val (_, jwt) = givenAUser(roles = listOf(CAS1_FUTURE_MANAGER))
 
-      apDeliusContextAddSingleResponseToUserAccessCall(
+      apDeliusContextUserAccessSingleCase(
         caseAccess = CaseAccessFactory()
           .withUserExcluded(true)
           .withUserRestricted(true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnOffender.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactor
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockCaseSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.prisonAPIMockNotFoundInmateDetailsCall
@@ -40,7 +40,7 @@ fun IntegrationTestBase.givenAnOffender(
 
   apDeliusContextMockSuccessfulCaseDetailCall(offenderDetails.otherIds.crn, caseDetail)
 
-  apDeliusContextMockCaseSummary(caseDetail.case)
+  apDeliusContextCaseSummariesAddCase(caseDetail.case)
   apDeliusContextMockUserAccess(
     CaseAccessFactory()
       .withCrn(offenderDetails.otherIds.crn)
@@ -109,7 +109,7 @@ fun IntegrationTestBase.givenSomeOffenders(
 
     apDeliusContextMockSuccessfulCaseDetailCall(offenderDetails.otherIds.crn, caseDetail)
 
-    apDeliusContextMockCaseSummary(caseDetail.case)
+    apDeliusContextCaseSummariesAddCase(caseDetail.case)
     apDeliusContextMockUserAccess(
       CaseAccessFactory()
         .withCrn(offenderDetails.otherIds.crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -154,7 +154,6 @@ fun IntegrationTestBase.apDeliusContextCaseSummariesAddCase(caseSummary: CaseSum
 }
 
 fun IntegrationTestBase.apDeliusContextCaseSummariesSingleCase(caseSummary: CaseSummary) {
-
   mockSuccessfulGetCallWithBodyAndJsonResponse(
     url = "/probation-cases/summaries",
     requestBody = WireMock.equalToJson(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/APDeliusContext.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.matching.AnythingPattern
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.APDeliusDocument
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseDetail
@@ -58,53 +58,49 @@ fun IntegrationTestBase.apDeliusContextMockSuccessfulTeamsManagingCaseCall(crn: 
 )
 
 fun IntegrationTestBase.apDeliusContextMockUserAccess(caseAccess: CaseAccess, username: String = ".*") {
-  apDeliusContextAddResponseToUserAccessCall(listOf(caseAccess), username)
-  apDeliusContextAddSingleResponseToUserAccessCall(caseAccess, username)
+  apDeliusContextUserAccessAddCase(listOf(caseAccess), username)
+  apDeliusContextUserAccessSingleCase(caseAccess, username)
 }
 
-fun IntegrationTestBase.apDeliusContextAddResponseToUserAccessCall(casesAccess: List<CaseAccess>, username: String = ".*") {
+fun IntegrationTestBase.apDeliusContextUserAccessAddCase(casesAccess: List<CaseAccess>, username: String = ".*") {
+  val metadata = "apDeliusContextAddResponseToUserAccessCall-$username"
   val url = "/users/access"
-  val existingMock = wiremockServer.listAllStubMappings().mappings.find { it.request.url == url && it.metadata != null && it.metadata.containsKey("bulk") }
+  // we use anything pattern because it's very difficult to accurately determine the
+  // list of CRNs provided for a given bulk response when the bulk response is being
+  // built on-the-fly
+  val requestBodyPattern = AnythingPattern()
+  val existingMock = findStubMappingByMetadataKey(metadata)
 
   if (existingMock != null) {
     val mockId = existingMock.id
     val responseBody = jsonMapper.readValue(existingMock.response.body, UserAccess::class.java)
-    val requestBody = jsonMapper.readValue(existingMock.request.bodyPatterns[0].expected, object : TypeReference<List<String>>() {}).toMutableList()
 
-    requestBody += casesAccess.map { it.crn }
     responseBody.access += casesAccess
 
     editGetStubWithBodyAndJsonResponse(
       url = url,
       uuid = mockId,
-      requestBody = WireMock.equalToJson(jsonMapper.writeValueAsString(requestBody), true, true),
+      requestBody = requestBodyPattern,
       responseBody = responseBody,
     ) {
       withQueryParam("username", WireMock.matching(username))
-      withMetadata(mapOf("bulk" to Unit))
+      withMetadata(mapOf(metadata to Unit))
     }
   } else {
-    val requestBody = casesAccess.map { it.crn }
     mockSuccessfulGetCallWithBodyAndJsonResponse(
       url = url,
-      requestBody = WireMock.equalToJson(
-        jsonMapper.writeValueAsString(
-          requestBody,
-        ),
-        true,
-        true,
-      ),
+      requestBody = requestBodyPattern,
       responseBody = UserAccess(
         access = casesAccess,
       ),
     ) {
       withQueryParam("username", WireMock.matching(username))
-      withMetadata(mapOf("bulk" to Unit))
+      withMetadata(mapOf(metadata to Unit))
     }
   }
 }
 
-fun IntegrationTestBase.apDeliusContextAddSingleResponseToUserAccessCall(caseAccess: CaseAccess, username: String = ".*") {
+fun IntegrationTestBase.apDeliusContextUserAccessSingleCase(caseAccess: CaseAccess, username: String = ".*") {
   mockSuccessfulGetCallWithBodyAndJsonResponse(
     url = "/users/access",
     requestBody = WireMock.equalToJson(
@@ -122,51 +118,43 @@ fun IntegrationTestBase.apDeliusContextAddSingleResponseToUserAccessCall(caseAcc
   }
 }
 
-fun IntegrationTestBase.apDeliusContextMockCaseSummary(caseSummary: CaseSummary) {
-  this.apDeliusContextAddCaseSummaryToBulkResponse(caseSummary)
-  this.apDeliusContextAddSingleCaseSummaryToBulkResponse(caseSummary)
-}
-
-fun IntegrationTestBase.apDeliusContextAddCaseSummaryToBulkResponse(caseSummary: CaseSummary) {
+fun IntegrationTestBase.apDeliusContextCaseSummariesAddCase(caseSummary: CaseSummary) {
+  val metadata = "apDeliusContextAddCaseSummaryToBulkResponse"
   val url = "/probation-cases/summaries"
-  val existingMock = wiremockServer.listAllStubMappings().mappings.find { it.request.url == url && it.metadata != null && it.metadata.containsKey("bulk") }
+  // we use anything pattern because it's very difficult to accurately determine the
+  // list of CRNs provided for a given bulk response when the bulk response is being
+  // built on-the-fly
+  val requestBodyPattern = AnythingPattern()
+  val existingMock = findStubMappingByMetadataKey(metadata)
 
   if (existingMock != null) {
     val mockId = existingMock.id
     val responseBody = jsonMapper.readValue(existingMock.response.body, CaseSummaries::class.java)
-    val requestBody = jsonMapper.readValue(existingMock.request.bodyPatterns[0].expected, object : TypeReference<List<String>>() {}).toMutableList()
-
-    requestBody += caseSummary.crn
     responseBody.cases += caseSummary
 
     editGetStubWithBodyAndJsonResponse(
       url = url,
       uuid = mockId,
-      requestBody = WireMock.equalToJson(jsonMapper.writeValueAsString(requestBody), true, true),
+      requestBody = requestBodyPattern,
       responseBody = responseBody,
     ) {
-      withMetadata(mapOf("bulk" to Unit))
+      withMetadata(mapOf(metadata to Unit))
     }
   } else {
     mockSuccessfulGetCallWithBodyAndJsonResponse(
       url = url,
-      requestBody = WireMock.equalToJson(
-        jsonMapper.writeValueAsString(
-          listOf(caseSummary.crn),
-        ),
-        true,
-        true,
-      ),
+      requestBody = requestBodyPattern,
       responseBody = CaseSummaries(
         cases = listOf(caseSummary),
       ),
     ) {
-      withMetadata(mapOf("bulk" to Unit))
+      withMetadata(mapOf(metadata to Unit))
     }
   }
 }
 
-fun IntegrationTestBase.apDeliusContextAddSingleCaseSummaryToBulkResponse(caseSummary: CaseSummary) {
+fun IntegrationTestBase.apDeliusContextCaseSummariesSingleCase(caseSummary: CaseSummary) {
+
   mockSuccessfulGetCallWithBodyAndJsonResponse(
     url = "/probation-cases/summaries",
     requestBody = WireMock.equalToJson(
@@ -197,7 +185,7 @@ fun IntegrationTestBase.apDeliusContextAddSingleCaseSummaryToBulkResponse(caseSu
   }
 }
 
-fun IntegrationTestBase.apDeliusContextAddListCaseSummaryToBulkResponse(
+fun IntegrationTestBase.apDeliusContextCaseSummariesMultipleCases(
   casesSummary: List<CaseSummary>,
   crns: List<String> = casesSummary.map { it.crn },
 ) {
@@ -227,7 +215,7 @@ fun IntegrationTestBase.apDeliusContextAddListCaseSummaryToBulkResponse(
   }
 }
 
-fun IntegrationTestBase.apDeliusContextEmptyCaseSummaryToBulkResponse(crn: String) {
+fun IntegrationTestBase.apDeliusContextCaseSummariesEmptyResponseForCrn(crn: String) {
   mockSuccessfulGetCallWithBodyAndJsonResponse(
     url = "/probation-cases/summaries",
     requestBody = WireMock.equalToJson(
@@ -243,7 +231,7 @@ fun IntegrationTestBase.apDeliusContextEmptyCaseSummaryToBulkResponse(crn: Strin
   )
 }
 
-fun IntegrationTestBase.apDeliusContextMockUnsuccessfulCaseSummaryCall(responseStatus: Int = 500) = mockUnsuccessfulGetCall(
+fun IntegrationTestBase.apDeliusContextCaseSummariesErrorResponse(responseStatus: Int = 500) = mockUnsuccessfulGetCall(
   url = "/probation-cases/summaries",
   responseStatus = responseStatus,
 )
@@ -286,3 +274,5 @@ fun IntegrationTestBase.apDeliusContextMockSuccessfulDocumentDownloadCall(crn: S
       ),
   )
 }
+
+private fun IntegrationTestBase.findStubMappingByMetadataKey(key: String) = wiremockServer.listAllStubMappings().mappings.find { it.metadata?.containsKey(key) == true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/BackfillCasesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/BackfillCasesJobTest.kt
@@ -9,8 +9,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextAddListCaseSummaryToBulkResponse
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUnsuccessfulCaseSummaryCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesErrorResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesMultipleCases
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock404V3TierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulV3TierCall
@@ -68,7 +68,7 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
     val case3 = CaseSummaryFactory().withCrn("CRN3").withName(NameFactory().withForename("Delius").withSurname("Three").produce()).withNomsId("NOMS3").produce()
     val case4 = CaseSummaryFactory().withCrn("CRN4").withName(NameFactory().withForename("Delius").withSurname("Four").produce()).withNomsId("NOMS4").produce()
 
-    apDeliusContextAddListCaseSummaryToBulkResponse(listOf(case1, case2, case3, case4))
+    apDeliusContextCaseSummariesMultipleCases(listOf(case1, case2, case3, case4))
 
     // tier_v2
     hmppsTierMockSuccessfulTierCall("CRN1", UpstreamTier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
@@ -141,7 +141,7 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
     }
 
     val caseNew = CaseSummaryFactory().withCrn("NEW_CRN").withName(NameFactory().withForename("New").withSurname("Name").produce()).withNomsId("NOMS_NEW").produce()
-    apDeliusContextAddListCaseSummaryToBulkResponse(listOf(caseNew))
+    apDeliusContextCaseSummariesMultipleCases(listOf(caseNew))
 
     hmppsTierMockSuccessfulTierCall("NEW_CRN", UpstreamTier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
     hmppsTierMockSuccessfulV3TierCall("NEW_CRN", UpstreamTier("C1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
@@ -178,7 +178,7 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
       withCreatedByUser(user)
     }
 
-    apDeliusContextMockUnsuccessfulCaseSummaryCall(500)
+    apDeliusContextCaseSummariesErrorResponse(500)
 
     hmppsTierMockSuccessfulTierCall("CRN_FALLBACK", UpstreamTier("D4", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason 2"))
     hmppsTierMockSuccessfulV3TierCall("CRN_FALLBACK", UpstreamTier("D4", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason 2"))
@@ -218,7 +218,7 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
       withCreatedByUser(user)
     }
 
-    apDeliusContextMockUnsuccessfulCaseSummaryCall(500)
+    apDeliusContextCaseSummariesErrorResponse(500)
 
     hmppsTierMockSuccessfulTierCall(crn, UpstreamTier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
     hmppsTierMockSuccessfulV3TierCall(crn, UpstreamTier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))


### PR DESCRIPTION
The 'user access' and 'case summaries' endpoints support a list of crns

We have various mocking code that allows the responses to these endpoints to be added to (e.g. by appending new results for a given CRN).

Unfortunately these 'progressive mocks' never worked as intended because the request url never matched when checking to see if a mock already existed. This means that previous mock configurations were being wiped out.

Furthermore, the current implementation requires a precise list of CRNs in a specific order for a result to be defined up-front in the mock, something that is difficult to setup in an integration test consistently whilst still adding results to the mocks whenever factories build new offenders.

This commit changes the behaviour in several ways:

1. It no longer checks the request CRN list when using the 'progressive mocks'. It's hard (if not impossible) to make this behave in a predictable and developer friendly way
2. All mocks have been renamed to clarify when they added to the progressive mock, or create a brand new mock
3. When calling a function that deals with a non-progressive mock, the progressive mock is reset

this helps ensure that mocks and predictable and easier to reason on in code

Most of this PR is renaming functions for consistency. The code to look at is:

* CaseService - https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/4987/changes#diff-00b7e846e12ae3b01d11de3f05ebb0c013ab5a19e4b4746e7b57712c4e2e2fd7
* Changes to mock setup - https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/4987/changes#diff-16bc3809e5de074574bbfa6a6afd4bcbd13afad76a263aa59bcaff0e565f6142