### PR TITLE
FM-904 CAS 1 OAsys answers Api endpoint response include Import date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1OASysAssessmentMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1OASysAssessmentMetadata.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.Instant
+import java.time.LocalDate
 
 data class Cas1OASysAssessmentMetadata(
 
@@ -11,4 +12,5 @@ data class Cas1OASysAssessmentMetadata(
 
   @get:JsonProperty("dateCompleted") val dateCompleted: Instant? = null,
   @get:JsonProperty("lastUpdatedDate") val lastUpdatedDate: Instant? = null,
+  @get:JsonProperty("importedDate") val importedDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysAssessmentInfoTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1OASysAssessmentInfoTransformer.kt
@@ -3,9 +3,13 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1OASysAssessmentMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.AssessmentInfo
+import java.time.Clock
+import java.time.LocalDate
 
 @Service
-class Cas1OASysAssessmentInfoTransformer {
+class Cas1OASysAssessmentInfoTransformer(
+  private val clock: Clock,
+) {
 
   fun toAssessmentMetadata(assessmentInfo: AssessmentInfo?) = assessmentInfo?.let {
     Cas1OASysAssessmentMetadata(
@@ -13,6 +17,7 @@ class Cas1OASysAssessmentInfoTransformer {
       dateStarted = assessmentInfo.initiationDate.toInstant(),
       dateCompleted = assessmentInfo.dateCompleted?.toInstant(),
       lastUpdatedDate = assessmentInfo.lastUpdatedDate?.toInstant(),
+      importedDate = LocalDate.now(clock),
     )
   } ?: Cas1OASysAssessmentMetadata(hasApplicableAssessment = false)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysAssessmentInfoTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/Cas1OASysAssessmentInfoTransformerTest.kt
@@ -5,12 +5,17 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OffenceDetailsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1OASysAssessmentInfoTransformer
+import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class Cas1OASysAssessmentInfoTransformerTest {
 
-  private val transformer = Cas1OASysAssessmentInfoTransformer()
+  private val importedDate = LocalDate.parse("2021-07-15")
+  private val clock = Clock.fixed(importedDate.atStartOfDay(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC)
+  private val transformer = Cas1OASysAssessmentInfoTransformer(clock)
 
   @Nested
   inner class ToAssessmentMetadata {
@@ -33,6 +38,7 @@ class Cas1OASysAssessmentInfoTransformerTest {
       assertThat(result.dateStarted).isEqualTo(Instant.parse("2020-05-02T12:01:00+00:00"))
       assertThat(result.dateCompleted).isEqualTo(Instant.parse("2021-05-02T12:02:00+00:00"))
       assertThat(result.lastUpdatedDate).isEqualTo(Instant.parse("2021-06-03T09:04:00Z"))
+      assertThat(result.importedDate).isEqualTo(importedDate)
     }
 
     @Test
@@ -45,6 +51,7 @@ class Cas1OASysAssessmentInfoTransformerTest {
 
       assertThat(result.hasApplicableAssessment).isTrue()
       assertThat(result.lastUpdatedDate).isNull()
+      assertThat(result.importedDate).isEqualTo(importedDate)
     }
 
     @Test
@@ -55,6 +62,7 @@ class Cas1OASysAssessmentInfoTransformerTest {
       assertThat(result.dateStarted).isNull()
       assertThat(result.dateCompleted).isNull()
       assertThat(result.lastUpdatedDate).isNull()
+      assertThat(result.importedDate).isNull()
     }
   }
 }


### PR DESCRIPTION
This [PR FM-904](https://dsdmoj.atlassian.net/browse/FM-904) is to extend the answers Api endpoint response to include Import date