### PR TITLE
FM-875 Publish inbox metrics if 0 results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventMonitor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/domainevent/listener/InboxEventMonitor.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.domainevent.list
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jpa.ProcessedStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.TelemetryService
 import kotlin.collections.associate
 
@@ -19,12 +20,21 @@ class InboxEventMonitor(
     lockAtMostFor = "PT1M",
     lockAtLeastFor = "PT1M",
   )
+  fun publishStatsOnSchedule() {
+    publishStats()
+  }
+
   fun publishStats() {
+    val stats = inboxEventService.getStats().associateBy { it.getProcessedStatus() }
+    val metrics = ProcessedStatus.entries.associate { status ->
+      status.name to (stats[status]?.getCount()?.toDouble() ?: 0.0)
+    }
+
     telemetryService.trackEvent(
       TelemetryService.Event(
         name = "InboxEventStats",
         properties = mapOf(),
-        metrics = inboxEventService.getStats().associate { it.getProcessedStatus() to it.getCount().toDouble() },
+        metrics = metrics,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jpa/InboxEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jpa/InboxEventEntity.kt
@@ -42,7 +42,7 @@ interface InboxEventRepository : JpaRepository<InboxEventEntity, UUID> {
 
   interface ProcessedStatusCount {
     fun getCount(): Long
-    fun getProcessedStatus(): String
+    fun getProcessedStatus(): ProcessedStatus
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxEventMonitorIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/integration/InboxEventMonitorIT.kt
@@ -16,6 +16,25 @@ class InboxEventMonitorIT : IntegrationTestBase() {
   lateinit var noOpTelemetryService: NoOpTelemetryService
 
   @Test
+  fun `if no entries still publish stats`() {
+    inboxEventMonitor.publishStats()
+
+    noOpTelemetryService.assertEventRaised(
+      TelemetryService.Event(
+        name = "InboxEventStats",
+        properties = emptyMap(),
+        metrics = mapOf(
+          "FAILED" to 0.0,
+          "FAILED_REVIEWED" to 0.0,
+          "IGNORED" to 0.0,
+          "PENDING" to 0.0,
+          "PROCESSED" to 0.0,
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun `stats are published correctly`() {
     inboxEventEntityFactory.produceAndPersist { withProcessedStatus(ProcessedStatus.PENDING) }
     inboxEventEntityFactory.produceAndPersist { withProcessedStatus(ProcessedStatus.PENDING) }


### PR DESCRIPTION
Before this commit if there were no entries in the inbox with a given status a metric wasn’t published for that status