### PR TITLE
Add `RiskTierEnvelopeDto.version`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/dto/RiskTierEnvelopeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/dto/RiskTierEnvelopeDto.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import java.time.LocalDate
 
 @Schema(name = "RiskTierEnvelope")
@@ -13,4 +14,5 @@ data class RiskTierEnvelopeDto(
 data class RiskTierDto(
   val level: String,
   val lastUpdated: LocalDate,
+  val version: TierVersionDto,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RisksTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RisksTransformer.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.FlagsEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.MappaEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisksEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.RiskEnvelopeStatusDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.RiskTierDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.RiskTierEnvelopeDto
@@ -11,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.Mappa
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTierVersion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RoshRisks
 
@@ -24,7 +26,7 @@ class RisksTransformer {
     flags = transformFlagsDomainToApi(domain.flags),
   )
 
-  fun transformRoshDomainToApi(domain: RiskWithStatus<RoshRisks>) = RoshRisksEnvelope(
+  private fun transformRoshDomainToApi(domain: RiskWithStatus<RoshRisks>) = RoshRisksEnvelope(
     status = transformStatusDomainToApi(domain.status),
     value = domain.value?.let {
       uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RoshRisks(
@@ -38,7 +40,7 @@ class RisksTransformer {
     },
   )
 
-  fun transformMappaDomainToApi(domain: RiskWithStatus<Mappa>) = MappaEnvelope(
+  private fun transformMappaDomainToApi(domain: RiskWithStatus<Mappa>) = MappaEnvelope(
     status = transformStatusDomainToApi(domain.status),
     value = domain.value?.let {
       uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Mappa(
@@ -54,6 +56,10 @@ class RisksTransformer {
       RiskTierDto(
         level = it.level,
         lastUpdated = it.lastUpdated,
+        version = when (it.version) {
+          RiskTierVersion.V2 -> TierVersionDto.V2
+          RiskTierVersion.V3 -> TierVersionDto.V3
+        },
       )
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RisksTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RisksTransformerTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.RiskEnvelopeStatusDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTierVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
+import java.time.LocalDate
+
+class RisksTransformerTest {
+
+  @CsvSource(
+    "V2,V2",
+    "V3,V3",
+  )
+  @ParameterizedTest
+  fun `tier transform`(version: RiskTierVersion, expectedVersion: TierVersionDto) {
+    val domain = RiskWithStatus(
+      status = RiskStatus.Retrieved,
+      value = RiskTier(
+        level = "A",
+        lastUpdated = LocalDate.of(2021, 7, 5),
+        version = version,
+      ),
+    )
+
+    val result = RisksTransformer().transformTierDomainToApi(domain)
+
+    assertThat(result.status).isEqualTo(RiskEnvelopeStatusDto.retrieved)
+    assertThat(result.value?.level).isEqualTo("A")
+    assertThat(result.value?.lastUpdated).isEqualTo(LocalDate.of(2021, 7, 5))
+    assertThat(result.value?.version).isEqualTo(expectedVersion)
+  }
+}


### PR DESCRIPTION
Whilst we want to move to using ‘live’ tier resolved from `Person` or `PersonSummary` moving forward, having the version available on this class will be helpful in the short term