### PR TITLE
FM-905 CAS3 Make the OASys 6-month Import Restriction Optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3OasysController.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.Cas3OASysAssessmentSuitabilityStrategyDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3OASysAssessmentInfoTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysSuitabilityService.SuitabilityStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
+
+@Cas3Controller
+class Cas3OasysController(
+  private val offenderService: OffenderService,
+  private val userService: UserService,
+  private val oaSysService: OASysService,
+  private val oaSysSectionsTransformer: OASysSectionsTransformer,
+  private val oaSysAssessmentInfoTransformer: Cas3OASysAssessmentInfoTransformer,
+) {
+
+  @GetMapping("/people/{crn}/oasys/riskManagement")
+  fun riskManagement(
+    @PathVariable crn: String,
+    @RequestParam(required = false, defaultValue = "completed_in_last_six_months", name = "suitabilityStrategy") suitabilityStrategyDto: Cas3OASysAssessmentSuitabilityStrategyDto?,
+  ): ResponseEntity<Cas3OASysGroup> {
+    ensureOffenderAccess(crn)
+
+    val suitabilityStrategy = (suitabilityStrategyDto ?: Cas3OASysAssessmentSuitabilityStrategyDto.COMPLETED_IN_LAST_SIX_MONTHS).toSuitabilityStrategy()
+
+    val riskManagementPlan = extractNullableOAsysResult(oaSysService.getRiskManagementPlan(crn, suitabilityStrategy))
+
+    return ResponseEntity.ok(
+      Cas3OASysGroup(
+        assessmentMetadata = oaSysAssessmentInfoTransformer.toAssessmentMetadata(riskManagementPlan),
+        answers = oaSysSectionsTransformer.riskManagementPlanAnswers(riskManagementPlan?.riskManagementPlan),
+      ),
+    )
+  }
+
+  @SuppressWarnings("ThrowsCount")
+  private fun ensureOffenderAccess(crn: String) {
+    when (
+      offenderService.canAccessOffender(
+        crn = crn,
+        laoStrategy = userService.getUserForRequest().cas3LaoStrategy(),
+      )
+    ) {
+      false -> throw ForbiddenProblem()
+      else -> Unit
+    }
+  }
+
+  private fun <EntityType> extractNullableOAsysResult(result: CasResult<EntityType>) = when (result) {
+    is CasResult.NotFound -> null
+    else -> extractEntityFromCasResult(result)
+  }
+
+  private fun Cas3OASysAssessmentSuitabilityStrategyDto.toSuitabilityStrategy() = when (this) {
+    Cas3OASysAssessmentSuitabilityStrategyDto.ALLOW_ALL -> SuitabilityStrategy.AllowAll
+    Cas3OASysAssessmentSuitabilityStrategyDto.COMPLETED_IN_LAST_SIX_MONTHS -> SuitabilityStrategy.CompletedInLastSixMonths
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3PeopleController.kt
@@ -4,59 +4,18 @@ import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.transformer.Cas3OASysAssessmentInfoTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.ForbiddenProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OASysService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderRisksService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas3LaoStrategy
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.OASysSectionsTransformer
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.extractEntityFromCasResult
 
 @Cas3Controller
 class Cas3PeopleController(
-  private val offenderService: OffenderService,
   private val offenderRiskService: OffenderRisksService,
-  private val userService: UserService,
-  private val oaSysService: OASysService,
-  private val oaSysSectionsTransformer: OASysSectionsTransformer,
-  private val oaSysAssessmentInfoTransformer: Cas3OASysAssessmentInfoTransformer,
 ) {
-
-  @GetMapping("/people/{crn}/oasys/riskManagement")
-  fun riskManagement(@PathVariable crn: String): ResponseEntity<Cas3OASysGroup> {
-    ensureOffenderAccess(crn)
-
-    val riskManagementPlan = extractEntityFromCasResult(oaSysService.getRiskManagementPlan(crn))
-
-    return ResponseEntity.ok(
-      Cas3OASysGroup(
-        assessmentMetadata = oaSysAssessmentInfoTransformer.toAssessmentMetadata(riskManagementPlan),
-        answers = oaSysSectionsTransformer.riskManagementPlanAnswers(riskManagementPlan.riskManagementPlan),
-      ),
-    )
-  }
 
   @Operation(summary = "Returns a risk profile for a Person.")
   @GetMapping("/people/{crn}/risk-profile")
   fun getPersonRiskProfile(@PathVariable crn: String): ResponseEntity<PersonRisks> {
     val personRisks = offenderRiskService.getPersonRisks(crn)
     return ResponseEntity.ok(personRisks)
-  }
-
-  @SuppressWarnings("ThrowsCount")
-  private fun ensureOffenderAccess(crn: String) {
-    when (
-      offenderService.canAccessOffender(
-        crn = crn,
-        laoStrategy = userService.getUserForRequest().cas3LaoStrategy(),
-      )
-    ) {
-      false -> throw ForbiddenProblem()
-      else -> Unit
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3OASysAssessmentSuitabilityStrategyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/model/Cas3OASysAssessmentSuitabilityStrategyDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class Cas3OASysAssessmentSuitabilityStrategyDto(@get:JsonValue val value: String) {
+  ALLOW_ALL("allow_all"),
+  COMPLETED_IN_LAST_SIX_MONTHS("completed_in_last_six_months"),
+  ;
+
+  companion object {
+    @JvmStatic
+    @JsonCreator
+    fun forValue(value: String) = entries.first { it.value == value }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3OasysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3OasysTest.kt
@@ -1,0 +1,225 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1OAsysTest.Companion.CRN
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockRiskManagementPlan404Call
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskManagementPlanCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
+import java.time.OffsetDateTime
+
+class Cas3OasysTest : InitialiseDatabasePerClassTestBase() {
+
+  @Nested
+  inner class OASysRiskManagement {
+    @Test
+    fun `No JWT returns 401`() {
+      webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Return forbidden if user can't access the CRN`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(
+        CaseAccessFactory()
+          .withCrn(CRN)
+          .withUserExcluded(true)
+          .produce(),
+      )
+
+      webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `When no risk management plan exists for the CRN returns OK with empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+      apAndOASysMockRiskManagementPlan404Call(CRN)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `When a risk management plan exists for the CRN, returns OK with the plan answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = "The supervision answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `Default 6 month suitability strategy, assessment is less than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(5))
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = "The supervision answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `Default 6 month suitability strategy, assessment is more than 6 months old, return empty answers`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `Allow all suitability strategy, assessment is more than 6 months old`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement?suitabilityStrategy=allow_all")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = "The supervision answer",
+        ),
+      )
+    }
+
+    @Test
+    fun `suitabilityStrategy is optional, a blank value defaults to the 6 month strategy`() {
+      val (_, jwt) = givenAUser()
+
+      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
+
+      val riskManagementPlan = RiskManagementPlanFactory()
+        .withSupervision("The supervision answer")
+        .withDateCompleted(OffsetDateTime.now().minusMonths(7))
+        .produce()
+      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
+
+      val result = webTestClient.get()
+        .uri("/cas3/people/$CRN/oasys/riskManagement?suitabilityStrategy=")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<Cas3OASysGroup>()
+
+      assertThat(result.assessmentMetadata.hasApplicableAssessment).isFalse()
+      assertThat(result.answers).contains(
+        OASysQuestion(
+          label = "Supervision",
+          questionNumber = "RM30",
+          answer = null,
+        ),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PeopleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/Cas3PeopleTest.kt
@@ -4,89 +4,23 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.returnResult
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OASysQuestion
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Cas3OASysGroup
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseAccessFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MappaDetailFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RegistrationFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RiskManagementPlanFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.InitialiseDatabasePerClassTestBase
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas1.Cas1OAsysTest.Companion.CRN
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockNeedsDetails404Call
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRiskManagementPlanCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apAndOASysMockSuccessfulRoshRatingsCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockSuccessfulCaseDetailCall
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextMockUserAccess
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.bodyAsObject
 import java.time.LocalDateTime
 import java.util.UUID
 
 class Cas3PeopleTest : InitialiseDatabasePerClassTestBase() {
-
-  @Nested
-  inner class OASysRiskManagement {
-
-    @Test
-    fun `No JWT returns 401`() {
-      webTestClient.get()
-        .uri("/cas3/people/CRN/oasys/riskManagement")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `Return 404 if needs record can't be found for the CRN`() {
-      val (_, jwt) = givenAUser()
-
-      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-      apAndOASysMockNeedsDetails404Call(CRN)
-
-      webTestClient.get()
-        .uri("/cas3/people/$CRN/oasys/riskManagement")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isNotFound
-    }
-
-    @Test
-    fun success() {
-      val (_, jwt) = givenAUser()
-
-      apDeliusContextMockUserAccess(CaseAccessFactory().withCrn(CRN).produce())
-
-      val riskManagementPlan = RiskManagementPlanFactory()
-        .withSupervision("The supervision answer")
-        .produce()
-      apAndOASysMockSuccessfulRiskManagementPlanCall(CRN, riskManagementPlan)
-
-      val result = webTestClient.get()
-        .uri("/cas3/people/$CRN/oasys/riskManagement")
-        .header("Authorization", "Bearer $jwt")
-        .exchange()
-        .expectStatus()
-        .isOk
-        .bodyAsObject<Cas3OASysGroup>()
-
-      assertThat(result.assessmentMetadata.hasApplicableAssessment).isTrue()
-      assertThat(result.answers).contains(
-        OASysQuestion(
-          label = "Supervision",
-          questionNumber = "RM30",
-          answer = "The supervision answer",
-        ),
-      )
-    }
-  }
 
   @Nested
   inner class GetPersonRiskProfileTest {


### PR DESCRIPTION
This [PR FM-905](https://dsdmoj.atlassian.net/browse/FM-905)  is to:
- Move the /people/{crn}/oasys/riskManagement Api endpoint to Cas3OasysController
- Add an optional suitabilityStrategy query parameter to enable the UI to select the suitability policy to apply.