### PR TITLE
CaseService Tier Retrieval Fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -86,8 +86,12 @@ class CaseService(
       .trim()
     nomsNumber = caseSummary.nomsId
     lastUpdatedAt = OffsetDateTime.now()
-    tierV2 = tiers.v2
-    tierV3 = tiers.v3
+    if (tiers.v2 != null) {
+      tierV2 = tiers.v2
+    }
+    if (tiers.v3 != null) {
+      tierV3 = tiers.v3
+    }
   }
 
   private fun newCaseEntity(caseSummary: CaseSummary, tiers: CaseTiers) = CaseEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
@@ -52,7 +53,7 @@ class CaseServiceTest {
   @Nested
   inner class EnsureCaseExists {
     @Test
-    fun `should update and return an existing case`() {
+    fun `existing case, update`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
@@ -106,7 +107,7 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `should create new case if one doesn't already exist`() {
+    fun `no existing case, create new`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
@@ -159,7 +160,7 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `should create new case if one doesn't already exist, setting tiers to null if get tiers errors`() {
+    fun `no existing case, create new, setting tiers to null if get tiers errors`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
@@ -210,7 +211,7 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `on create should not include v3 flag is disabled`() {
+    fun `no existing case, create new, dont include v3 tier if flag is disabled`() {
       val crn = "CRN123"
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
 
@@ -257,7 +258,7 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `on create should include tier v3 when flag is enabled`() {
+    fun `no existing case, create new, include tier v3 when flag is enabled`() {
       val crn = "CRN123"
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -1,16 +1,15 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
 import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentMatchers.any
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
@@ -34,27 +33,28 @@ import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
 class CaseServiceTest {
-  private val mockCaseRepository = mockk<CaseRepository>()
-  private val mockHMPPSTierApiClient = mockk<HMPPSTierApiClient>()
-  private val mockApDeliusContextApiClient = mockk<ApDeliusContextApiClient>()
-  private val mockFeatureFlagService = mockk<FeatureFlagService>()
 
+  @MockK
+  private lateinit var mockCaseRepository: CaseRepository
+
+  @MockK
+  private lateinit var mockHMPPSTierApiClient: HMPPSTierApiClient
+
+  @MockK
+  private lateinit var mockApDeliusContextApiClient: ApDeliusContextApiClient
+
+  @MockK
+  private lateinit var mockFeatureFlagService: FeatureFlagService
+
+  @InjectMockKs
   private lateinit var service: CaseService
-
-  private fun setupService(includeTierV3: Boolean = false) {
-    every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns includeTierV3
-    service = CaseService(mockCaseRepository, mockApDeliusContextApiClient, mockHMPPSTierApiClient, mockFeatureFlagService)
-  }
 
   @Nested
   inner class EnsureCaseExists {
-    @BeforeEach
-    fun setup() {
-      setupService(includeTierV3 = false)
-    }
-
     @Test
-    fun `should return existing offender when exist`() {
+    fun `should update and return an existing case`() {
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+
       val crn = "CRN123"
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
@@ -106,7 +106,9 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `should create new offender when not exist`() {
+    fun `should create new case if one doesn't already exist`() {
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+
       val crn = "CRN123"
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
@@ -157,13 +159,16 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `should set tier null and create new offender when not exist and get tier return error`() {
+    fun `should create new case if one doesn't already exist, setting tiers to null if get tiers errors`() {
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+
       val crn = "CRN123"
-      val caseEntity = CaseEntityFactory()
+      val expectedCaseEntity = CaseEntityFactory()
         .withCrn(crn)
         .withName("NAME")
         .withNomsNumber("NOMS123")
         .withTierV2(null)
+        .withTierV3(null)
         .produce()
 
       val caseSummary = CaseSummary(
@@ -184,7 +189,7 @@ class CaseServiceTest {
       )
 
       every { mockCaseRepository.findByCrn(crn) } returns null
-      every { mockCaseRepository.saveAndFlush(any()) } returns caseEntity
+      every { mockCaseRepository.saveAndFlush(any()) } returns expectedCaseEntity
       every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
         HttpStatus.OK,
         CaseSummaries(
@@ -201,13 +206,13 @@ class CaseServiceTest {
       )
 
       val result = service.ensureCaseExists(crn)
-      assertThat(result).isEqualTo(caseEntity)
+      assertThat(result).isEqualTo(expectedCaseEntity)
     }
 
     @Test
-    fun `should only include tier v2 when flag is disabled`() {
+    fun `on create should not include v3 flag is disabled`() {
       val crn = "CRN123"
-      setupService(includeTierV3 = false)
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
 
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
@@ -252,9 +257,9 @@ class CaseServiceTest {
     }
 
     @Test
-    fun `should include tier v3 when flag is enabled`() {
+    fun `on create should include tier v3 when flag is enabled`() {
       val crn = "CRN123"
-      setupService(includeTierV3 = true)
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
@@ -326,7 +331,7 @@ class CaseServiceTest {
     @Test
     fun `should update tierV2 and tierV3 when flag is enabled`() {
       val crn = "CRN123"
-      setupService(includeTierV3 = true)
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
@@ -360,7 +365,7 @@ class CaseServiceTest {
     @Test
     fun `should only update tierV2 when flag is disabled`() {
       val crn = "CRN123"
-      setupService(includeTierV3 = false)
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
 
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
@@ -390,7 +395,7 @@ class CaseServiceTest {
     @Test
     fun `should return false if case does not exist`() {
       val crn = "CRN123"
-      setupService()
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
       every { mockCaseRepository.findByCrn(crn) } returns null
 
       val result = service.reviseTier(crn)
@@ -401,7 +406,7 @@ class CaseServiceTest {
     @Test
     fun `should throw exception if fetch fails`() {
       val crn = "CRN123"
-      setupService()
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
       val caseEntity = CaseEntityFactory().withCrn(crn).produce()
 
       every { mockCaseRepository.findByCrn(crn) } returns caseEntity
@@ -424,7 +429,7 @@ class CaseServiceTest {
     @Test
     fun `should return tierV2`() {
       val crn = "CRN123"
-      setupService(includeTierV3 = false)
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
 
       val tierV2 = TierFactory().withTierScore("V2").withVersion(TierVersion.V2).produce()
       val tierV3 = TierFactory().withTierScore("V3").withVersion(TierVersion.V3).produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -20,12 +21,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Cas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Name
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ManagerFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import java.time.LocalDate
@@ -59,51 +63,58 @@ class CaseServiceTest {
       val crn = "CRN123"
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
-        .withName("NAME")
-        .withNomsNumber("NOMS123")
+        .withName("old name")
+        .withNomsNumber("old noms")
+        .withTierV2(TierFactory().withTierScore("oldv2").produce())
+        .withTierV3(TierFactory().withTierScore("oldv3").produce())
         .produce()
 
-      val caseSummary = CaseSummary(
-        crn = crn,
-        nomsId = "NOMS123",
-        name = Name(
-          forename = "John",
-          surname = "Smith",
-          middleNames = emptyList(),
-        ),
-        pnc = "PNC123",
-        dateOfBirth = LocalDate.parse("2023-06-26"),
-        gender = "male",
-        profile = null,
-        manager = ManagerFactory().produce(),
-        currentExclusion = false,
-        currentRestriction = false,
-      )
+      val caseSummary = CaseSummaryFactory()
+        .withCrn(crn)
+        .withName(NameFactory().withForename("John").withSurname("Smith").produce())
+        .withNomsId("NOMS123")
+        .produce()
 
       every { mockCaseRepository.findByCrn(crn) } returns caseEntity
-      every { mockCaseRepository.saveAndFlush(any()) } returns caseEntity
+      val createdCase = slot<CaseEntity>()
+      every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
       every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
         HttpStatus.OK,
-        CaseSummaries(
-          listOf(
-            caseSummary,
-          ),
-        ),
+        CaseSummaries(listOf(caseSummary)),
       )
 
-      every { mockHMPPSTierApiClient.getTier(crn, any()) } returns ClientResult.Success(
+      val tierV2CalculationId = UUID.randomUUID()
+      every { mockHMPPSTierApiClient.getTier(crn, TierVersion.V2) } returns ClientResult.Success(
         body = Tier(
-          tierScore = "low",
-          calculationId = UUID.randomUUID(),
+          tierScore = "tierv2score",
+          calculationId = tierV2CalculationId,
           calculationDate = LocalDateTime.now(),
-          changeReason = "reason",
+          changeReason = "v2Reason",
+        ),
+        status = HttpStatus.OK,
+      )
+
+      val tierV3CalculationId = UUID.randomUUID()
+      every { mockHMPPSTierApiClient.getTier(crn, TierVersion.V3) } returns ClientResult.Success(
+        body = Tier(
+          tierScore = "tierv3score",
+          calculationId = tierV3CalculationId,
+          calculationDate = LocalDateTime.now(),
+          changeReason = "v3Reason",
         ),
         status = HttpStatus.OK,
       )
 
       val result = service.ensureCaseExists(crn)
-
-      assertThat(result).isEqualTo(caseEntity)
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.name).isEqualTo("JOHN SMITH")
+      assertThat(result.nomsNumber).isEqualTo("NOMS123")
+      assertThat(result.tierV2?.tierScore).isEqualTo("tierv2score")
+      assertThat(result.tierV2?.calculationId).isEqualTo(tierV2CalculationId)
+      assertThat(result.tierV2?.changeReason).isEqualTo("v2Reason")
+      assertThat(result.tierV3?.tierScore).isEqualTo("tierv3score")
+      assertThat(result.tierV3?.calculationId).isEqualTo(tierV3CalculationId)
+      assertThat(result.tierV3?.changeReason).isEqualTo("v3Reason")
     }
 
     @Test
@@ -111,52 +122,54 @@ class CaseServiceTest {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
-      val caseEntity = CaseEntityFactory()
+
+      val caseSummary = CaseSummaryFactory()
         .withCrn(crn)
-        .withName("NAME")
-        .withNomsNumber("NOMS123")
-        .withTierV2(TierFactory().withTierScore("tier").produce())
+        .withName(NameFactory().withForename("John").withSurname("Smith").produce())
+        .withNomsId("NOMS123")
         .produce()
 
-      val caseSummary = CaseSummary(
-        crn = crn,
-        nomsId = "NOMS123",
-        name = Name(
-          forename = "John",
-          surname = "Smith",
-          middleNames = emptyList(),
-        ),
-        pnc = "PNC123",
-        dateOfBirth = LocalDate.parse("2023-06-26"),
-        gender = "male",
-        profile = null,
-        manager = ManagerFactory().produce(),
-        currentExclusion = false,
-        currentRestriction = false,
-      )
-
       every { mockCaseRepository.findByCrn(crn) } returns null
-      every { mockCaseRepository.saveAndFlush(any()) } returns caseEntity
+
+      val createdCase = slot<CaseEntity>()
+      every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
       every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
         HttpStatus.OK,
-        CaseSummaries(
-          listOf(
-            caseSummary,
-          ),
-        ),
+        CaseSummaries(listOf(caseSummary)),
       )
-      every { mockHMPPSTierApiClient.getTier(crn, any()) } returns ClientResult.Success(
+
+      val tierV2CalculationId = UUID.randomUUID()
+      every { mockHMPPSTierApiClient.getTier(crn, TierVersion.V2) } returns ClientResult.Success(
         body = Tier(
-          tierScore = "tier",
-          calculationId = UUID.randomUUID(),
+          tierScore = "tierv2score",
+          calculationId = tierV2CalculationId,
           calculationDate = LocalDateTime.now(),
-          changeReason = "reason",
+          changeReason = "v2Reason",
+        ),
+        status = HttpStatus.OK,
+      )
+
+      val tierV3CalculationId = UUID.randomUUID()
+      every { mockHMPPSTierApiClient.getTier(crn, TierVersion.V3) } returns ClientResult.Success(
+        body = Tier(
+          tierScore = "tierv3score",
+          calculationId = tierV3CalculationId,
+          calculationDate = LocalDateTime.now(),
+          changeReason = "v3Reason",
         ),
         status = HttpStatus.OK,
       )
 
       val result = service.ensureCaseExists(crn)
-      assertThat(result).isEqualTo(caseEntity)
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.name).isEqualTo("JOHN SMITH")
+      assertThat(result.nomsNumber).isEqualTo("NOMS123")
+      assertThat(result.tierV2?.tierScore).isEqualTo("tierv2score")
+      assertThat(result.tierV2?.calculationId).isEqualTo(tierV2CalculationId)
+      assertThat(result.tierV2?.changeReason).isEqualTo("v2Reason")
+      assertThat(result.tierV3?.tierScore).isEqualTo("tierv3score")
+      assertThat(result.tierV3?.calculationId).isEqualTo(tierV3CalculationId)
+      assertThat(result.tierV3?.changeReason).isEqualTo("v3Reason")
     }
 
     @Test
@@ -164,38 +177,16 @@ class CaseServiceTest {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
-      val expectedCaseEntity = CaseEntityFactory()
-        .withCrn(crn)
-        .withName("NAME")
-        .withNomsNumber("NOMS123")
-        .withTierV2(null)
-        .withTierV3(null)
-        .produce()
-
-      val caseSummary = CaseSummary(
-        crn = crn,
-        nomsId = "NOMS123",
-        name = Name(
-          forename = "John",
-          surname = "Smith",
-          middleNames = emptyList(),
-        ),
-        pnc = "PNC123",
-        dateOfBirth = LocalDate.parse("2023-06-26"),
-        gender = "male",
-        profile = null,
-        manager = ManagerFactory().produce(),
-        currentExclusion = false,
-        currentRestriction = false,
-      )
 
       every { mockCaseRepository.findByCrn(crn) } returns null
-      every { mockCaseRepository.saveAndFlush(any()) } returns expectedCaseEntity
-      every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
+
+      val createdCase = slot<CaseEntity>()
+      every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
+      every { mockApDeliusContextApiClient.getCaseSummaries(listOf(crn)) } returns ClientResult.Success(
         HttpStatus.OK,
         CaseSummaries(
           listOf(
-            caseSummary,
+            CaseSummaryFactory().withCrn(crn).produce(),
           ),
         ),
       )
@@ -207,7 +198,9 @@ class CaseServiceTest {
       )
 
       val result = service.ensureCaseExists(crn)
-      assertThat(result).isEqualTo(expectedCaseEntity)
+
+      assertThat(result.tierV2).isNull()
+      assertThat(result.tierV3).isNull()
     }
 
     @Test
@@ -215,10 +208,6 @@ class CaseServiceTest {
       val crn = "CRN123"
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
 
-      val caseEntity = CaseEntityFactory()
-        .withCrn(crn)
-        .produce()
-
       val caseSummary = CaseSummary(
         crn = crn,
         nomsId = "NOMS123",
@@ -233,79 +222,23 @@ class CaseServiceTest {
       )
 
       every { mockCaseRepository.findByCrn(crn) } returns null
-      every { mockCaseRepository.saveAndFlush(any()) } returns caseEntity
-      every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
+      val createdCase = slot<CaseEntity>()
+      every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
+      every { mockApDeliusContextApiClient.getCaseSummaries(listOf(crn)) } returns ClientResult.Success(
         HttpStatus.OK,
-        CaseSummaries(listOf(caseSummary)),
+        CaseSummaries(listOf(CaseSummaryFactory().withCrn(crn).produce())),
       )
       every { mockHMPPSTierApiClient.getTier(crn, any()) } returns ClientResult.Success(
-        body = Tier(tierScore = "V2", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason"),
+        body = Tier(tierScore = "tier value", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason"),
         status = HttpStatus.OK,
       )
 
       service.ensureCaseExists(crn)
 
-      verify { mockHMPPSTierApiClient.getTier(crn, TierVersion.V2) }
-      verify(exactly = 0) { mockHMPPSTierApiClient.getTier(any(), TierVersion.V3) }
-      verify {
-        mockCaseRepository.saveAndFlush(
-          withArg {
-            assertThat(it.tierV2?.tierScore).isEqualTo("V2")
-            assertThat(it.tierV3).isNull()
-          },
-        )
-      }
-    }
+      val result = service.ensureCaseExists(crn)
 
-    @Test
-    fun `no existing case, create new, include tier v3 when flag is enabled`() {
-      val crn = "CRN123"
-      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
-
-      val caseEntity = CaseEntityFactory()
-        .withCrn(crn)
-        .produce()
-
-      val caseSummary = CaseSummary(
-        crn = crn,
-        nomsId = "NOMS123",
-        name = Name(forename = "John", surname = "Smith", middleNames = emptyList()),
-        pnc = "PNC123",
-        dateOfBirth = LocalDate.parse("2023-06-26"),
-        gender = "male",
-        profile = null,
-        manager = ManagerFactory().produce(),
-        currentExclusion = false,
-        currentRestriction = false,
-      )
-
-      every { mockCaseRepository.findByCrn(crn) } returns null
-      every { mockCaseRepository.saveAndFlush(any()) } returns caseEntity
-      every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
-        HttpStatus.OK,
-        CaseSummaries(listOf(caseSummary)),
-      )
-      every { mockHMPPSTierApiClient.getTier(crn, TierVersion.V2) } returns ClientResult.Success(
-        body = Tier(tierScore = "V2", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason"),
-        status = HttpStatus.OK,
-      )
-      every { mockHMPPSTierApiClient.getTier(crn, TierVersion.V3) } returns ClientResult.Success(
-        body = Tier(tierScore = "V3", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason"),
-        status = HttpStatus.OK,
-      )
-
-      service.ensureCaseExists(crn)
-
-      verify { mockHMPPSTierApiClient.getTier(crn, TierVersion.V2) }
-      verify { mockHMPPSTierApiClient.getTier(crn, TierVersion.V3) }
-      verify {
-        mockCaseRepository.saveAndFlush(
-          withArg {
-            assertThat(it.tierV2?.tierScore).isEqualTo("V2")
-            assertThat(it.tierV3?.tierScore).isEqualTo("V3")
-          },
-        )
-      }
+      assertThat(result.tierV2?.tierScore).isEqualTo("tier value")
+      assertThat(result.tierV3).isNull()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -118,6 +118,39 @@ class CaseServiceTest {
     }
 
     @Test
+    fun `existing case, update, leaving tiers as current value if getting tiers fails`() {
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+
+      val crn = "CRN123"
+      val caseEntity = CaseEntityFactory()
+        .withCrn(crn)
+        .withTierV2(TierFactory().withTierScore("oldv2").produce())
+        .withTierV3(TierFactory().withTierScore("oldv3").produce())
+        .produce()
+
+      val caseSummary = CaseSummaryFactory().withCrn(crn).produce()
+
+      every { mockCaseRepository.findByCrn(crn) } returns caseEntity
+      val createdCase = slot<CaseEntity>()
+      every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
+      every { mockApDeliusContextApiClient.getCaseSummaries(any()) } returns ClientResult.Success(
+        HttpStatus.OK,
+        CaseSummaries(listOf(caseSummary)),
+      )
+
+      every { mockHMPPSTierApiClient.getTier(crn, any()) } returns ClientResult.Failure.StatusCode(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        method = HttpMethod.GET,
+        path = "/crn/crn123/tier",
+        body = null,
+      )
+
+      val result = service.ensureCaseExists(crn)
+      assertThat(result.tierV2?.tierScore).isEqualTo("oldv2")
+      assertThat(result.tierV3?.tierScore).isEqualTo("oldv3")
+    }
+
+    @Test
     fun `no existing case, create new`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
@@ -232,8 +265,6 @@ class CaseServiceTest {
         body = Tier(tierScore = "tier value", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason"),
         status = HttpStatus.OK,
       )
-
-      service.ensureCaseExists(crn)
 
       val result = service.ensureCaseExists(crn)
 


### PR DESCRIPTION
**On case update leave tiers as if if get fails**

Before this commit if a call to get tier failed and tiers already existed on a case, those tiers were overwritten with `null` values

**CaseServiceTests weren’t correcly asserting**

The tests were returning a CaseEntity from a mock. This was returned from the service, and the tests were then asserting on this value (i.e. the tests weren’t actually asserting on the CaseEntity created in the code)

This commit fixes this problem. It also uses Factories where possible to reduce the size of the tests