### PR TITLE
FM-831 Add authorised client/JWt for draft doc backfill

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/migration/Cas1BackfillApplicationDraftDocumentJob.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.migration
 
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -9,13 +9,12 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.http.HttpEntity
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.support.TransactionTemplate
-import org.springframework.web.client.RestTemplate
-import org.springframework.web.client.postForEntity
+import org.springframework.web.reactive.function.client.bodyToMono
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.migration.MigrationJob
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.WebClientConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.LaoStrategy
@@ -27,12 +26,11 @@ import java.util.UUID
 class Cas1BackfillApplicationDraftDocumentJob(
   private val repository: Cas1BackfillApplicationDraftDocumentJobRepository,
   private val transactionTemplate: TransactionTemplate,
-  @Value($$"${services.cas1-ui.base-url}") private val cas1UiBaseUrl: String,
   private val applicationsTransformer: ApplicationsTransformer,
   private val offenderDetailService: OffenderDetailService,
+  @Qualifier("cas1UiWebClient") private val webClientConfig: WebClientConfig,
 ) : MigrationJob() {
   override val shouldRunInTransaction = false
-  private val restTemplate = RestTemplate()
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -87,8 +85,13 @@ class Cas1BackfillApplicationDraftDocumentJob(
     )
 
     try {
-      val result = restTemplate.postForEntity<String>("$cas1UiBaseUrl/render-application", HttpEntity(cas1Application))
-      repository.updateDocument(applicationId, result.body!!)
+      webClientConfig.webClient.post()
+        .uri("/render-application")
+        .bodyValue(cas1Application)
+        .retrieve()
+        .bodyToMono<String>()
+        .block()
+        ?.let { repository.updateDocument(applicationId, it) } ?: throw IllegalStateException("empty body returned for application $applicationId")
     } catch (e: Exception) {
       throw Exception("Error rendering document for application $applicationId", e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -44,6 +44,37 @@ class WebClientConfiguration(
     return manager
   }
 
+  @Bean(name = ["cas1UiWebClient"])
+  fun cas1UiWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    @Value("\${services.cas1-ui.base-url}") cas1UiBaseUrl: String,
+  ): WebClientConfig {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+
+    oauth2Client.setDefaultClientRegistrationId("delius-backed-apis")
+
+    return WebClientConfig(
+      WebClient.builder()
+        .baseUrl(cas1UiBaseUrl)
+        .filter(oauth2Client)
+        .clientConnector(
+          ReactorClientHttpConnector(
+            HttpClient
+              .create()
+              .responseTimeout(Duration.ofMillis(defaultUpstreamTimeoutMs))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(defaultUpstreamTimeoutMs).toMillis().toInt()),
+          ),
+        )
+        .exchangeStrategies(
+          ExchangeStrategies.builder().codecs {
+            it.defaultCodecs().maxInMemorySize(defaultMaxResponseInMemorySizeBytes)
+          }.build(),
+        )
+        .build(),
+      retryOnReadTimeout = true,
+    )
+  }
+
   @Bean(name = ["apDeliusContextApiWebClient"])
   fun apDeliusContextApiWebClient(
     authorizedClientManager: OAuth2AuthorizedClientManager,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/migration/Cas1BackfillApplicationDraftDocumentJobTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationT
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.cas1UiMockRenderApplicationPost
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.cas1UiMockRenderApplicationPost500Error
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
@@ -23,6 +24,31 @@ class Cas1BackfillApplicationDraftDocumentJobTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var applicationsTransformer: ApplicationsTransformer
+
+  @Test
+  fun `backfill applications log exception`() {
+    val (offender, inmateDetails) = givenAnOffender()
+    val app = TestApplication(
+      application = givenACas1Application(
+        submittedAt = null,
+        data = """{ "name" : "populated data" }""",
+        document = null,
+        crn = offender.otherIds.crn,
+      ),
+      offenderDetailSummary = offender,
+      inmateDetails = inmateDetails,
+    )
+
+    cas1UiMockRenderApplicationPost500Error(
+      request = app.toCas1ApplicationJson(),
+      response = """{ "crn": "${app.application.crn}", "name": "backfilled document" }""",
+    )
+
+    // note - this test has been added to ensure errors are logged. check logs to ensure this has happened
+    migrationJobService.runMigrationJob(MigrationJobType.cas1BackfillAppDraftDoc)
+
+    assertThat(approvedPremisesApplicationRepository.findByIdOrNull(app.application.id)!!.document).isNull()
+  }
 
   @Test
   fun `backfill applications ignoring null data`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/Cas1UiHttpMock.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/httpmocks/Cas1UiHttpMock.kt
@@ -11,3 +11,13 @@ fun IntegrationTestBase.cas1UiMockRenderApplicationPost(
   requestBody = WireMock.equalToJson(request),
   responseBody = response,
 )
+
+fun IntegrationTestBase.cas1UiMockRenderApplicationPost500Error(
+  request: String,
+  response: String,
+) = mockSuccessfulPostCallWithJsonStringResponse(
+  url = "/render-application",
+  requestBody = WireMock.equalToJson(request),
+  responseBody = response,
+  responseStatus = 500,
+)


### PR DESCRIPTION
As this is a temporary client and endpoint we’re using existing credentials to retrieve a JWT