### PR TITLE
Chore/sort test files in split tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
     env:
       _JAVA_OPTIONS: "-Xmx3g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"

--- a/script/split_tests
+++ b/script/split_tests
@@ -4,7 +4,7 @@ SPLIT_INDEX=$1
 SPLIT_TOTAL=$2
 
 TESTS="$(find src/test/kotlin -type d -name integration | \
-  xargs -I{} find "{}" -type f -name "*Test.kt" | \
+  xargs -I{} find "{}" -type f \( -name "*Test.kt" -o -name "*IT.kt" \) | \
   LC_ALL=C sort | \
   awk -v splitTotal=$SPLIT_TOTAL -v splitIndex=$SPLIT_INDEX 'NR % splitTotal == splitIndex % splitTotal' | \
   tr '\n' ',' | sed 's/,$//')"

--- a/script/split_tests
+++ b/script/split_tests
@@ -5,6 +5,7 @@ SPLIT_TOTAL=$2
 
 TESTS="$(find src/test/kotlin -type d -name integration | \
   xargs -I{} find "{}" -type f -name "*Test.kt" | \
+  LC_ALL=C sort | \
   awk -v splitTotal=$SPLIT_TOTAL -v splitIndex=$SPLIT_INDEX 'NR % splitTotal == splitIndex % splitTotal' | \
   tr '\n' ',' | sed 's/,$//')"
 


### PR DESCRIPTION
**Changes:**

- Update `script/split_tests` to include both `*Test.kt` and `*IT.kt` files and sort the discovered test list before sharding.
- Increase the GitHub Actions integration test shard matrix from 12 to 20 shards (this results in approx. 10 tests per shard which appears to be reasonable).

Including the additional `*IT.kt` filter results in the number of current integration tests increasing from 192 to 193 due to the inclusion of `Cas1RequestsForPlacementIT.kt`.

See [related comment](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/5006#discussion_r3596668838) discussing integration tests missing from the pipeline runs.  This was due to inconsistent sort ordering because rows 0, 2, 4, 6 etc extracted in `split_tests` are not consistent across the test splitting when sort ordering is not common across the stages.  Previously we were seeing tests appearing in more than one shard (e.g. `Cas3v2BedspaceArchiveTest` appearing in shard [1](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/29502547280/job/87639305485?pr=5006#step:7:23) and [3](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/29502547280/job/87639305678?pr=5006#step:7:37)).  Checks have been done to ensure that each test appears only once in the output after sorting using the method implemented in this PR.

After this PR is merged PR https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/5006 `Cas1PlacementMatchingOutcomesV2ReportTest` tests will then fail after rebasing (and then fixed after the url is changed from `/placement-requests/$placementRequestId/booking-not-made` to `/cas1/placement-requests/$placementRequestId/booking-not-made`).

Increasing the number of shards looks to reduce the time taken to run the integration tests from typically [9 minutes](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/29847847592/job/88693839712?pr=5023) to [6 minutes](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/29862758841/job/88744112639?pr=5025), shaving off 2 - 3 minutes from the feature branch and main branch pipelines - which will improve developer experience.