### PR TITLE
Updated CAS2 cohorts longDisplayName to match UI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/Cas2ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/jpa/entity/Cas2ApplicationEntity.kt
@@ -94,11 +94,11 @@ enum class Cas2Cohort(val apiType: Cas2CohortDto, val displayName: String, val l
   HDC(Cas2CohortDto.HOME_DETENTION_CURFEW, "HDC", "Home Detention Curfew", "3 working days"),
   PRISON_BAIL(Cas2CohortDto.PRISON_BAIL, "Prison Bail", "Prison Bail", "1 working day"),
   COURT_BAIL(Cas2CohortDto.COURT_BAIL, "Court Bail", "Court Bail", "1 hour"),
-  ATCR(Cas2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL, "ATCR", "Alternative to Custodial Recall", "1 hour"),
-  HCRD(Cas2CohortDto.HOMELESS_AT_CONDITIONAL_RELEASE_DATE, "HCRD", "Homeless at Conditional Release Date", "3 working days"),
-  HEFR(Cas2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL, "HEFR", "Homeless at End of Fixed Term Recall", "3 working days"),
-  ISC(Cas2CohortDto.INTENSIVE_SUPERVISION_COURTS, "ISC", "Intensive Supervision Courts", "3 working days"),
-  RARR(Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW, "RARR", "Risk Assessed Recall Review", "3 working days"),
+  ATCR(Cas2CohortDto.ALTERNATIVE_TO_CUSTODIAL_RECALL, "ATCR", "Alternative to Custodial Recall (ATCR)", "1 hour"),
+  HCRD(Cas2CohortDto.HOMELESS_AT_CONDITIONAL_RELEASE_DATE, "HCRD", "Homeless at Conditional Release Date (HCRD)", "3 working days"),
+  HEFR(Cas2CohortDto.HOMELESS_AT_END_OF_FIXED_TERM_RECALL, "HEFR", "Homeless at End of Fixed-term Recall", "3 working days"),
+  ISC(Cas2CohortDto.INTENSIVE_SUPERVISION_COURTS, "ISC", "Intensive Supervision Courts (ISC)", "3 working days"),
+  RARR(Cas2CohortDto.RISK_ASSESSED_RECALL_REVIEW, "RARR", "Risk Assessed Recall Review (RARR)", "3 working days"),
   FROM_AP(Cas2CohortDto.REFERRAL_FROM_APPROVED_PREMISES, "From AP", "Referral from Approved Premises", "3 working days"),
   ;
 


### PR DESCRIPTION
After chatting with Kristina I've updated the CAS2 cohort long display names to match the UI

4 entries have had their initialisms appended, and fixed-term has been hyphenated 

*I've updated this branch with a merge commit, as I got an error trying to rebase through the Github UI*