### PR TITLE
FM-859-add-reference-data-tiers-GET-Step-2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/ReferenceDataController.kt
@@ -29,7 +29,9 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReferralReject
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.Cas3VoidBedspaceReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3VoidBedspaceReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.AvailableTierDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.TierService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
@@ -81,6 +83,7 @@ class ReferenceDataController(
   private val referralRejectionReasonTransformer: ReferralRejectionReasonTransformer,
   private val apAreaRepository: ApAreaRepository,
   private val apAreaTransformer: ApAreaTransformer,
+  private val tierService: TierService,
 ) {
 
   @Operation(
@@ -380,4 +383,17 @@ class ReferenceDataController(
 
     return ResponseEntity.ok(referralRejectionReasons.map(referralRejectionReasonTransformer::transformJpaToApi))
   }
+
+  @Operation(
+    summary = "Lists all available tiers",
+    responses = [
+      ApiResponse(responseCode = "200", description = "successful operation", content = [Content(array = ArraySchema(schema = Schema(implementation = AvailableTierDto::class)))]),
+    ],
+  )
+  @RequestMapping(
+    method = [RequestMethod.GET],
+    value = ["/reference-data/tiers"],
+    produces = ["application/json"],
+  )
+  fun referenceDataTiersGet(): ResponseEntity<List<AvailableTierDto>> = ResponseEntity.ok(tierService.getAvailableTiers())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/dto/AvailableTierDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/dto/AvailableTierDto.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto
+
+data class AvailableTierDto(
+  val tier: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/TierService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/TierService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.AvailableTierDto
+
+@Service
+class TierService {
+
+  companion object {
+    val TIERS = listOf(
+      "D0", "D1", "D2", "D3",
+      "C0", "C1", "C2", "C3",
+      "B0", "B1", "B2", "B3",
+      "A0", "A1", "A2", "A3",
+    ).map { AvailableTierDto(it) }
+  }
+
+  fun getAvailableTiers(): List<AvailableTierDto> = TIERS
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Characteristic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MoveOnCategory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3VoidBedspaceReasonTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.AvailableTierDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
@@ -957,5 +958,43 @@ class ReferenceDataTest : IntegrationTestBase() {
       .isOk
       .expectBody()
       .json(expectedJson)
+  }
+
+  @Nested
+  inner class GetAvailableTiers {
+    @Test
+    fun `Get Available Tiers returns 200 with correct body`() {
+      val expectedJson = jsonMapper.writeValueAsString(
+        listOf(
+          AvailableTierDto("D0"),
+          AvailableTierDto("D1"),
+          AvailableTierDto("D2"),
+          AvailableTierDto("D3"),
+          AvailableTierDto("C0"),
+          AvailableTierDto("C1"),
+          AvailableTierDto("C2"),
+          AvailableTierDto("C3"),
+          AvailableTierDto("B0"),
+          AvailableTierDto("B1"),
+          AvailableTierDto("B2"),
+          AvailableTierDto("B3"),
+          AvailableTierDto("A0"),
+          AvailableTierDto("A1"),
+          AvailableTierDto("A2"),
+          AvailableTierDto("A3"),
+        ),
+      )
+
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.get()
+        .uri("/reference-data/tiers")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
   }
 }


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-859  STEP 2

# Changes in this PR
Implemented the new GET /reference-data/tiers endpoint to return available tier values from the API rather than a hardcoded UI list.

