### PR TITLE
FM-831 CAS1 draft document backfill changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
@@ -52,7 +52,7 @@ class Cas1BackfillApplicationDraftDocumentJob(
 
     if (data != null) {
       try {
-        val result = restTemplate.postForEntity<String>("$cas1UiBaseUrl/backfill/application/$applicationId", HttpEntity(data))
+        val result = restTemplate.postForEntity<String>("$cas1UiBaseUrl/render-application", HttpEntity(data))
         repository.updateDocument(applicationId, result.body!!)
       } catch (e: Exception) {
         log.error("Error getting document for $applicationId", e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpEntity
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
@@ -17,6 +16,10 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.postForEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.migration.MigrationJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderDetailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import java.util.UUID
 
 @Component
@@ -24,6 +27,8 @@ class Cas1BackfillApplicationDraftDocumentJob(
   private val repository: Cas1BackfillApplicationDraftDocumentJobRepository,
   private val transactionTemplate: TransactionTemplate,
   @Value($$"${services.cas1-ui.base-url}") private val cas1UiBaseUrl: String,
+  private val applicationsTransformer: ApplicationsTransformer,
+  private val offenderDetailService: OffenderDetailService,
 ) : MigrationJob() {
   override val shouldRunInTransaction = false
   private val restTemplate = RestTemplate()
@@ -39,37 +44,52 @@ class Cas1BackfillApplicationDraftDocumentJob(
         log.info("Have processed $runningCount applications")
       }
 
-      val applicationIds = repository.applicationIdsWithNoDocument(PageRequest.of(0, 50))
+      val applications = repository.applicationsWithNoDocument(PageRequest.of(0, pageSize))
+      val personInfoResults = offenderDetailService.getPersonInfoResults(
+        applications.map { it.crn }.toSet(),
+        LaoStrategy.NeverRestricted,
+      )
 
-      applicationIds.forEach { applicationId ->
+      applications.forEach { application ->
+        val personInfoResult = personInfoResults.first { it.crn == application.crn }
+
         transactionTemplate.executeWithoutResult {
-          processApplication(applicationId)
+          processApplication(
+            application,
+            personInfoResult,
+          )
         }
       }
 
-      runningCount += applicationIds.size
+      runningCount += applications.size
 
-      hasNext = applicationIds.hasNext()
+      hasNext = applications.hasNext()
     }
+
+    log.info("Have backfilled a total $runningCount applications")
   }
 
   @SuppressWarnings("TooGenericExceptionCaught", "TooGenericExceptionThrown")
-  private fun processApplication(applicationId: UUID) {
-    val application = repository.findByIdOrNull(applicationId)!!
+  private fun processApplication(
+    application: ApprovedPremisesApplicationEntity,
+    personInfoResult: PersonInfoResult,
+  ) {
+    val applicationId = application.id
 
     if (application.submittedAt != null) {
       error("Application $applicationId has no document but has been submitted")
     }
 
-    val data = application.data
+    val cas1Application = applicationsTransformer.transformJpaToCas1Application(
+      application,
+      personInfoResult,
+    )
 
-    if (data != null) {
-      try {
-        val result = restTemplate.postForEntity<String>("$cas1UiBaseUrl/render-application", HttpEntity(data))
-        repository.updateDocument(applicationId, result.body!!)
-      } catch (e: Exception) {
-        throw Exception("Error getting document for $applicationId", e)
-      }
+    try {
+      val result = restTemplate.postForEntity<String>("$cas1UiBaseUrl/render-application", HttpEntity(cas1Application))
+      repository.updateDocument(applicationId, result.body!!)
+    } catch (e: Exception) {
+      throw Exception("Error getting document for $applicationId", e)
     }
   }
 }
@@ -79,12 +99,11 @@ interface Cas1BackfillApplicationDraftDocumentJobRepository : JpaRepository<Appr
 
   @Query(
     value = """
-      SELECT a.id 
-      FROM applications a inner join approved_premises_applications apa on a.id = apa.id 
-      WHERE a.document IS NULL AND a.data IS NOT NULL AND a.submitted_at IS NULL""",
-    nativeQuery = true,
+      FROM ApprovedPremisesApplicationEntity a
+      WHERE a.document IS NULL AND a.data IS NOT NULL AND a.submittedAt IS NULL
+      ORDER BY a.createdAt ASC""",
   )
-  fun applicationIdsWithNoDocument(pageable: Pageable): Slice<UUID>
+  fun applicationsWithNoDocument(pageable: Pageable): Slice<ApprovedPremisesApplicationEntity>
 
   @Modifying
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -27,25 +30,35 @@ class Cas1BackfillApplicationDraftDocumentJob(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
+  @SuppressWarnings("MagicNumber")
   override fun process(pageSize: Int) {
-    val applicationIds = repository.applicationIdsWithNoDocument()
-
-    log.info("There are ${applicationIds.size} applications with data but no document")
-
-    applicationIds.forEach { applicationId ->
-      transactionTemplate.executeWithoutResult {
-        processApplication(applicationId)
+    var hasNext = true
+    var runningCount = 0
+    while (hasNext) {
+      if (runningCount % 100 == 0) {
+        log.info("Have processed $runningCount applications")
       }
+
+      val applicationIds = repository.applicationIdsWithNoDocument(PageRequest.of(0, 50))
+
+      applicationIds.forEach { applicationId ->
+        transactionTemplate.executeWithoutResult {
+          processApplication(applicationId)
+        }
+      }
+
+      runningCount += applicationIds.size
+
+      hasNext = applicationIds.hasNext()
     }
   }
 
-  @SuppressWarnings("TooGenericExceptionCaught")
+  @SuppressWarnings("TooGenericExceptionCaught", "TooGenericExceptionThrown")
   private fun processApplication(applicationId: UUID) {
     val application = repository.findByIdOrNull(applicationId)!!
 
     if (application.submittedAt != null) {
-      log.error("Application $applicationId has no document but has been submitted")
-      return
+      error("Application $applicationId has no document but has been submitted")
     }
 
     val data = application.data
@@ -55,7 +68,7 @@ class Cas1BackfillApplicationDraftDocumentJob(
         val result = restTemplate.postForEntity<String>("$cas1UiBaseUrl/render-application", HttpEntity(data))
         repository.updateDocument(applicationId, result.body!!)
       } catch (e: Exception) {
-        log.error("Error getting document for $applicationId", e)
+        throw Exception("Error getting document for $applicationId", e)
       }
     }
   }
@@ -71,7 +84,7 @@ interface Cas1BackfillApplicationDraftDocumentJobRepository : JpaRepository<Appr
       WHERE a.document IS NULL AND a.data IS NOT NULL AND a.submitted_at IS NULL""",
     nativeQuery = true,
   )
-  fun applicationIdsWithNoDocument(): List<UUID>
+  fun applicationIdsWithNoDocument(pageable: Pageable): Slice<UUID>
 
   @Modifying
   @Query(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
@@ -18,14 +18,19 @@ class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
   @Test
   fun `backfill applications ignoring null data`() {
     val applicationNoDataNoDocument = givenACas1Application(
+      submittedAt = null,
       data = null,
       document = null,
     )
-    val applicationHasDataNoDocument = givenACas1Application(
-      data = """{ "name" : "populated data" }""",
-      document = null,
-    )
+    val applicationsHasDataNoDocument = (0..12).map {
+      givenACas1Application(
+        submittedAt = null,
+        data = """{ "name" : "populated data" }""",
+        document = null,
+      )
+    }
     val applicationHasDocument = givenACas1Application(
+      submittedAt = null,
       data = """{ "name" : "populated data" }""",
       document = """{ "name": "already populated document" }""",
     )
@@ -44,8 +49,10 @@ class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
 
     assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationNoDataNoDocument.id)!!.document).isNull()
 
-    assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationHasDataNoDocument.id)!!.document)
-      .isEqualTo("""{ "name": "backfilled document" }""")
+    applicationsHasDataNoDocument.forEach { applicationHasDataNoDocument ->
+      assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationHasDataNoDocument.id)!!.document)
+        .isEqualTo("""{ "name": "backfilled document" }""")
+    }
 
     assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationHasDocument.id)!!.document)
       .isEqualTo("""{ "name": "already populated document" }""")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
@@ -36,7 +36,6 @@ class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
     )
 
     cas1UiMockPostForBackfillApplicationDocument(
-      applicationId = applicationHasDataNoDocument.id,
       request = """{ "name" : "populated data" }""",
       response = """{ "name": "backfilled document" }""",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
@@ -5,30 +5,33 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MigrationJobType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateDetail
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.migration.MigrationJobService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.cas1UiMockPostForBackfillApplicationDocument
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.cas1UiMockRenderApplicationPost
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import java.time.OffsetDateTime
 
 class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
   @Autowired
   lateinit var migrationJobService: MigrationJobService
 
+  @Autowired
+  lateinit var applicationsTransformer: ApplicationsTransformer
+
   @Test
   fun `backfill applications ignoring null data`() {
+    // ignored
     val applicationNoDataNoDocument = givenACas1Application(
       submittedAt = null,
       data = null,
       document = null,
     )
-    val applicationsHasDataNoDocument = (0..12).map {
-      givenACas1Application(
-        submittedAt = null,
-        data = """{ "name" : "populated data" }""",
-        document = null,
-      )
-    }
     val applicationHasDocument = givenACas1Application(
       submittedAt = null,
       data = """{ "name" : "populated data" }""",
@@ -40,18 +43,34 @@ class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
       document = null,
     )
 
-    cas1UiMockPostForBackfillApplicationDocument(
-      request = """{ "name" : "populated data" }""",
-      response = """{ "name": "backfilled document" }""",
-    )
+    val applicationsHasDataNoDocument = (0..12).map {
+      val (offender, inmateDetails) = givenAnOffender()
+      TestApplication(
+        application = givenACas1Application(
+          submittedAt = null,
+          data = """{ "name" : "populated data" }""",
+          document = null,
+          crn = offender.otherIds.crn,
+        ),
+        offenderDetailSummary = offender,
+        inmateDetails = inmateDetails,
+      )
+    }
+
+    applicationsHasDataNoDocument.forEach {
+      cas1UiMockRenderApplicationPost(
+        request = it.toCas1ApplicationJson(),
+        response = """{ "crn": "${it.application.crn}", "name": "backfilled document" }""",
+      )
+    }
 
     migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillAppDraftDoc)
 
     assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationNoDataNoDocument.id)!!.document).isNull()
 
-    applicationsHasDataNoDocument.forEach { applicationHasDataNoDocument ->
-      assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationHasDataNoDocument.id)!!.document)
-        .isEqualTo("""{ "name": "backfilled document" }""")
+    applicationsHasDataNoDocument.forEach {
+      assertThat(approvedPremisesApplicationRepository.findByIdOrNull(it.application.id)!!.document)
+        .isEqualTo("""{ "crn": "${it.application.crn}", "name": "backfilled document" }""")
     }
 
     assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationHasDocument.id)!!.document)
@@ -60,4 +79,22 @@ class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
     assertThat(approvedPremisesApplicationRepository.findByIdOrNull(applicationSubmitted.id)!!.document)
       .isNull()
   }
+
+  private fun TestApplication.toCas1ApplicationJson() = jackson3JsonMapper.writeValueAsString(
+    applicationsTransformer.transformJpaToCas1Application(
+      applicationEntity = application,
+      personInfo = PersonInfoResult.Success.Full(
+        crn = offenderDetailSummary.otherIds.crn,
+        offenderDetailSummary = offenderDetailSummary,
+        inmateDetail = inmateDetails,
+        tier = null,
+      ),
+    ),
+  )
+
+  private data class TestApplication(
+    val application: ApprovedPremisesApplicationEntity,
+    val offenderDetailSummary: OffenderDetailSummary,
+    val inmateDetails: InmateDetail,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/Cas1UiHttpMock.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/Cas1UiHttpMock.kt
@@ -2,14 +2,12 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
-import java.util.UUID
 
 fun IntegrationTestBase.cas1UiMockPostForBackfillApplicationDocument(
-  applicationId: UUID,
   request: String,
   response: String,
 ) = mockSuccessfulPostCallWithJsonStringResponse(
-  url = "/backfill/application/$applicationId",
+  url = "/render-application",
   requestBody = WireMock.equalToJson(request),
   responseBody = response,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/Cas1UiHttpMock.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/Cas1UiHttpMock.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks
 import com.github.tomakehurst.wiremock.client.WireMock
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 
-fun IntegrationTestBase.cas1UiMockPostForBackfillApplicationDocument(
+fun IntegrationTestBase.cas1UiMockRenderApplicationPost(
   request: String,
   response: String,
 ) = mockSuccessfulPostCallWithJsonStringResponse(


### PR DESCRIPTION
miscellaneous changes to align with the implemented endpoint in cas1 ui:

* use correct URL
* use paging when retrieving applications
* post a `Cas1Application` instead of the json data