### PR TITLE
Move preprod db restore to tuesday

### DIFF
--- a/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-approved-premises-api/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -58,7 +58,7 @@ kind: CronJob
 metadata:
   name: db-refresh-job
 spec:
-  schedule: "0 7 * * 1"
+  schedule: "0 7 * * 2"
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:


### PR DESCRIPTION
Preprod db restore currently fails if preprod ddl is out of sync with prod ddl. This is likely on a monday morning as we don’t release to prod on a friday

This commit moves the restore job to tuesday morning to make this issue less likely