### PR TITLE
SAS-798: Get applications first rather than assessments.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalReferralsController.kt
@@ -5,21 +5,21 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ReferralHistory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1AssessmentService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external.Cas1ExternalApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
 
 @Cas1ExternalController
 class Cas1ExternalReferralsController(
-  private val cas1AssessmentService: Cas1AssessmentService,
+  private val cas1ApplicationService: Cas1ApplicationService,
   private val cas1AssessmentTransformer: Cas1AssessmentTransformer,
   private val cas1ExternalApplicationService: Cas1ExternalApplicationService,
 ) {
   @PreAuthorize("hasRole('APPROVED_PREMISES__SINGLE_ACCOMMODATION_SERVICE')")
   @GetMapping("/referrals/{crn}")
   fun getReferralsByCrn(@PathVariable crn: String): ResponseEntity<List<Cas1ReferralHistory>> = ResponseEntity.ok(
-    cas1AssessmentService.getApprovedPremisesAssessmentsByCrn(crn).flatMap {
-      val placementHistories = cas1ExternalApplicationService.getPlacementHistories(it.application.id)
+    cas1ApplicationService.getApplicationsByCrn(crn).flatMap {
+      val placementHistories = cas1ExternalApplicationService.getPlacementHistories(it.id)
       cas1AssessmentTransformer.transformDomainToApiCas1ReferralHistory(it, placementHistories)
     },
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -42,6 +42,8 @@ class Cas1ApplicationService(
 ) {
   fun getApplication(applicationId: UUID) = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)
 
+  fun getApplicationsByCrn(crn: String) = approvedPremisesApplicationRepository.findByCrn(crn)
+
   fun getApplicationForUsername(
     applicationId: UUID,
     userDistinguishedName: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
@@ -82,23 +82,21 @@ class Cas1AssessmentTransformer(
     dueAt = ase.dueAt!!,
   )
 
-  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity, placementHistories: List<Cas1PlacementHistory>): List<Cas1ReferralHistory> {
-    val application = entity.cas1Application()
-
+  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesApplicationEntity, placementHistories: List<Cas1PlacementHistory>): List<Cas1ReferralHistory> {
     val referralHistory = Cas1ReferralHistory(
       id = entity.id,
-      applicationId = entity.application.id,
+      applicationId = entity.id,
       date = entity.submittedAt?.toLocalDate() ?: entity.createdAt.toLocalDate(),
-      applicationStatus = application.status,
+      applicationStatus = entity.status,
       type = ServiceType.CAS1,
-      referralRejectionReason = entity.rejectionRationale,
-      localAuthorityArea = application.apArea?.name,
-      pdu = application.cruManagementArea?.name,
-      referredBy = transformToStaffDto(application.createdByUser),
+      referralRejectionReason = entity.getLatestAssessment()?.rejectionRationale,
+      localAuthorityArea = entity.apArea?.name,
+      pdu = entity.cruManagementArea?.name,
+      referredBy = transformToStaffDto(entity.createdByUser),
       placementAddress = null,
       placementStatus = null,
       requestForPlacementStatus = null,
-      uiUrl = cas1ApplicationUrlTemplate.replace("#id", entity.application.id.toString()),
+      uiUrl = cas1ApplicationUrlTemplate.replace("#id", entity.id.toString()),
     )
 
     return placementHistories.map {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalReferralsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalReferralsTest.kt
@@ -76,7 +76,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
 
           val expectedReferrals = listOf(
             Cas1ReferralHistory(
-              id = assessment1.id,
+              id = assessment1.application.id,
               applicationId = assessment1.application.id,
               date = assessment1.createdAt.toLocalDate(),
               applicationStatus = (assessment1.application as ApprovedPremisesApplicationEntity).status,
@@ -91,7 +91,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               uiUrl = "http://frontend/applications/${assessment1.application.id}",
             ),
             Cas1ReferralHistory(
-              id = assessment2.id,
+              id = assessment2.application.id,
               applicationId = assessment2.application.id,
               date = assessment2.createdAt.toLocalDate(),
               applicationStatus = (assessment2.application as ApprovedPremisesApplicationEntity).status,
@@ -106,7 +106,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               uiUrl = "http://frontend/applications/${assessment2.application.id}",
             ),
             Cas1ReferralHistory(
-              id = assessment3.id,
+              id = assessment3.application.id,
               applicationId = assessment3.application.id,
               date = assessment3.createdAt.toLocalDate(),
               applicationStatus = (assessment3.application as ApprovedPremisesApplicationEntity).status,
@@ -121,7 +121,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               uiUrl = "http://frontend/applications/${assessment3.application.id}",
             ),
             Cas1ReferralHistory(
-              id = assessment4.id,
+              id = assessment4.application.id,
               applicationId = assessment4.application.id,
               date = assessment4.createdAt.toLocalDate(),
               applicationStatus = (assessment4.application as ApprovedPremisesApplicationEntity).status,
@@ -136,7 +136,7 @@ class Cas1ExternalReferralsTest : IntegrationTestBase() {
               uiUrl = "http://frontend/applications/${assessment4.application.id}",
             ),
             Cas1ReferralHistory(
-              id = assessment5.id,
+              id = assessment5.application.id,
               applicationId = assessment5.application.id,
               date = assessment5.createdAt.toLocalDate(),
               applicationStatus = (assessment5.application as ApprovedPremisesApplicationEntity).status,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1AssessmentTransformerTest.kt
@@ -15,13 +15,18 @@ import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApprovedPremisesUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1Application
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ReferralHistory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.TemporaryAccommodationApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
@@ -45,6 +50,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.util.JsonMapperFact
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as ApiAssessmentDecision
@@ -281,6 +287,62 @@ class Cas1AssessmentTransformerTest {
       assertThat(apiSummary.status).isEqualTo(Cas1AssessmentStatus.awaitingResponse)
       assertThat(apiSummary.risks).isEqualTo(risksTransformer.transformDomainToApi(personRisks, domainSummary.crn))
       assertThat(apiSummary.person).isNotNull
+    }
+  }
+
+  @Nested
+  inner class TransformDomainToApiCas1ReferralHistory {
+    @Test
+    fun `transformDomainToApiCas1ReferralHistory transforms correctly`() {
+      val user = UserEntityFactory()
+        .withYieldedProbationRegion {
+          ProbationRegionEntityFactory()
+            .withYieldedApArea { ApAreaEntityFactory().produce() }
+            .produce()
+        }
+        .produce()
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(user)
+        .withSubmittedAt(OffsetDateTime.parse("2022-12-14T12:06:00Z"))
+        .produce()
+
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withApplication(application)
+        .withRejectionRationale("Not suitable")
+        .produce()
+
+      application.assessments.add(assessment)
+
+      val placementHistories = listOf(
+        Cas1ExternalApplicationService.Cas1PlacementHistory(
+          dateApplied = LocalDate.parse("2022-12-15"),
+          premises = null,
+          placementStatus = null,
+          requestForPlacementStatus = RequestForPlacementStatus.requestSubmitted,
+        ),
+      )
+
+      val result = cas1AssessmentTransformer.transformDomainToApiCas1ReferralHistory(application, placementHistories)
+
+      assertThat(result).hasSize(1)
+      assertThat(result[0]).isEqualTo(
+        Cas1ReferralHistory(
+          id = application.id,
+          applicationId = application.id,
+          date = LocalDate.parse("2022-12-15"),
+          applicationStatus = application.status,
+          type = ServiceType.CAS1,
+          referralRejectionReason = "Not suitable",
+          localAuthorityArea = application.apArea?.name,
+          pdu = application.cruManagementArea?.name,
+          referredBy = Cas1StaffDto(user.name, user.deliusUsername, user.deliusStaffCode),
+          placementAddress = null,
+          placementStatus = null,
+          requestForPlacementStatus = RequestForPlacementStatus.requestSubmitted,
+          uiUrl = "http://localhost:3000/applications/${application.id}",
+        ),
+      )
     }
   }
 }


### PR DESCRIPTION
This Pull Request updates the logic in the Cas1ExternalReferralsController by refactoring how application and referral data is fetched and transformed. The PR also adds new functionality to retrieve applications by CRN, updates related service classes, and improves both unit and integration tests for the affected logic.

Main Changes:

- Refactored Cas1ExternalReferralsController to replace the use of Cas1AssessmentService with Cas1ApplicationService and updated the logic for fetching application and referral data.
- Added a new method getApplication(crn: String) to Cas1ApplicationService for retrieving applications by CRN.
- Updated transformation logic in Cas1AssessmentTransformer, adjusting how referral histories are mapped to align with updated domain models.
- Modified integration tests in Cas1ExternalReferralsTest to validate the new changes in logic around assessing referral history IDs.
- Introduced a new unit test case in Cas1AssessmentTransformerTest to validate the transformation logic for Cas1ReferralHistory.

This refactor centralizes application retrieval logic and ensures accurate transformation, bringing the implementation closer to the intended business requirements.