### PR TITLE
FM-890 Add tier-based duration calculation logic for CAS1 placement requests…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1RequestsForPlacementController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1RequestsForPlacementController.kt
@@ -29,7 +29,7 @@ class Cas1RequestsForPlacementController(
     @RequestParam("apType") apType: ApType,
     @RequestParam("sentenceType") sentenceType: SentenceTypeOption,
   ): ResponseEntity<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
-    val result = cas1RequestForPlacementService.defaultDurations(apType)
+    val result = cas1RequestForPlacementService.defaultDurations(applicationId, apType)
 
     return ResponseEntity.ok(extractEntityFromCasResult(result))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1RequestsForPlacementController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1RequestsForPlacementController.kt
@@ -29,7 +29,7 @@ class Cas1RequestsForPlacementController(
     @RequestParam("apType") apType: ApType,
     @RequestParam("sentenceType") sentenceType: SentenceTypeOption,
   ): ResponseEntity<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
-    val result = cas1RequestForPlacementService.defaultDurations(applicationId, apType)
+    val result = cas1RequestForPlacementService.defaultDurations(applicationId, apType, sentenceType.value)
 
     return ResponseEntity.ok(extractEntityFromCasResult(result))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -3,14 +3,16 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1SpaceBookingTransformer
 import java.time.Period
@@ -18,13 +20,14 @@ import java.util.UUID
 
 @Component
 class Cas1RequestForPlacementService(
-  private val applicationService: ApplicationService,
+  private val applicationService: Cas1ApplicationService,
   private val cas1PlacementApplicationService: Cas1PlacementApplicationService,
   private val placementRequestService: Cas1PlacementRequestService,
   private val requestForPlacementTransformer: RequestForPlacementTransformer,
   private val cas1WithdrawableService: Cas1WithdrawableService,
   private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
   private val cas1SpaceBookingTransformer: Cas1SpaceBookingTransformer,
+  private val caseService: CaseService,
 ) {
   fun getRequestsForPlacementByApplication(applicationId: UUID, requestingUser: UserEntity?): CasResult<List<RequestForPlacement>> {
     val application = applicationService.getApplication(applicationId)
@@ -42,19 +45,96 @@ class Cas1RequestForPlacementService(
     return CasResult.Success(result.sortedByDescending { it.submittedAt })
   }
 
+  @SuppressWarnings("ComplexCondition", "CyclomaticComplexMethod", "NestedBlockDepth", "MagicNumber")
   fun defaultDurations(
+    applicationId: UUID,
     apType: ApType,
   ): CasResult<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
-    val responseDto = when (apType) {
-      ApType.pipe -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null)
-      ApType.esap -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(52).days, maxDurationDays = null)
-      ApType.normal,
-      ApType.rfap,
-      ApType.mhapStJosephs,
-      ApType.mhapElliottHouse,
-      -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(12).days, maxDurationDays = null)
+    val application = applicationService.getApplication(applicationId)
+      ?: return CasResult.NotFound("Application", applicationId.toString())
+    val liveTier = (caseService.getCase(application.crn) ?: return CasResult.NotFound("Case", application.crn)).tier
+    val liveTierVersion = liveTier?.version
+      ?: return CasResult.NotFound("Version for live tier associated with case CRN", application.crn)
+
+    return when (liveTierVersion) {
+      TierVersionDto.V2 -> CasResult.Success(
+        when (apType) {
+          ApType.pipe -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null)
+          ApType.esap -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(52).days, maxDurationDays = null)
+          ApType.normal,
+          ApType.rfap,
+          ApType.mhapStJosephs,
+          ApType.mhapElliottHouse,
+          -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(12).days, maxDurationDays = null)
+        },
+      )
+
+      TierVersionDto.V3 -> {
+        when (apType) {
+          ApType.pipe -> CasResult.Success(
+            Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null),
+          )
+
+          ApType.esap -> CasResult.Success(
+            Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(62).days, maxDurationDays = null),
+          )
+
+          ApType.mhapStJosephs,
+          ApType.mhapElliottHouse,
+          -> if (application.isWomensApplication == true) {
+            CasResult.GeneralValidationError("MHAP not supported for women's applications")
+          } else {
+            CasResult.Success(
+              Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null),
+            )
+          }
+
+          ApType.normal,
+          ApType.rfap,
+          -> if (application.isWomensApplication == true) {
+            CasResult.Success(
+              Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(16).days, maxDurationDays = null),
+            )
+          } else {
+            if (application.sentenceType == SentenceTypeOption.life.value || application.sentenceType == SentenceTypeOption.ipp.value) {
+              if (liveTier.tierScore in listOf("A", "B", "C")) {
+                CasResult.Success(
+                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(16).days, maxDurationDays = null),
+                )
+              } else {
+                CasResult.GeneralValidationError("Only tier A, B or C is eligible for life and ipp sentence type")
+              }
+            } else if (
+              application.sentenceType == SentenceTypeOption.standardDeterminate.value ||
+              application.sentenceType == SentenceTypeOption.extendedDeterminate.value ||
+              application.sentenceType == SentenceTypeOption.communityOrder.value ||
+              application.sentenceType == SentenceTypeOption.bailPlacement.value ||
+              application.sentenceType == SentenceTypeOption.nonStatutory.value
+            ) {
+              if (liveTier.tierScore == "A") {
+                CasResult.Success(
+                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(16).days, maxDurationDays = null),
+                )
+              } else if (liveTier.tierScore == "B") {
+                CasResult.Success(
+                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(12).days, maxDurationDays = null),
+                )
+              } else if (liveTier.tierScore == "C" || liveTier.tierScore == "D") {
+                CasResult.Success(
+                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(8).days, maxDurationDays = null),
+                )
+              } else if (liveTier.tierScore in listOf("E", "F", "G")) {
+                CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score ${liveTier.tierScore}")
+              } else {
+                CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score ${liveTier.tierScore}")
+              }
+            } else {
+              CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score ${liveTier.tierScore}")
+            }
+          }
+        }
+      }
     }
-    return CasResult.Success(responseDto)
   }
 
   private fun toRequestForPlacement(placementApplication: PlacementApplicationEntity, user: UserEntity?) = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -49,93 +49,80 @@ class Cas1RequestForPlacementService(
   fun defaultDurations(
     applicationId: UUID,
     apType: ApType,
+    sentenceType: String,
   ): CasResult<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
     val application = applicationService.getApplication(applicationId)
       ?: return CasResult.NotFound("Application", applicationId.toString())
-    val liveTier = (caseService.getCase(application.crn) ?: return CasResult.NotFound("Case", application.crn)).tier
+    val liveTier = (caseService.getCase(application.crn) ?: return CasResult.GeneralValidationError("Case is null for application crn ${application.crn}")).tier
     val liveTierVersion = liveTier?.version
       ?: return CasResult.NotFound("Version for live tier associated with case CRN", application.crn)
 
     return when (liveTierVersion) {
-      TierVersionDto.V2 -> CasResult.Success(
+      TierVersionDto.V2 ->
         when (apType) {
-          ApType.pipe -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null)
-          ApType.esap -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(52).days, maxDurationDays = null)
+          ApType.pipe -> createDurationCalculation(Period.ofWeeks(26), null)
+          ApType.esap -> createDurationCalculation(Period.ofWeeks(52), null)
           ApType.normal,
           ApType.rfap,
           ApType.mhapStJosephs,
           ApType.mhapElliottHouse,
-          -> Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(12).days, maxDurationDays = null)
-        },
-      )
+          -> createDurationCalculation(Period.ofWeeks(12), null)
+        }
 
       TierVersionDto.V3 -> {
         when (apType) {
-          ApType.pipe -> CasResult.Success(
-            Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null),
-          )
+          ApType.pipe -> createDurationCalculation(Period.ofWeeks(26), null)
 
-          ApType.esap -> CasResult.Success(
-            Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(62).days, maxDurationDays = null),
-          )
+          ApType.esap -> createDurationCalculation(Period.ofWeeks(62), null)
 
           ApType.mhapStJosephs,
           ApType.mhapElliottHouse,
           -> if (application.isWomensApplication == true) {
             CasResult.GeneralValidationError("MHAP not supported for women's applications")
           } else {
-            CasResult.Success(
-              Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(26).days, maxDurationDays = null),
-            )
+            createDurationCalculation(Period.ofWeeks(26), null)
           }
 
           ApType.normal,
           ApType.rfap,
           -> if (application.isWomensApplication == true) {
-            CasResult.Success(
-              Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(16).days, maxDurationDays = null),
-            )
+            createDurationCalculation(Period.ofWeeks(16), null)
           } else {
-            if (application.sentenceType == SentenceTypeOption.life.value || application.sentenceType == SentenceTypeOption.ipp.value) {
+            if (sentenceType == SentenceTypeOption.life.value || sentenceType == SentenceTypeOption.ipp.value) {
               if (liveTier.tierScore in listOf("A", "B", "C")) {
-                CasResult.Success(
-                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(16).days, maxDurationDays = null),
-                )
+                createDurationCalculation(Period.ofWeeks(16), null)
               } else {
                 CasResult.GeneralValidationError("Only tier A, B or C is eligible for life and ipp sentence type")
               }
             } else if (
-              application.sentenceType == SentenceTypeOption.standardDeterminate.value ||
-              application.sentenceType == SentenceTypeOption.extendedDeterminate.value ||
-              application.sentenceType == SentenceTypeOption.communityOrder.value ||
-              application.sentenceType == SentenceTypeOption.bailPlacement.value ||
-              application.sentenceType == SentenceTypeOption.nonStatutory.value
+              sentenceType == SentenceTypeOption.standardDeterminate.value ||
+              sentenceType == SentenceTypeOption.extendedDeterminate.value ||
+              sentenceType == SentenceTypeOption.communityOrder.value ||
+              sentenceType == SentenceTypeOption.bailPlacement.value ||
+              sentenceType == SentenceTypeOption.nonStatutory.value
             ) {
               if (liveTier.tierScore == "A") {
-                CasResult.Success(
-                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(16).days, maxDurationDays = null),
-                )
+                createDurationCalculation(Period.ofWeeks(16), null)
               } else if (liveTier.tierScore == "B") {
-                CasResult.Success(
-                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(12).days, maxDurationDays = null),
-                )
+                createDurationCalculation(Period.ofWeeks(12), null)
               } else if (liveTier.tierScore == "C" || liveTier.tierScore == "D") {
-                CasResult.Success(
-                  Cas1RequestsForPlacementDurationsCalculationResponseDto(Period.ofWeeks(8).days, maxDurationDays = null),
-                )
+                createDurationCalculation(Period.ofWeeks(8), null)
               } else if (liveTier.tierScore in listOf("E", "F", "G")) {
-                CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score ${liveTier.tierScore}")
+                CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type $sentenceType, tier score ${liveTier.tierScore}")
               } else {
-                CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score ${liveTier.tierScore}")
+                CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type $sentenceType, tier score ${liveTier.tierScore}")
               }
             } else {
-              CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score ${liveTier.tierScore}")
+              CasResult.GeneralValidationError("Cannot calculate duration for ap type $apType, sentence type $sentenceType, tier score ${liveTier.tierScore}")
             }
           }
         }
       }
     }
   }
+
+  @SuppressWarnings("MaxLineLength")
+  private fun createDurationCalculation(period: Period, maxDurationDays: Int?): CasResult.Success<Cas1RequestsForPlacementDurationsCalculationResponseDto> = CasResult.Success(Cas1RequestsForPlacementDurationsCalculationResponseDto(period.days, maxDurationDays))
 
   private fun toRequestForPlacement(placementApplication: PlacementApplicationEntity, user: UserEntity?) = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
     placementApplication,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
@@ -40,7 +40,7 @@ class Cas1RequestsForPlacementIT : IntegrationTestBase() {
         mockFeatureFlagService.setFlag("use-tier-v3", false)
 
         val (_, jwt) = givenAUser()
-        val application = givenACas1Application(apType = ApprovedPremisesType.MHAP_ELLIOTT_HOUSE, sentenceType = SentenceTypeOption.standardDeterminate.value)
+        val application = givenACas1Application(apType = ApprovedPremisesType.MHAP_ELLIOTT_HOUSE, sentenceType = SentenceTypeOption.ipp.value)
         givenACase(application.crn, tierV2 = TierFactory().produce(), tierV3 = null)
 
         val response = webTestClient.get()
@@ -63,7 +63,7 @@ class Cas1RequestsForPlacementIT : IntegrationTestBase() {
         mockFeatureFlagService.setFlag("use-tier-v3", true)
 
         val (_, jwt) = givenAUser()
-        val application = givenACas1Application(apType = ApprovedPremisesType.RFAP, sentenceType = SentenceTypeOption.ipp.value)
+        val application = givenACas1Application(apType = ApprovedPremisesType.RFAP, sentenceType = SentenceTypeOption.nonStatutory.value)
         givenACase(application.crn, tierV2 = null, tierV3 = TierFactory().withVersion(TierVersion.V3).withTierScore("B").produce())
 
         val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/Cas1RequestsForPlacementIT.kt
@@ -7,9 +7,15 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1RequestsForPlacementDurationsCalculationResponseDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACas1Application
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenACase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+import java.time.Period
 import java.util.UUID
 
 class Cas1RequestsForPlacementIT : IntegrationTestBase() {
@@ -27,20 +33,50 @@ class Cas1RequestsForPlacementIT : IntegrationTestBase() {
         .isUnauthorized
     }
 
-    @Test
-    fun `returns correct response body for ApType`() {
-      val (_, jwt) = givenAUser()
+    @Nested
+    inner class V2 {
+      @Test
+      fun `returns correct response body for apType mhapElliottHouse, sentence type standardDeterminate`() {
+        mockFeatureFlagService.setFlag("use-tier-v3", false)
 
-      val response = webTestClient.get()
-        .uri("/cas1/applications/${UUID.randomUUID()}/requests-for-placement/calc/durations?apType=${ApType.mhapElliottHouse}&sentenceType=${SentenceTypeOption.standardDeterminate}")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isOk
-        .bodyAsObject<Cas1RequestsForPlacementDurationsCalculationResponseDto>()
+        val (_, jwt) = givenAUser()
+        val application = givenACas1Application(apType = ApprovedPremisesType.MHAP_ELLIOTT_HOUSE, sentenceType = SentenceTypeOption.standardDeterminate.value)
+        givenACase(application.crn, tierV2 = TierFactory().produce(), tierV3 = null)
 
-      assertThat(response.defaultDurationDays).isEqualTo(84)
-      assertThat(response.maxDurationDays).isNull()
+        val response = webTestClient.get()
+          .uri("/cas1/applications/${application.id}/requests-for-placement/calc/durations?apType=${ApType.mhapElliottHouse}&sentenceType=${SentenceTypeOption.standardDeterminate}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .bodyAsObject<Cas1RequestsForPlacementDurationsCalculationResponseDto>()
+
+        assertThat(response.defaultDurationDays).isEqualTo(Period.ofWeeks(12).days)
+        assertThat(response.maxDurationDays).isNull()
+      }
+    }
+
+    @Nested
+    inner class V3 {
+      @Test
+      fun `returns correct response body for apType rfap, sentence type ipp, tier B`() {
+        mockFeatureFlagService.setFlag("use-tier-v3", true)
+
+        val (_, jwt) = givenAUser()
+        val application = givenACas1Application(apType = ApprovedPremisesType.RFAP, sentenceType = SentenceTypeOption.ipp.value)
+        givenACase(application.crn, tierV2 = null, tierV3 = TierFactory().withVersion(TierVersion.V3).withTierScore("B").produce())
+
+        val response = webTestClient.get()
+          .uri("/cas1/applications/${application.id}/requests-for-placement/calc/durations?apType=${ApType.rfap}&sentenceType=${SentenceTypeOption.ipp}")
+          .header("Authorization", "Bearer $jwt")
+          .exchange()
+          .expectStatus()
+          .isOk
+          .bodyAsObject<Cas1RequestsForPlacementDurationsCalculationResponseDto>()
+
+        assertThat(response.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
+        assertThat(response.maxDurationDays).isNull()
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/ApprovedPremisesApplicationEntityFactory.kt
@@ -143,7 +143,7 @@ class ApprovedPremisesApplicationEntityFactory : Factory<ApprovedPremisesApplica
     this.releaseType = { releaseType }
   }
 
-  fun withSentenceType(sentenceType: String) = apply {
+  fun withSentenceType(sentenceType: String?) = apply {
     this.sentenceType = { sentenceType }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenAnApplication.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens
 
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.deliuscontext.CaseSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersonRisksFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
@@ -54,6 +55,7 @@ fun IntegrationTestBase.givenACas1Application(
   createdAt: OffsetDateTime = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   duration: Int? = null,
   document: String? = "{}",
+  sentenceType: String? = null,
   block: (application: ApplicationEntity) -> Unit = {},
 ) = givenAnApplication(
   createdByUser,
@@ -72,6 +74,7 @@ fun IntegrationTestBase.givenACas1Application(
   createdAt,
   duration,
   document,
+  sentenceType,
   block,
 )
 
@@ -93,6 +96,7 @@ fun IntegrationTestBase.givenAnApplication(
   createdAt: OffsetDateTime = OffsetDateTime.now().roundNanosToMillisToAccountForLossOfPrecisionInPostgres(),
   duration: Int? = null,
   document: String? = "{}",
+  sentenceType: String? = SentenceTypeOption.standardDeterminate.value,
   block: (application: ApplicationEntity) -> Unit = {},
 ): ApprovedPremisesApplicationEntity {
   val riskRatings = tier?.let {
@@ -117,6 +121,7 @@ fun IntegrationTestBase.givenAnApplication(
     withData(data)
     withDocument(document)
     withApType(apType)
+    withSentenceType(sentenceType ?: SentenceTypeOption.standardDeterminate.value)
   }
 
   block(application)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
@@ -273,9 +272,11 @@ class Cas1RequestForPlacementServiceTest {
     fun `returns not found when application not found for applicationId`() {
       val applicationId = UUID.randomUUID()
 
+      val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
       every { applicationService.getApplication(applicationId) } returns null
 
-      val defaultDuration = cas1RequestForPlacementService.defaultDurations(applicationId, mockk<ApType>())
+      val defaultDuration = cas1RequestForPlacementService.defaultDurations(applicationId, mockk<ApType>(), sentenceType = sentenceType)
 
       assertThatCasResult(defaultDuration).isNotFound(
         "Application",
@@ -284,36 +285,28 @@ class Cas1RequestForPlacementServiceTest {
     }
 
     @Test
-    fun `returns not found when case not found for crn`() {
+    fun `returns validation error when case not found for crn`() {
       val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(
-          UserEntityFactory().withProbationRegion(
-            ProbationRegionEntityFactory().produce(),
-          )
-            .produce(),
-        )
+        .withCrn("CRN123")
+        .withDefaults()
         .produce()
+
+      val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
 
       every { applicationService.getApplication(application.id) } returns application
       every { caseService.getCase(application.crn) } returns null
 
-      val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, mockk<ApType>())
+      val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, mockk<ApType>(), sentenceType)
 
-      assertThatCasResult(defaultDuration).isNotFound(
-        "Case",
-        expectedId = application.crn,
+      assertThatCasResult(defaultDuration).isGeneralValidationError(
+        "Case is null for application crn CRN123",
       )
     }
 
     @Test
     fun `returns not found error when case tier is null`() {
       val application = ApprovedPremisesApplicationEntityFactory()
-        .withCreatedByUser(
-          UserEntityFactory().withProbationRegion(
-            ProbationRegionEntityFactory().produce(),
-          )
-            .produce(),
-        )
+        .withDefaults()
         .produce()
 
       val case = CaseDtoFactory().withTier(null).produce()
@@ -321,7 +314,7 @@ class Cas1RequestForPlacementServiceTest {
       every { applicationService.getApplication(application.id) } returns application
       every { caseService.getCase(application.crn) } returns case
 
-      val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, mockk<ApType>())
+      val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, mockk<ApType>(), SentenceTypeOption.entries.toTypedArray().random().value)
 
       assertThatCasResult(defaultDuration).isNotFound(
         "Version for live tier associated with case CRN",
@@ -342,12 +335,7 @@ class Cas1RequestForPlacementServiceTest {
       )
       fun `returns duration 12 weeks when apType is normal or mhapElliottHouse or mhapStJosephs or rfap`(apType: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -357,10 +345,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(12).days)
@@ -371,12 +361,7 @@ class Cas1RequestForPlacementServiceTest {
       @Test
       fun `returns duration 26 weeks when apType is pipe`() {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -386,10 +371,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.pipe)
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.pipe, sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(26).days)
@@ -400,12 +387,7 @@ class Cas1RequestForPlacementServiceTest {
       @Test
       fun `returns duration 52 weeks when apType is esap`() {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -415,10 +397,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.esap)
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.esap, sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(52).days)
@@ -432,12 +416,7 @@ class Cas1RequestForPlacementServiceTest {
       @Test
       fun `returns duration 26 weeks when apType is pipe`() {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -447,10 +426,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.pipe)
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.pipe, sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(26).days)
@@ -461,12 +442,7 @@ class Cas1RequestForPlacementServiceTest {
       @Test
       fun `returns duration 62 weeks when apType is esap`() {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -476,10 +452,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.esap)
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.esap, sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(62).days)
@@ -496,12 +474,7 @@ class Cas1RequestForPlacementServiceTest {
       )
       fun `returns general validation error when apType is mhap st josephs or mhap elliott house and womens`(apType: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .withIsWomensApplication(true)
           .produce()
 
@@ -512,10 +485,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isGeneralValidationError(
           "MHAP not supported for women's applications",
@@ -531,12 +506,8 @@ class Cas1RequestForPlacementServiceTest {
       )
       fun `returns duration 26 weeks when apType is mhap st josephs or mhap elliott house and mens`(apType: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -546,10 +517,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(26).days)
@@ -566,12 +539,7 @@ class Cas1RequestForPlacementServiceTest {
       )
       fun `returns duration 16 weeks when apType is normal or rfap and womens`(apType: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
+          .withDefaults()
           .withIsWomensApplication(true)
           .produce()
 
@@ -582,10 +550,12 @@ class Cas1RequestForPlacementServiceTest {
         )
           .produce()
 
+        val sentenceType = SentenceTypeOption.entries.toTypedArray().random().value
+
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
@@ -612,13 +582,8 @@ class Cas1RequestForPlacementServiceTest {
       )
       fun `returns duration 16 weeks when apType is normal or rfap and mens and sentence type is life or ipp and live tier is A, B, or C`(apType: String, sentenceType: String, liveTierScore: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(sentenceType)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -631,7 +596,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
@@ -662,13 +627,8 @@ class Cas1RequestForPlacementServiceTest {
       )
       fun `returns general validation error when apType is normal or rfap and mens and sentence type is life or ipp and live tier is D, E, F or G`(apType: String, sentenceType: String, liveTierScore: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(sentenceType)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -681,7 +641,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isGeneralValidationError(
           "Only tier A, B or C is eligible for life and ipp sentence type",
@@ -706,13 +666,8 @@ class Cas1RequestForPlacementServiceTest {
       @SuppressWarnings("MaxLineLength")
       fun `returns duration 16 weeks when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is A`(apType: String, sentenceType: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(sentenceType)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -725,7 +680,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
@@ -751,13 +706,8 @@ class Cas1RequestForPlacementServiceTest {
       @SuppressWarnings("MaxLineLength")
       fun `returns duration 12 weeks when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is B`(apType: String, sentenceType: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(sentenceType)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -770,7 +720,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(12).days)
@@ -806,13 +756,8 @@ class Cas1RequestForPlacementServiceTest {
       @SuppressWarnings("MaxLineLength")
       fun `returns duration 8 weeks when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is C or D`(apType: String, sentenceType: String, liveTierScore: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(sentenceType)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -825,7 +770,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isSuccess().with {
           assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(8).days)
@@ -871,13 +816,8 @@ class Cas1RequestForPlacementServiceTest {
       @SuppressWarnings("MaxLineLength")
       fun `returns general validation error when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is E, F or G`(apType: String, sentenceType: String, liveTierScore: String) {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(sentenceType)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -890,23 +830,18 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType), sentenceType)
 
         assertThatCasResult(defaultDuration).isGeneralValidationError(
-          "Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score $liveTierScore",
+          "Cannot calculate duration for ap type $apType, sentence type $sentenceType, tier score $liveTierScore",
         )
       }
 
       @Test
       fun `returns general validation error when apType is normal and mens and sentence type is standardDeterminate and live tier is H`() {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType(SentenceTypeOption.standardDeterminate.value)
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -919,7 +854,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.normal)
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.normal, SentenceTypeOption.standardDeterminate.value)
 
         assertThatCasResult(defaultDuration).isGeneralValidationError(
           "Cannot calculate duration for ap type normal, sentence type standardDeterminate, tier score H",
@@ -929,13 +864,8 @@ class Cas1RequestForPlacementServiceTest {
       @Test
       fun `returns general validation error when apType is normal and mens and sentence type is invalidSentenceType and live tier is A`() {
         val application = ApprovedPremisesApplicationEntityFactory()
-          .withCreatedByUser(
-            UserEntityFactory().withProbationRegion(
-              ProbationRegionEntityFactory().produce(),
-            )
-              .produce(),
-          )
-          .withSentenceType("invalidSentenceType")
+          .withIsWomensApplication(false)
+          .withDefaults()
           .produce()
 
         val case = CaseDtoFactory().withTier(
@@ -948,7 +878,7 @@ class Cas1RequestForPlacementServiceTest {
         every { applicationService.getApplication(application.id) } returns application
         every { caseService.getCase(application.crn) } returns case
 
-        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.normal)
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.normal, "invalidSentenceType")
 
         assertThatCasResult(defaultDuration).isGeneralValidationError(
           "Cannot calculate duration for ap type normal, sentence type invalidSentenceType, tier score A",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
@@ -15,16 +16,22 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1RequestForPlacementService
@@ -36,17 +43,19 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.Period
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class Cas1RequestForPlacementServiceTest {
-  private val applicationService = mockk<ApplicationService>()
+  private val applicationService = mockk<Cas1ApplicationService>()
   private val cas1PlacementApplicationService = mockk<Cas1PlacementApplicationService>()
   private val placementRequestService = mockk<Cas1PlacementRequestService>()
   private val requestForPlacementTransformer = mockk<RequestForPlacementTransformer>()
   private val cas1WithdrawableService = mockk<Cas1WithdrawableService>()
   private val cas1SpaceBookingRepository = mockk<Cas1SpaceBookingRepository>()
   private val cas1SpaceBookingTransformer = mockk<Cas1SpaceBookingTransformer>()
+  private val caseService = mockk<CaseService>()
 
   private val cas1RequestForPlacementService = Cas1RequestForPlacementService(
     applicationService,
@@ -56,6 +65,7 @@ class Cas1RequestForPlacementServiceTest {
     cas1WithdrawableService,
     cas1SpaceBookingRepository,
     cas1SpaceBookingTransformer,
+    caseService,
   )
 
   @BeforeEach
@@ -259,41 +269,690 @@ class Cas1RequestForPlacementServiceTest {
 
   @Nested
   inner class GetRequestsForPlacementDurations {
-    @ParameterizedTest
-    @ValueSource(
-      strings = [
-        "normal",
-        "mhapElliottHouse",
-        "mhapStJosephs",
-        "rfap",
-      ],
-    )
-    fun `returns duration 84 (12 x 7) when apType is normal or mhapElliottHouse or mhapStJosephs or rfap`(apType: String) {
-      val result = cas1RequestForPlacementService.defaultDurations(ApType.valueOf(apType))
+    @Test
+    fun `returns not found when application not found for applicationId`() {
+      val applicationId = UUID.randomUUID()
 
-      assertThatCasResult(result).isSuccess().with {
-        assertThat(it.defaultDurationDays).isEqualTo(84)
-        assertThat(it.maxDurationDays).isNull()
-      }
+      every { applicationService.getApplication(applicationId) } returns null
+
+      val defaultDuration = cas1RequestForPlacementService.defaultDurations(applicationId, mockk<ApType>())
+
+      assertThatCasResult(defaultDuration).isNotFound(
+        "Application",
+        expectedId = applicationId,
+      )
     }
 
     @Test
-    fun `returns duration 182 (26 x 7) when apType is pipe`() {
-      val result = cas1RequestForPlacementService.defaultDurations(ApType.pipe)
+    fun `returns not found when case not found for crn`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(
+          UserEntityFactory().withProbationRegion(
+            ProbationRegionEntityFactory().produce(),
+          )
+            .produce(),
+        )
+        .produce()
 
-      assertThatCasResult(result).isSuccess().with {
-        assertThat(it.defaultDurationDays).isEqualTo(182)
-        assertThat(it.maxDurationDays).isNull()
-      }
+      every { applicationService.getApplication(application.id) } returns application
+      every { caseService.getCase(application.crn) } returns null
+
+      val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, mockk<ApType>())
+
+      assertThatCasResult(defaultDuration).isNotFound(
+        "Case",
+        expectedId = application.crn,
+      )
     }
 
     @Test
-    fun `returns duration 364 (52 x 7) when apType is esap`() {
-      val result = cas1RequestForPlacementService.defaultDurations(ApType.esap)
+    fun `returns not found error when case tier is null`() {
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withCreatedByUser(
+          UserEntityFactory().withProbationRegion(
+            ProbationRegionEntityFactory().produce(),
+          )
+            .produce(),
+        )
+        .produce()
 
-      assertThatCasResult(result).isSuccess().with {
-        assertThat(it.defaultDurationDays).isEqualTo(364)
-        assertThat(it.maxDurationDays).isNull()
+      val case = CaseDtoFactory().withTier(null).produce()
+
+      every { applicationService.getApplication(application.id) } returns application
+      every { caseService.getCase(application.crn) } returns case
+
+      val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, mockk<ApType>())
+
+      assertThatCasResult(defaultDuration).isNotFound(
+        "Version for live tier associated with case CRN",
+        expectedId = application.crn,
+      )
+    }
+
+    @Nested
+    inner class V2 {
+      @ParameterizedTest
+      @ValueSource(
+        strings = [
+          "normal",
+          "mhapElliottHouse",
+          "mhapStJosephs",
+          "rfap",
+        ],
+      )
+      fun `returns duration 12 weeks when apType is normal or mhapElliottHouse or mhapStJosephs or rfap`(apType: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V2,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(12).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @Test
+      fun `returns duration 26 weeks when apType is pipe`() {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V2,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.pipe)
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(26).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @Test
+      fun `returns duration 52 weeks when apType is esap`() {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V2,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.esap)
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(52).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+    }
+
+    @Nested
+    inner class V3 {
+      @Test
+      fun `returns duration 26 weeks when apType is pipe`() {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V3,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.pipe)
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(26).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @Test
+      fun `returns duration 62 weeks when apType is esap`() {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V3,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.esap)
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(62).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @ValueSource(
+        strings = [
+          "mhapElliottHouse",
+          "mhapStJosephs",
+        ],
+      )
+      fun `returns general validation error when apType is mhap st josephs or mhap elliott house and womens`(apType: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withIsWomensApplication(true)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V3,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isGeneralValidationError(
+          "MHAP not supported for women's applications",
+        )
+      }
+
+      @ParameterizedTest
+      @ValueSource(
+        strings = [
+          "mhapElliottHouse",
+          "mhapStJosephs",
+        ],
+      )
+      fun `returns duration 26 weeks when apType is mhap st josephs or mhap elliott house and mens`(apType: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V3,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(26).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @ValueSource(
+        strings = [
+          "normal",
+          "rfap",
+        ],
+      )
+      fun `returns duration 16 weeks when apType is normal or rfap and womens`(apType: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withIsWomensApplication(true)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory().withVersion(
+            TierVersionDto.V3,
+          ).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+        value = [
+          "normal,life,A",
+          "normal,life,B",
+          "normal,life,C",
+          "normal,ipp,A",
+          "normal,ipp,B",
+          "normal,ipp,C",
+          "rfap,life,A",
+          "rfap,life,B",
+          "rfap,life,C",
+          "rfap,ipp,A",
+          "rfap,ipp,B",
+          "rfap,ipp,C",
+        ],
+      )
+      fun `returns duration 16 weeks when apType is normal or rfap and mens and sentence type is life or ipp and live tier is A, B, or C`(apType: String, sentenceType: String, liveTierScore: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(sentenceType)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore(liveTierScore).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+        value = [
+          "normal,life,D",
+          "normal,life,E",
+          "normal,life,F",
+          "normal,life,G",
+          "normal,ipp,D",
+          "normal,ipp,E",
+          "normal,ipp,F",
+          "normal,ipp,G",
+          "rfap,life,D",
+          "rfap,life,E",
+          "rfap,life,F",
+          "rfap,life,G",
+          "rfap,ipp,D",
+          "rfap,ipp,E",
+          "rfap,ipp,F",
+          "rfap,ipp,G",
+        ],
+      )
+      fun `returns general validation error when apType is normal or rfap and mens and sentence type is life or ipp and live tier is D, E, F or G`(apType: String, sentenceType: String, liveTierScore: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(sentenceType)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore(liveTierScore).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isGeneralValidationError(
+          "Only tier A, B or C is eligible for life and ipp sentence type",
+        )
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+        value = [
+          "normal,standardDeterminate",
+          "normal,extendedDeterminate",
+          "normal,communityOrder",
+          "normal,bailPlacement",
+          "normal,nonStatutory",
+          "rfap,standardDeterminate",
+          "rfap,extendedDeterminate",
+          "rfap,communityOrder",
+          "rfap,bailPlacement",
+          "rfap,nonStatutory",
+        ],
+      )
+      @SuppressWarnings("MaxLineLength")
+      fun `returns duration 16 weeks when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is A`(apType: String, sentenceType: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(sentenceType)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore("A").produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(16).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+        value = [
+          "normal,standardDeterminate",
+          "normal,extendedDeterminate",
+          "normal,communityOrder",
+          "normal,bailPlacement",
+          "normal,nonStatutory",
+          "rfap,standardDeterminate",
+          "rfap,extendedDeterminate",
+          "rfap,communityOrder",
+          "rfap,bailPlacement",
+          "rfap,nonStatutory",
+        ],
+      )
+      @SuppressWarnings("MaxLineLength")
+      fun `returns duration 12 weeks when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is B`(apType: String, sentenceType: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(sentenceType)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore("B").produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(12).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+        value = [
+          "normal,standardDeterminate,C",
+          "normal,extendedDeterminate,C",
+          "normal,communityOrder,C",
+          "normal,bailPlacement,C",
+          "normal,nonStatutory,C",
+          "rfap,standardDeterminate,C",
+          "rfap,extendedDeterminate,C",
+          "rfap,communityOrder,C",
+          "rfap,bailPlacement,C",
+          "rfap,nonStatutory,C",
+          "normal,standardDeterminate,D",
+          "normal,extendedDeterminate,D",
+          "normal,communityOrder,D",
+          "normal,bailPlacement,D",
+          "normal,nonStatutory,D",
+          "rfap,standardDeterminate,D",
+          "rfap,extendedDeterminate,D",
+          "rfap,communityOrder,D",
+          "rfap,bailPlacement,D",
+          "rfap,nonStatutory,D",
+        ],
+      )
+      @SuppressWarnings("MaxLineLength")
+      fun `returns duration 8 weeks when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is C or D`(apType: String, sentenceType: String, liveTierScore: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(sentenceType)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore(liveTierScore).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isSuccess().with {
+          assertThat(it.defaultDurationDays).isEqualTo(Period.ofWeeks(8).days)
+          assertThat(it.maxDurationDays).isNull()
+        }
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+        value = [
+          "normal,standardDeterminate,E",
+          "normal,extendedDeterminate,E",
+          "normal,communityOrder,E",
+          "normal,bailPlacement,E",
+          "normal,nonStatutory,E",
+          "rfap,standardDeterminate,E",
+          "rfap,extendedDeterminate,E",
+          "rfap,communityOrder,E",
+          "rfap,bailPlacement,E",
+          "rfap,nonStatutory,E",
+          "normal,standardDeterminate,F",
+          "normal,extendedDeterminate,F",
+          "normal,communityOrder,F",
+          "normal,bailPlacement,F",
+          "normal,nonStatutory,F",
+          "rfap,standardDeterminate,F",
+          "rfap,extendedDeterminate,F",
+          "rfap,communityOrder,F",
+          "rfap,bailPlacement,F",
+          "rfap,nonStatutory,F",
+          "normal,standardDeterminate,G",
+          "normal,extendedDeterminate,G",
+          "normal,communityOrder,G",
+          "normal,bailPlacement,G",
+          "normal,nonStatutory,G",
+          "rfap,standardDeterminate,G",
+          "rfap,extendedDeterminate,G",
+          "rfap,communityOrder,G",
+          "rfap,bailPlacement,G",
+          "rfap,nonStatutory,G",
+        ],
+      )
+      @SuppressWarnings("MaxLineLength")
+      fun `returns general validation error when apType is normal or rfap and mens and sentence type is standardDeterminate, extendedDeterminate, communityOrder, bailPlacement or nonStatutory and live tier is E, F or G`(apType: String, sentenceType: String, liveTierScore: String) {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(sentenceType)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore(liveTierScore).produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.valueOf(apType))
+
+        assertThatCasResult(defaultDuration).isGeneralValidationError(
+          "Cannot calculate duration for ap type $apType, sentence type ${application.sentenceType}, tier score $liveTierScore",
+        )
+      }
+
+      @Test
+      fun `returns general validation error when apType is normal and mens and sentence type is standardDeterminate and live tier is H`() {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType(SentenceTypeOption.standardDeterminate.value)
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore("H").produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.normal)
+
+        assertThatCasResult(defaultDuration).isGeneralValidationError(
+          "Cannot calculate duration for ap type normal, sentence type standardDeterminate, tier score H",
+        )
+      }
+
+      @Test
+      fun `returns general validation error when apType is normal and mens and sentence type is invalidSentenceType and live tier is A`() {
+        val application = ApprovedPremisesApplicationEntityFactory()
+          .withCreatedByUser(
+            UserEntityFactory().withProbationRegion(
+              ProbationRegionEntityFactory().produce(),
+            )
+              .produce(),
+          )
+          .withSentenceType("invalidSentenceType")
+          .produce()
+
+        val case = CaseDtoFactory().withTier(
+          TierDtoFactory()
+            .withVersion(TierVersionDto.V3)
+            .withTierScore("A").produce(),
+        )
+          .produce()
+
+        every { applicationService.getApplication(application.id) } returns application
+        every { caseService.getCase(application.crn) } returns case
+
+        val defaultDuration = cas1RequestForPlacementService.defaultDurations(application.id, ApType.normal)
+
+        assertThatCasResult(defaultDuration).isGeneralValidationError(
+          "Cannot calculate duration for ap type normal, sentence type invalidSentenceType, tier score A",
+        )
       }
     }
   }


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-890

Add tier-based duration calculation logic for CAS1 placement requests, including V2 and V3 tier versions. Update service, controller, tests, and mock setups accordingly.

**Changes:**
- Update `Cas1RequestForPlacementService.defaultDurations` to calculate durations using live tier version (V2/V3), with expanded V3 rule set.
- Update controller + integration/unit tests to call the new duration calculation entrypoint and cover additional scenarios.
- Extend test givens/factories to populate `sentenceType` for applications to support the new rules.