### PR TITLE
Process inbox events more frequently

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -362,8 +362,8 @@ domain-events:
     enabled: true
   inbox:
     dispatcher:
-      # every 10 seconds
-      cron: '*/10 * * * * *'
+      # every 5 seconds
+      cron: '*/5 * * * * *'
       max-events-per-batch: 10
       max-concurrent-events: 4
       shedlock:


### PR DESCRIPTION
We often see a backlog of pending inbox events in production. This commit runs the job twice as often to help get through this backlog quicker.