### PR TITLE
FM-839 Add new /cas1/applications/create endpoint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
@@ -31,7 +31,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApproved
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.UpdateApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Withdrawables
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1CreateApplicationOutcome
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExpireApplicationReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ConflictProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
@@ -47,6 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.DocumentService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.HttpAuthService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderDetailService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AppealService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationCreationService
@@ -88,6 +91,7 @@ class Cas1ApplicationsController(
   private val applicationTimelineNoteTransformer: ApplicationTimelineNoteTransformer,
   private val documentService: DocumentService,
   private val cas1ApplicationCreationService: Cas1ApplicationCreationService,
+  private val offenderService: OffenderService,
 ) {
 
   @Operation(summary = "Returns domain event summary")
@@ -230,6 +234,31 @@ class Cas1ApplicationsController(
     return ResponseEntity
       .created(URI.create("/cas1/applications/${application.id}"))
       .body(applicationsTransformer.transformCas1JpaToApi(application, personInfo))
+  }
+
+  @Operation(
+    summary = "Creates an application",
+  )
+  @PostMapping("/applications/create")
+  fun createEligibleApplication(
+    @RequestBody body: Cas1NewApplication,
+  ): ResponseEntity<Cas1CreateApplicationOutcome> {
+    val user = userService.getUserForRequest()
+    val crn = body.crn
+
+    offenderService.canAccessOffender(crn, user.cas1LaoStrategy())
+
+    val outcome = extractEntityFromCasResult(
+      cas1ApplicationCreationService.createApplication(
+        crn,
+        user,
+        body.convictionId,
+        body.deliusEventNumber,
+        body.offenceId,
+      ),
+    )
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(outcome)
   }
 
   @Operation(summary = "Updates an application")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
@@ -240,6 +240,7 @@ class Cas1ApplicationsController(
     summary = "Creates an application",
   )
   @PostMapping("/applications/create")
+  @Transactional
   fun createEligibleApplication(
     @RequestBody body: Cas1NewApplication,
   ): ResponseEntity<Cas1CreateApplicationOutcome> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
@@ -247,7 +247,9 @@ class Cas1ApplicationsController(
     val user = userService.getUserForRequest()
     val crn = body.crn
 
-    offenderService.canAccessOffender(crn, user.cas1LaoStrategy())
+    if (!offenderService.canAccessOffender(crn, user.cas1LaoStrategy())) {
+      throw ForbiddenProblem()
+    }
 
     val outcome = extractEntityFromCasResult(
       cas1ApplicationCreationService.createApplication(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1CreateApplicationOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1CreateApplicationOutcome.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
+
+import java.util.UUID
+
+data class Cas1CreateApplicationOutcome(
+  val applicationId: UUID? = null,
+  val tier: TierDto? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1NewApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1NewApplication.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Cas1NewApplication(
+  val crn: String,
+
+  @Schema(example = "1502724704")
+  val convictionId: Long,
+
+  @Schema(example = "7")
+  val deliusEventNumber: String,
+
+  @Schema(example = "M1502750438")
+  val offenceId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -43,7 +43,7 @@ class CaseService(
   private val useTierV3: Boolean
     get() = featureFlagService.getBooleanFlag(FEATURE_FLAG_USE_TIER_V3)
 
-  fun ensureCaseExists(crn: String): CaseEntity {
+  fun ensureCaseExists(crn: String): CaseDto {
     val caseSummary = getCaseSummary(crn)
     val tiers = fetchAvailableTiers(crn)
 
@@ -51,7 +51,7 @@ class CaseService(
       ?.updateFrom(caseSummary, tiers)
       ?: newCaseEntity(caseSummary, tiers)
 
-    return caseRepository.saveAndFlush(caseEntity)
+    return caseRepository.saveAndFlush(caseEntity).toDto()
   }
 
   fun reviseTier(crn: String): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOpt
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1CreateApplicationOutcome
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
@@ -107,7 +108,8 @@ class Cas1ApplicationCreationService(
         deliusEventNumber,
         offenceId,
         riskRatings,
-        offenderDetails,
+        nomsNumber = offenderDetails.otherIds.nomsNumber,
+        name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}",
       ),
     )
 
@@ -126,6 +128,46 @@ class Cas1ApplicationCreationService(
     return success(createdApplication)
   }
 
+  fun createApplication(
+    crn: String,
+    user: UserEntity,
+    convictionId: Long,
+    deliusEventNumber: String,
+    offenceId: String,
+  ): CasResult<Cas1CreateApplicationOutcome> {
+    val case = caseService.ensureCaseExists(crn)
+
+    if (case.tier == null) {
+      return CasResult.Success(
+        Cas1CreateApplicationOutcome(
+          tier = null,
+        ),
+      )
+    } else {
+      val riskRatings = offenderRisksService.getPersonRisks(crn)
+
+      val createdApplicationId = applicationRepository.saveAndFlush(
+        createApprovedPremisesApplicationEntity(
+          crn,
+          user,
+          convictionId,
+          deliusEventNumber,
+          offenceId,
+          riskRatings,
+          case.nomsNumber,
+          case.name?.uppercase() ?: error("name is null"),
+        ),
+      ).id
+
+      return CasResult.Success(
+        Cas1CreateApplicationOutcome(
+          applicationId = createdApplicationId,
+          tier = case.tier,
+        ),
+      )
+    }
+  }
+
   fun createApprovedPremisesApplicationEntity(
     crn: String,
     user: UserEntity,
@@ -133,7 +175,8 @@ class Cas1ApplicationCreationService(
     deliusEventNumber: String?,
     offenceId: String?,
     riskRatings: PersonRisks,
-    offenderDetails: OffenderDetailSummary,
+    nomsNumber: String?,
+    name: String,
   ): ApprovedPremisesApplicationEntity = ApprovedPremisesApplicationEntity(
     id = UUID.randomUUID(),
     crn = crn,
@@ -160,8 +203,8 @@ class Cas1ApplicationCreationService(
     isWithdrawn = false,
     withdrawalReason = null,
     otherWithdrawalReason = null,
-    nomsNumber = offenderDetails.otherIds.nomsNumber,
-    name = "${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}",
+    nomsNumber = nomsNumber,
+    name = name,
     targetLocation = null,
     status = ApprovedPremisesApplicationStatus.STARTED,
     sentenceType = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2v2ApplicationServiceTest.kt
@@ -53,7 +53,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.ValidatableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
@@ -392,7 +392,7 @@ class Cas2v2ApplicationServiceTest {
           Cas2ApplicationEntity
       }
 
-      every { mockCaseService.ensureCaseExists(any()) } returns CaseEntityFactory().produce()
+      every { mockCaseService.ensureCaseExists(any()) } returns CaseDtoFactory().produce()
 
       val result = cas2ApplicationService.createCas2Application(crn, user, ApplicationOrigin.prisonBail, bailHearingDate)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/Cas2ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/unit/service/Cas2ApplicationServiceTest.kt
@@ -49,7 +49,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.Authorisa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.InmateDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.EmailNotificationService
@@ -418,7 +418,7 @@ class Cas2ApplicationServiceTest {
         it.invocation.args[0] as
           Cas2ApplicationEntity
       }
-      every { mockCaseService.ensureCaseExists(any()) } returns CaseEntityFactory().produce()
+      every { mockCaseService.ensureCaseExists(any()) } returns CaseDtoFactory().produce()
 
       val result = applicationService.createApplication(personInfoResult, user)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
@@ -36,7 +36,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.Authorisa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenderDetailsSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
@@ -1133,7 +1133,7 @@ class Cas3ApplicationServiceTest {
       )
       every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockCaseService.ensureCaseExists(any()) } returns CaseEntityFactory().produce()
+      every { mockCaseService.ensureCaseExists(any()) } returns CaseDtoFactory().produce()
 
       val riskRatings = PersonRisksFactory()
         .withRoshRisks(
@@ -1211,7 +1211,7 @@ class Cas3ApplicationServiceTest {
       )
       every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockCaseService.ensureCaseExists(any()) } returns CaseEntityFactory().produce()
+      every { mockCaseService.ensureCaseExists(any()) } returns CaseDtoFactory().produce()
 
       val riskRatings = PersonRisksFactory()
         .withRoshRisks(
@@ -1288,7 +1288,7 @@ class Cas3ApplicationServiceTest {
       )
       every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockCaseService.ensureCaseExists(any()) } returns CaseEntityFactory().produce()
+      every { mockCaseService.ensureCaseExists(any()) } returns CaseDtoFactory().produce()
 
       val riskRatings = PersonRisksFactory()
         .withRoshRisks(
@@ -1366,7 +1366,7 @@ class Cas3ApplicationServiceTest {
       )
       every { mockUserService.getUserForRequest() } returns user
       every { mockApplicationRepository.save(any()) } answers { it.invocation.args[0] as ApplicationEntity }
-      every { mockCaseService.ensureCaseExists(any()) } returns CaseEntityFactory().produce()
+      every { mockCaseService.ensureCaseExists(any()) } returns CaseDtoFactory().produce()
 
       val riskRatings = PersonRisksFactory()
         .withRoshRisks(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/TierDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/factory/TierDtoFactory.kt
@@ -17,6 +17,10 @@ class TierDtoFactory : Factory<TierDto> {
     this.version = { version }
   }
 
+  fun withTierScore(tierScore: String) = apply {
+    this.tierScore = { tierScore }
+  }
+
   override fun produce(): TierDto = TierDto(
     tierScore = this.tierScore(),
     calculationDate = this.calculationDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -42,15 +42,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawalReas
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1CreateApplicationOutcome
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExpireApplicationReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1TimelineEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.ManagingTeamsResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.toHttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas1NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NeedsDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.StaffDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TeamFactoryDeliusContext
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
@@ -64,12 +69,15 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulNeedsDetailsCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextCaseSummariesEmptyResponseForCrn
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulV3TierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
@@ -1767,6 +1775,266 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             it.person.crn == offenderDetails.otherIds.crn &&
               caseService.getCase(it.person.crn) != null
           }
+        }
+      }
+    }
+  }
+
+  @Nested
+  inner class CreateEligibleApplication {
+
+    @Test
+    fun `Create new application without JWT returns 401`() {
+      webTestClient.post()
+        .uri("/cas1/applications/create")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Create new application returns 404 when a person cannot be found`() {
+      givenAUser { user, jwt ->
+        val crn = "X1234"
+
+        apDeliusContextCaseSummariesEmptyResponseForCrn(crn)
+
+        apDeliusContextMockUserAccess(
+          caseAccess = CaseAccessFactory()
+            .withCrn(crn)
+            .withUserExcluded(false)
+            .withUserRestricted(false)
+            .produce(),
+          username = user.deliusUsername,
+        )
+
+        webTestClient.post()
+          .uri("/cas1/applications/create")
+          .header("Authorization", "Bearer $jwt")
+          .bodyValue(
+            Cas1NewApplication(
+              crn = crn,
+              convictionId = 1234,
+              deliusEventNumber = "1",
+              offenceId = "offence123",
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isNotFound
+          .expectBody()
+          .jsonPath("$.detail").isEqualTo("No Offender with an ID of $crn could be found")
+      }
+    }
+
+    @Test
+    fun `Create new application returns 201 with correct body and Location header`() {
+      givenAUser { _, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+
+          apAndOASysMockSuccessfulNeedsDetailsCall(
+            offenderDetails.otherIds.crn,
+            NeedsDetailsFactory().produce(),
+          )
+
+          apAndOASysMockSuccessfulRoshRatingsCall(
+            offenderDetails.otherIds.crn,
+            RoshRatingsFactory().produce(),
+          )
+
+          val tier = Tier(tierScore = "A1", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "Change Reason")
+
+          hmppsTierMockSuccessfulTierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          hmppsTierMockSuccessfulV3TierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          val result = webTestClient.post()
+            .uri("/cas1/applications/create")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isCreated
+            .returnResult(Cas1CreateApplicationOutcome::class.java)
+            .responseBody
+            .blockFirst()
+
+          assertThat(result!!.applicationId).isNotNull
+          assertThat(result.tier!!.tierScore).isEqualTo(tier.tierScore)
+          assertThat(result.tier.calculationDate).isEqualTo(tier.calculationDate)
+          assertThat(result.tier.provisional).isNull()
+          assertThat(result.tier.version.name).isEqualTo(TierVersion.V2.name)
+        }
+      }
+    }
+
+    @Test
+    fun `Create new application returns successfully when a person has no NOMS number`() {
+      givenAUser { _, jwt ->
+        givenAnOffender(
+          offenderDetailsConfigBlock = { withoutNomsNumber() },
+        ) { offenderDetails, _ ->
+
+          apAndOASysMockSuccessfulRoshRatingsCall(
+            offenderDetails.otherIds.crn,
+            RoshRatingsFactory().produce(),
+          )
+
+          val tier = Tier(tierScore = "A1", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "Change Reason")
+
+          hmppsTierMockSuccessfulTierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          hmppsTierMockSuccessfulV3TierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          val result = webTestClient.post()
+            .uri("/cas1/applications/create")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isCreated
+            .returnResult(Cas1CreateApplicationOutcome::class.java)
+            .responseBody
+            .blockFirst()
+
+          assertThat(result!!.applicationId).isNotNull
+          assertThat(result.tier!!.tierScore).isEqualTo(tier.tierScore)
+          assertThat(result.tier.calculationDate).isEqualTo(tier.calculationDate)
+          assertThat(result.tier.provisional).isNull()
+          assertThat(result.tier.version.name).isEqualTo(TierVersion.V2.name)
+        }
+      }
+    }
+
+    @Test
+    fun `Create new application returns successfully when the person cannot be fetched from the prisons API`() {
+      givenAUser { userEntity, jwt ->
+        givenAnOffender(
+          offenderDetailsConfigBlock = {
+            withNomsNumber("ABC123")
+          },
+        ) { offenderDetails, _ ->
+
+          apAndOASysMockSuccessfulRoshRatingsCall(
+            offenderDetails.otherIds.crn,
+            RoshRatingsFactory().produce(),
+          )
+
+          val tier = Tier(tierScore = "A1", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "Change Reason")
+
+          hmppsTierMockSuccessfulTierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          hmppsTierMockSuccessfulV3TierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          val result = webTestClient.post()
+            .uri("/cas1/applications/create")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isCreated
+            .returnResult(Cas1CreateApplicationOutcome::class.java)
+            .responseBody
+            .blockFirst()
+
+          assertThat(result!!.applicationId).isNotNull
+          assertThat(result.tier!!.tierScore).isEqualTo(tier.tierScore)
+          assertThat(result.tier.calculationDate).isEqualTo(tier.calculationDate)
+          assertThat(result.tier.provisional).isNull()
+          assertThat(result.tier.version.name).isEqualTo(TierVersion.V2.name)
+        }
+      }
+    }
+
+    @Test
+    fun `Create new application without risks returns 201 with correct body and Location header`() {
+      givenAUser { _, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+
+          apAndOASysMockSuccessfulRoshRatingsCall(
+            offenderDetails.otherIds.crn,
+            RoshRatingsFactory().produce(),
+          )
+
+          val tier = Tier(tierScore = "A1", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "Change Reason")
+
+          hmppsTierMockSuccessfulTierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          hmppsTierMockSuccessfulV3TierCall(
+            offenderDetails.otherIds.crn,
+            tier,
+          )
+
+          apAndOASysMockSuccessfulNeedsDetailsCall(
+            offenderDetails.otherIds.crn,
+            NeedsDetailsFactory().produce(),
+          )
+
+          val result = webTestClient.post()
+            .uri("/cas1/applications/create?createWithRisks=false")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isCreated
+            .returnResult(Cas1CreateApplicationOutcome::class.java)
+            .responseBody
+            .blockFirst()
+
+          assertThat(result!!.applicationId).isNotNull
+          assertThat(result.tier!!.tierScore).isEqualTo(tier.tierScore)
+          assertThat(result.tier.calculationDate).isEqualTo(tier.calculationDate)
+          assertThat(result.tier.provisional).isNull()
+          assertThat(result.tier.version.name).isEqualTo(TierVersion.V2.name)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -75,6 +75,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulTeamsManagingCaseCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulV3TierCall
@@ -1790,6 +1791,68 @@ class Cas1ApplicationTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isUnauthorized
+    }
+
+    @Test
+    fun `Returns Forbidden and don't create application if user restricted is true`() {
+      givenAUser { user, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+
+          apDeliusContextUserAccessSingleCase(
+            caseAccess = CaseAccessFactory()
+              .withUserRestricted(true)
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
+            user.deliusUsername,
+          )
+
+          webTestClient.post()
+            .uri("/cas1/applications/create")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isForbidden
+        }
+      }
+    }
+
+    @Test
+    fun `Returns Forbidden and don't create application if user excluded is true`() {
+      givenAUser { user, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+
+          apDeliusContextUserAccessSingleCase(
+            caseAccess = CaseAccessFactory()
+              .withUserExcluded(true)
+              .withCrn(offenderDetails.otherIds.crn)
+              .produce(),
+            user.deliusUsername,
+          )
+
+          webTestClient.post()
+            .uri("/cas1/applications/create")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .isForbidden
+        }
+      }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 
+import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.NullSource
 import org.springframework.data.repository.findByIdOrNull
@@ -24,13 +26,13 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOptio
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SubmitApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationTimelinessCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationUserDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.ManagingTeamsResponse
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.prisonsapi.InmateStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.CaseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.AuthorisableActionResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
@@ -73,7 +75,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1Assessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.assertThatCasResult
 import java.time.Clock
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -168,20 +169,18 @@ class Cas1ApplicationCreationServiceTest {
 
       val cas1OffenderEntityId = UUID.randomUUID()
 
-      val caseEntity = CaseEntity(
+      val caseDto = CaseDto(
         crn = "CRN345",
-        name = "name",
         nomsNumber = "nomsNo",
-        tierV2 = Tier(tierScore = "level", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason", version = TierVersion.V2),
-        tierV3 = Tier(tierScore = "level", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason", version = TierVersion.V3),
-        id = cas1OffenderEntityId,
+        name = "name",
+        tier = TierDtoFactory().withVersion(TierVersionDto.V2).produce(),
         createdAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
         lastUpdatedAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
       )
 
       every { mockApplicationRepository.saveAndFlush(any()) } answers { it.invocation.args[0] as ApplicationEntity }
       every { mockApplicationTeamCodeRepository.save(any()) } answers { it.invocation.args[0] as ApplicationTeamCodeEntity }
-      every { mockCaseService.ensureCaseExists(any()) } returns caseEntity
+      every { mockCaseService.ensureCaseExists(any()) } returns caseDto
 
       val riskRatings = PersonRisksFactory()
         .withRoshRisks(
@@ -223,6 +222,249 @@ class Cas1ApplicationCreationServiceTest {
         assertThat(approvedPremisesApplication.riskRatings).isEqualTo(riskRatings)
         assertThat(approvedPremisesApplication.name).isEqualTo("${offenderDetails.firstName.uppercase()} ${offenderDetails.surname.uppercase()}")
       }
+    }
+  }
+
+  @Nested
+  inner class CreateApprovedPremisesEligibleApplication {
+
+    @Test
+    fun `Returns tier not eligible and no application created if tier is null`() {
+      val crn = "CRN345"
+      val username = "SOMEPERSON"
+      val user = userWithUsername(username)
+
+      val caseDto = CaseDto(
+        crn = "CRN345",
+        nomsNumber = "nomsNo",
+        name = "JANE DOE",
+        tier = null,
+        createdAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+        lastUpdatedAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+      )
+
+      every { mockCaseService.ensureCaseExists(any()) } returns caseDto
+
+      val riskRatings = PersonRisksFactory().produce()
+
+      every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
+
+      val result = applicationService.createApplication(crn, user, 123, "1", "A12HI")
+
+      assertThatCasResult(result).isSuccess().with {
+        val outcome = it
+        assertThat(outcome.tier).isNull()
+      }
+
+      verify { mockApplicationRepository wasNot Called }
+    }
+
+    @Test
+    fun `Returns success with created application, tier eligible and persists risk data and offender name`() {
+      val crn = "CRN345"
+      val username = "SOMEPERSON"
+      val user = userWithUsername(username)
+
+      val caseDto = CaseDto(
+        crn = "CRN345",
+        nomsNumber = "nomsNo",
+        name = "JANE DOE",
+        tier = TierDtoFactory().withVersion(TierVersionDto.V2).withTierScore("A0").produce(),
+        createdAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+        lastUpdatedAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+      )
+
+      every { mockCaseService.ensureCaseExists(any()) } returns caseDto
+
+      val riskRatings = PersonRisksFactory()
+        .withRoshRisks(
+          RiskWithStatus(
+            value = RoshRisks(
+              overallRisk = "High",
+              riskToChildren = "Medium",
+              riskToPublic = "Low",
+              riskToKnownAdult = "High",
+              riskToStaff = "High",
+              lastUpdated = null,
+            ),
+          ),
+        )
+        .withMappa(
+          RiskWithStatus(
+            value = Mappa(
+              level = "",
+              lastUpdated = LocalDate.parse("2022-12-12"),
+            ),
+          ),
+        )
+        .withFlags(
+          RiskWithStatus(
+            value = listOf(
+              "flag1",
+              "flag2",
+            ),
+          ),
+        )
+        .produce()
+
+      every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
+
+      val savedApplication = slot<ApplicationEntity>()
+
+      every { mockApplicationRepository.saveAndFlush(capture(savedApplication)) } answers {
+        savedApplication.captured
+      }
+
+      val result = applicationService.createApplication(crn, user, 123, "1", "A12HI")
+
+      assertThatCasResult(result).isSuccess().with {
+        val outcome = it
+        assertThat(outcome.tier?.version).isEqualTo(TierVersionDto.V2)
+        assertThat(outcome.tier?.tierScore).isEqualTo("A0")
+      }
+
+      val createdApplication = savedApplication.captured as ApprovedPremisesApplicationEntity
+      assertThat(createdApplication.riskRatings).isEqualTo(riskRatings)
+      assertThat(createdApplication.name).isEqualTo("JANE DOE")
+    }
+
+    @Test
+    fun `Returns success with created application, tier in-eligible and persists risk data and offender name`() {
+      val crn = "CRN345"
+      val username = "SOMEPERSON"
+      val user = userWithUsername(username)
+
+      val caseDto = CaseDto(
+        crn = "CRN345",
+        nomsNumber = "nomsNo",
+        name = "JANE DOE",
+        tier = TierDtoFactory().withVersion(TierVersionDto.V2).withTierScore("A0").produce(),
+        createdAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+        lastUpdatedAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+      )
+
+      every { mockCaseService.ensureCaseExists(any()) } returns caseDto
+
+      val riskRatings = PersonRisksFactory()
+        .withRoshRisks(
+          RiskWithStatus(
+            value = RoshRisks(
+              overallRisk = "High",
+              riskToChildren = "Medium",
+              riskToPublic = "Low",
+              riskToKnownAdult = "High",
+              riskToStaff = "High",
+              lastUpdated = null,
+            ),
+          ),
+        )
+        .withMappa(
+          RiskWithStatus(
+            value = Mappa(
+              level = "",
+              lastUpdated = LocalDate.parse("2022-12-12"),
+            ),
+          ),
+        )
+        .withFlags(
+          RiskWithStatus(
+            value = listOf(
+              "flag1",
+              "flag2",
+            ),
+          ),
+        )
+        .produce()
+
+      every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
+
+      val savedApplication = slot<ApplicationEntity>()
+
+      every { mockApplicationRepository.saveAndFlush(capture(savedApplication)) } answers {
+        savedApplication.captured
+      }
+
+      val result = applicationService.createApplication(crn, user, 123, "1", "A12HI")
+
+      assertThatCasResult(result).isSuccess().with {
+        val outcome = it
+        assertThat(outcome.tier?.version).isEqualTo(TierVersionDto.V2)
+        assertThat(outcome.tier?.tierScore).isEqualTo("A0")
+      }
+
+      val createdApplication = savedApplication.captured as ApprovedPremisesApplicationEntity
+      assertThat(createdApplication.riskRatings).isEqualTo(riskRatings)
+      assertThat(createdApplication.name).isEqualTo("JANE DOE")
+    }
+
+    @ParameterizedTest
+    @CsvSource("A1", "A2", "A3", "B1", "B2", "B3")
+    fun `Returns success with created application, tier eligible and persists risk data and offender name when gender is null`(tierScore: String) {
+      val crn = "CRN345"
+      val username = "SOMEPERSON"
+      val user = userWithUsername(username)
+
+      val caseDto = CaseDto(
+        crn = "CRN345",
+        nomsNumber = "nomsNo",
+        name = "JANE DOE",
+        tier = TierDtoFactory().withVersion(TierVersionDto.V2).withTierScore(tierScore).produce(),
+        createdAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+        lastUpdatedAt = OffsetDateTime.of(2025, 3, 5, 10, 30, 0, 0, ZoneOffset.UTC),
+      )
+
+      every { mockCaseService.ensureCaseExists(any()) } returns caseDto
+
+      val riskRatings = PersonRisksFactory()
+        .withRoshRisks(
+          RiskWithStatus(
+            value = RoshRisks(
+              overallRisk = "High",
+              riskToChildren = "Medium",
+              riskToPublic = "Low",
+              riskToKnownAdult = "High",
+              riskToStaff = "High",
+              lastUpdated = null,
+            ),
+          ),
+        )
+        .withMappa(
+          RiskWithStatus(
+            value = Mappa(
+              level = "",
+              lastUpdated = LocalDate.parse("2022-12-12"),
+            ),
+          ),
+        )
+        .withFlags(
+          RiskWithStatus(
+            value = listOf(
+              "flag1",
+              "flag2",
+            ),
+          ),
+        )
+        .produce()
+
+      every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
+
+      val savedApplication = slot<ApplicationEntity>()
+
+      every { mockApplicationRepository.saveAndFlush(capture(savedApplication)) } answers {
+        savedApplication.captured
+      }
+
+      val result = applicationService.createApplication(crn, user, 123, "1", "A12HI")
+
+      assertThatCasResult(result).isSuccess().with {
+        val outcome = it
+        assertThat(outcome.tier?.version).isEqualTo(TierVersionDto.V2)
+        assertThat(outcome.tier?.tierScore).isEqualTo(tierScore)
+      }
+
+      val createdApplication = savedApplication.captured as ApprovedPremisesApplicationEntity
+      assertThat(createdApplication.riskRatings).isEqualTo(riskRatings)
+      assertThat(createdApplication.name).isEqualTo("JANE DOE")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -14,11 +14,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummaries
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.Name
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
@@ -28,12 +28,11 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ManagerFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
-import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -61,12 +60,14 @@ class CaseServiceTest {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
+      val now = OffsetDateTime.now()
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
         .withName("old name")
         .withNomsNumber("old noms")
         .withTierV2(TierFactory().withTierScore("oldv2").produce())
         .withTierV3(TierFactory().withTierScore("oldv3").produce())
+        .withCreatedAt(now)
         .produce()
 
       val caseSummary = CaseSummaryFactory()
@@ -88,7 +89,7 @@ class CaseServiceTest {
         body = Tier(
           tierScore = "tierv2score",
           calculationId = tierV2CalculationId,
-          calculationDate = LocalDateTime.now(),
+          calculationDate = now.toLocalDateTime(),
           changeReason = "v2Reason",
         ),
         status = HttpStatus.OK,
@@ -106,15 +107,24 @@ class CaseServiceTest {
       )
 
       val result = service.ensureCaseExists(crn)
+
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result.name).isEqualTo("JOHN SMITH")
       assertThat(result.nomsNumber).isEqualTo("NOMS123")
-      assertThat(result.tierV2?.tierScore).isEqualTo("tierv2score")
-      assertThat(result.tierV2?.calculationId).isEqualTo(tierV2CalculationId)
-      assertThat(result.tierV2?.changeReason).isEqualTo("v2Reason")
-      assertThat(result.tierV3?.tierScore).isEqualTo("tierv3score")
-      assertThat(result.tierV3?.calculationId).isEqualTo(tierV3CalculationId)
-      assertThat(result.tierV3?.changeReason).isEqualTo("v3Reason")
+      assertThat(result.tier?.tierScore).isEqualTo("tierv2score")
+      assertThat(result.tier?.calculationDate).isEqualTo(now.toLocalDateTime())
+      assertThat(result.tier?.version).isEqualTo(TierVersionDto.V2)
+      assertThat(result.tier?.provisional).isNull()
+
+      assertThat(createdCase.captured.crn).isEqualTo(crn)
+      assertThat(createdCase.captured.name).isEqualTo("JOHN SMITH")
+      assertThat(createdCase.captured.nomsNumber).isEqualTo("NOMS123")
+      assertThat(createdCase.captured.tierV2?.tierScore).isEqualTo("tierv2score")
+      assertThat(createdCase.captured.tierV2?.calculationId).isEqualTo(tierV2CalculationId)
+      assertThat(createdCase.captured.tierV2?.changeReason).isEqualTo("v2Reason")
+      assertThat(createdCase.captured.tierV3?.tierScore).isEqualTo("tierv3score")
+      assertThat(createdCase.captured.tierV3?.calculationId).isEqualTo(tierV3CalculationId)
+      assertThat(createdCase.captured.tierV3?.changeReason).isEqualTo("v3Reason")
     }
 
     @Test
@@ -122,13 +132,14 @@ class CaseServiceTest {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
+      val now = OffsetDateTime.now()
       val caseEntity = CaseEntityFactory()
         .withCrn(crn)
-        .withTierV2(TierFactory().withTierScore("oldv2").produce())
+        .withTierV2(TierFactory().withTierScore("oldv2").withCalculationDate(now.toLocalDateTime()).produce())
         .withTierV3(TierFactory().withTierScore("oldv3").produce())
         .produce()
 
-      val caseSummary = CaseSummaryFactory().withCrn(crn).produce()
+      val caseSummary = CaseSummaryFactory().withCrn(crn).withName(Name("JOHN", "SMITH")).withNomsId("NOMS123").produce()
 
       every { mockCaseRepository.findByCrn(crn) } returns caseEntity
       val createdCase = slot<CaseEntity>()
@@ -146,8 +157,16 @@ class CaseServiceTest {
       )
 
       val result = service.ensureCaseExists(crn)
-      assertThat(result.tierV2?.tierScore).isEqualTo("oldv2")
-      assertThat(result.tierV3?.tierScore).isEqualTo("oldv3")
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.name).isEqualTo("JOHN SMITH")
+      assertThat(result.nomsNumber).isEqualTo("NOMS123")
+      assertThat(result.tier?.tierScore).isEqualTo("oldv2")
+      assertThat(result.tier?.calculationDate).isEqualTo(now.toLocalDateTime())
+      assertThat(result.tier?.version).isEqualTo(TierVersionDto.V2)
+      assertThat(result.tier?.provisional).isNull()
+
+      assertThat(createdCase.captured.tierV2?.tierScore).isEqualTo("oldv2")
+      assertThat(createdCase.captured.tierV3?.tierScore).isEqualTo("oldv3")
     }
 
     @Test
@@ -155,6 +174,7 @@ class CaseServiceTest {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
 
       val crn = "CRN123"
+      val now = OffsetDateTime.now()
 
       val caseSummary = CaseSummaryFactory()
         .withCrn(crn)
@@ -176,7 +196,7 @@ class CaseServiceTest {
         body = Tier(
           tierScore = "tierv2score",
           calculationId = tierV2CalculationId,
-          calculationDate = LocalDateTime.now(),
+          calculationDate = now.toLocalDateTime(),
           changeReason = "v2Reason",
         ),
         status = HttpStatus.OK,
@@ -197,12 +217,17 @@ class CaseServiceTest {
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result.name).isEqualTo("JOHN SMITH")
       assertThat(result.nomsNumber).isEqualTo("NOMS123")
-      assertThat(result.tierV2?.tierScore).isEqualTo("tierv2score")
-      assertThat(result.tierV2?.calculationId).isEqualTo(tierV2CalculationId)
-      assertThat(result.tierV2?.changeReason).isEqualTo("v2Reason")
-      assertThat(result.tierV3?.tierScore).isEqualTo("tierv3score")
-      assertThat(result.tierV3?.calculationId).isEqualTo(tierV3CalculationId)
-      assertThat(result.tierV3?.changeReason).isEqualTo("v3Reason")
+      assertThat(result.tier?.tierScore).isEqualTo("tierv2score")
+      assertThat(result.tier?.calculationDate).isEqualTo(now.toLocalDateTime())
+      assertThat(result.tier?.version).isEqualTo(TierVersionDto.V2)
+      assertThat(result.tier?.provisional).isNull()
+
+      assertThat(createdCase.captured.tierV2?.tierScore).isEqualTo("tierv2score")
+      assertThat(createdCase.captured.tierV2?.calculationId).isEqualTo(tierV2CalculationId)
+      assertThat(createdCase.captured.tierV2?.changeReason).isEqualTo("v2Reason")
+      assertThat(createdCase.captured.tierV3?.tierScore).isEqualTo("tierv3score")
+      assertThat(createdCase.captured.tierV3?.calculationId).isEqualTo(tierV3CalculationId)
+      assertThat(createdCase.captured.tierV3?.changeReason).isEqualTo("v3Reason")
     }
 
     @Test
@@ -219,7 +244,7 @@ class CaseServiceTest {
         HttpStatus.OK,
         CaseSummaries(
           listOf(
-            CaseSummaryFactory().withCrn(crn).produce(),
+            CaseSummaryFactory().withCrn(crn).withName(Name("JOHN", "SMITH")).withNomsId("NOMS123").produce(),
           ),
         ),
       )
@@ -232,44 +257,45 @@ class CaseServiceTest {
 
       val result = service.ensureCaseExists(crn)
 
-      assertThat(result.tierV2).isNull()
-      assertThat(result.tierV3).isNull()
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.name).isEqualTo("JOHN SMITH")
+      assertThat(result.nomsNumber).isEqualTo("NOMS123")
+      assertThat(result.tier).isNull()
+
+      assertThat(createdCase.captured.tierV2).isNull()
+      assertThat(createdCase.captured.tierV3).isNull()
     }
 
     @Test
     fun `no existing case, create new, dont include v3 tier if flag is disabled`() {
       val crn = "CRN123"
+      val now = OffsetDateTime.now()
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
-
-      val caseSummary = CaseSummary(
-        crn = crn,
-        nomsId = "NOMS123",
-        name = Name(forename = "John", surname = "Smith", middleNames = emptyList()),
-        pnc = "PNC123",
-        dateOfBirth = LocalDate.parse("2023-06-26"),
-        gender = "male",
-        profile = null,
-        manager = ManagerFactory().produce(),
-        currentExclusion = false,
-        currentRestriction = false,
-      )
 
       every { mockCaseRepository.findByCrn(crn) } returns null
       val createdCase = slot<CaseEntity>()
       every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
       every { mockApDeliusContextApiClient.getCaseSummaries(listOf(crn)) } returns ClientResult.Success(
         HttpStatus.OK,
-        CaseSummaries(listOf(CaseSummaryFactory().withCrn(crn).produce())),
+        CaseSummaries(listOf(CaseSummaryFactory().withCrn(crn).withName(Name("JOHN", "SMITH")).withNomsId("NOMS123").produce())),
       )
       every { mockHMPPSTierApiClient.getTier(crn, any()) } returns ClientResult.Success(
-        body = Tier(tierScore = "tier value", calculationId = UUID.randomUUID(), calculationDate = LocalDateTime.now(), changeReason = "reason"),
+        body = Tier(tierScore = "tier value", calculationId = UUID.randomUUID(), calculationDate = now.toLocalDateTime(), changeReason = "reason"),
         status = HttpStatus.OK,
       )
 
       val result = service.ensureCaseExists(crn)
 
-      assertThat(result.tierV2?.tierScore).isEqualTo("tier value")
-      assertThat(result.tierV3).isNull()
+      assertThat(result.crn).isEqualTo(crn)
+      assertThat(result.name).isEqualTo("JOHN SMITH")
+      assertThat(result.nomsNumber).isEqualTo("NOMS123")
+      assertThat(result.tier?.tierScore).isEqualTo("tier value")
+      assertThat(result.tier?.calculationDate).isEqualTo(now.toLocalDateTime())
+      assertThat(result.tier?.version).isEqualTo(TierVersionDto.V2)
+      assertThat(result.tier?.provisional).isNull()
+
+      assertThat(createdCase.captured.tierV2?.tierScore).isEqualTo("tier value")
+      assertThat(createdCase.captured.tierV3).isNull()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -58,6 +58,7 @@ class CaseServiceTest {
     @Test
     fun `existing case, update`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+      every { mockFeatureFlagService.getBooleanFlag("use-tier-v3") } returns false
 
       val crn = "CRN123"
       val now = OffsetDateTime.now()
@@ -130,6 +131,7 @@ class CaseServiceTest {
     @Test
     fun `existing case, update, leaving tiers as current value if getting tiers fails`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+      every { mockFeatureFlagService.getBooleanFlag("use-tier-v3") } returns false
 
       val crn = "CRN123"
       val now = OffsetDateTime.now()
@@ -172,6 +174,7 @@ class CaseServiceTest {
     @Test
     fun `no existing case, create new`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+      every { mockFeatureFlagService.getBooleanFlag("use-tier-v3") } returns false
 
       val crn = "CRN123"
       val now = OffsetDateTime.now()
@@ -233,6 +236,7 @@ class CaseServiceTest {
     @Test
     fun `no existing case, create new, setting tiers to null if get tiers errors`() {
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
+      every { mockFeatureFlagService.getBooleanFlag("use-tier-v3") } returns false
 
       val crn = "CRN123"
 
@@ -271,6 +275,7 @@ class CaseServiceTest {
       val crn = "CRN123"
       val now = OffsetDateTime.now()
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
+      every { mockFeatureFlagService.getBooleanFlag("use-tier-v3") } returns false
 
       every { mockCaseRepository.findByCrn(crn) } returns null
       val createdCase = slot<CaseEntity>()


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-839

Add new /cas1/applications/create endpoint.

Changes:

- Added POST `/cas1/applications/create` plus request/response DTOs (`Cas1NewApplication`, `Cas1CreateApplicationOutcome`).
- Updated `CaseService.ensureCaseExists` to return `CaseDto`, updating affected tests.
- Extended CAS1 application-creation unit/integration tests and added a TierDtoFactory helper method.