### PR TITLE
FM-903 CAS 1 Make OASys 6-Month Import Restriction Optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1OasysController.kt
@@ -92,11 +92,11 @@ class Cas1OasysController(
     @PathVariable @Parameter(description = "CRN of the Person to fetch latest OASys selection") crn: String,
     @RequestParam group: Cas1OASysGroupName,
     @RequestParam includeOptionalSections: List<Int>?,
-    @RequestParam(defaultValue = "completed_in_last_six_months", name = "suitabilityStrategy") suitabilityStrategyDto: Cas1OASysAssessmentSuitabilityStrategyDto,
+    @RequestParam(required = false, defaultValue = "completed_in_last_six_months", name = "suitabilityStrategy") suitabilityStrategyDto: Cas1OASysAssessmentSuitabilityStrategyDto?,
   ): ResponseEntity<Cas1OASysGroup> {
     ensureOffenderAccess(crn)
 
-    val suitabilityStrategy = suitabilityStrategyDto.toSuitabilityStrategy()
+    val suitabilityStrategy = (suitabilityStrategyDto ?: Cas1OASysAssessmentSuitabilityStrategyDto.COMPLETED_IN_LAST_SIX_MONTHS).toSuitabilityStrategy()
 
     val group = when (group) {
       Cas1OASysGroupName.RISK_MANAGEMENT_PLAN -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1OAsysTest.kt
@@ -330,6 +330,39 @@ class Cas1OAsysTest : InitialiseDatabasePerClassTestBase() {
     }
 
     @Test
+    fun `Risk Management - suitabilityStrategy is optional, a blank value defaults to the 6 month strategy`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .withLastUpdatedDate(LAST_UPDATED_DATE)
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas1/people/$CRN/oasys/answers?group=riskManagementPlan&suitabilityStrategy=")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas1OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.assessmentMetadata.lastUpdatedDate).isNull()
+      assertThat(result.group).isEqualTo(Cas1OASysGroupName.RISK_MANAGEMENT_PLAN)
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
     fun `Offence Details - Not Found, return empty answers`() {
       val (_, jwt) = givenAUser()
 


### PR DESCRIPTION
This [PR FM-903](https://dsdmoj.atlassian.net/browse/FM-903) is to make suitabilityStrategyDto parameter optional for GET /people/{crn}/oasys/answers Api endpoint