### PR TITLE
FM-836 CAS2 Email Fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationEmailService.kt
@@ -4,12 +4,14 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.format.DateTimeFormatter
 
 @Service
 class Cas2ApplicationEmailService(
   private val cas2EmailService: Cas2EmailService,
+  private val notifyConfig: NotifyConfig,
   @Value("\${url-templates.frontend.cas2v2.submitted-application-overview}") private val submittedApplicationUrlTemplate: UrlTemplate,
 ) {
 
@@ -38,7 +40,7 @@ class Cas2ApplicationEmailService(
     )
 
     cas2EmailService.sendEmail(
-      recipientEmailAddress = recipientEmailAddress,
+      recipientEmailAddress = notifyConfig.emailAddresses.cas2Assessors,
       templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_TO_ASSESS,
       personalisation = commonPersonalisation + mapOf(
         "sla" to cohort.assessmentSla,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteEmailService.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHourOfDay
 import java.time.format.DateTimeFormatter
-import kotlin.io.resolve
 
 @Service
 class Cas2ApplicationNoteEmailService(
@@ -30,12 +29,14 @@ class Cas2ApplicationNoteEmailService(
 
   fun assessorNoteAdded(
     cas2Application: Cas2ApplicationEntity,
+    assessment: Cas2AssessmentEntity,
     applicationNote: Cas2ApplicationNoteEntity,
   ) {
     val recipientEmail = cas2Application.createdByUser.email ?: return
 
     sendNoteAddedEmail(
       cas2Application = cas2Application,
+      assessment = assessment,
       applicationNote = applicationNote,
       recipientEmail = recipientEmail,
       resolvedUrl = applicationUrlTemplate.resolve(mapOf("id" to cas2Application.id.toString())),
@@ -45,10 +46,12 @@ class Cas2ApplicationNoteEmailService(
 
   fun refererNoteAdded(
     cas2Application: Cas2ApplicationEntity,
+    assessment: Cas2AssessmentEntity,
     applicationNote: Cas2ApplicationNoteEntity,
   ) {
     sendNoteAddedEmail(
       cas2Application = cas2Application,
+      assessment = assessment,
       applicationNote = applicationNote,
       recipientEmail = notifyConfig.emailAddresses.cas2Assessors,
       resolvedUrl = assessmentUrlTemplate.resolve(mapOf("applicationId" to cas2Application.id.toString())),
@@ -58,6 +61,7 @@ class Cas2ApplicationNoteEmailService(
 
   private fun sendNoteAddedEmail(
     cas2Application: Cas2ApplicationEntity,
+    assessment: Cas2AssessmentEntity,
     applicationNote: Cas2ApplicationNoteEntity,
     recipientEmail: String,
     resolvedUrl: String,
@@ -73,8 +77,8 @@ class Cas2ApplicationNoteEmailService(
       "crn" to cas2Application.crn,
       "timeApplicationReceived" to submittedAt.format(TIME_FORMAT),
       "dateApplicationReceived" to submittedAt.format(DATE_FORMAT),
-      "nacroReferenceId" to getNacroReferenceIdOrPlaceholder(cas2Application.assessment!!),
-      "nacroReferenceIdInSubject" to getSubjectLineReferenceIdOrPlaceholder(cas2Application.assessment!!),
+      "nacroReferenceId" to getNacroReferenceIdOrPlaceholder(assessment),
+      "nacroReferenceIdInSubject" to getSubjectLineReferenceIdOrPlaceholder(assessment),
       "viewSubmittedApplicationUrl" to resolvedUrl,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteEmailService.kt
@@ -4,12 +4,14 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationNoteEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormat
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toCas2UiFormattedHourOfDay
 import java.time.format.DateTimeFormatter
+import kotlin.io.resolve
 
 @Service
 class Cas2ApplicationNoteEmailService(
@@ -30,11 +32,13 @@ class Cas2ApplicationNoteEmailService(
     cas2Application: Cas2ApplicationEntity,
     applicationNote: Cas2ApplicationNoteEntity,
   ) {
+    val recipientEmail = cas2Application.createdByUser.email ?: return
+
     sendNoteAddedEmail(
       cas2Application = cas2Application,
       applicationNote = applicationNote,
-      recipientEmail = notifyConfig.emailAddresses.cas2Assessors,
-      resolvedUrl = assessmentUrlTemplate.resolve(mapOf("applicationId" to cas2Application.id.toString())),
+      recipientEmail = recipientEmail,
+      resolvedUrl = applicationUrlTemplate.resolve(mapOf("id" to cas2Application.id.toString())),
       templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_ASSESSOR_NOTE_ADDED,
     )
   }
@@ -43,13 +47,11 @@ class Cas2ApplicationNoteEmailService(
     cas2Application: Cas2ApplicationEntity,
     applicationNote: Cas2ApplicationNoteEntity,
   ) {
-    val recipientEmail = cas2Application.createdByUser.email ?: return
-
     sendNoteAddedEmail(
       cas2Application = cas2Application,
       applicationNote = applicationNote,
-      recipientEmail = recipientEmail,
-      resolvedUrl = applicationUrlTemplate.resolve(mapOf("id" to cas2Application.id.toString())),
+      recipientEmail = notifyConfig.emailAddresses.cas2Assessors,
+      resolvedUrl = assessmentUrlTemplate.resolve(mapOf("applicationId" to cas2Application.id.toString())),
       templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_REFERRER_NOTE_ADDED,
     )
   }
@@ -71,7 +73,8 @@ class Cas2ApplicationNoteEmailService(
       "crn" to cas2Application.crn,
       "timeApplicationReceived" to submittedAt.format(TIME_FORMAT),
       "dateApplicationReceived" to submittedAt.format(DATE_FORMAT),
-      "nacroReferenceId" to cas2Application.id.toString(),
+      "nacroReferenceId" to getNacroReferenceIdOrPlaceholder(cas2Application.assessment!!),
+      "nacroReferenceIdInSubject" to getSubjectLineReferenceIdOrPlaceholder(cas2Application.assessment!!),
       "viewSubmittedApplicationUrl" to resolvedUrl,
     )
 
@@ -81,5 +84,19 @@ class Cas2ApplicationNoteEmailService(
       personalisation = personalisation,
       cas2Application = cas2Application,
     )
+  }
+
+  private fun getSubjectLineReferenceIdOrPlaceholder(assessment: Cas2AssessmentEntity): String {
+    if (assessment.nacroReferralId != null) {
+      return "(${assessment.nacroReferralId!!})"
+    }
+    return ""
+  }
+
+  private fun getNacroReferenceIdOrPlaceholder(assessment: Cas2AssessmentEntity): String {
+    if (assessment.nacroReferralId != null) {
+      return assessment.nacroReferralId!!
+    }
+    return "Unknown. The Nacro CAS-2 reference number has not been added to the application yet."
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
@@ -61,7 +61,7 @@ class Cas2ApplicationNoteService(
     }
 
     val savedNote = saveNote(application, assessment, note.note, user)
-    sendEmail(user.isExternal(), application, savedNote)
+    sendEmail(user.isExternal(), application, assessment, savedNote)
 
     return CasResult.Success(savedNote)
   }
@@ -69,16 +69,17 @@ class Cas2ApplicationNoteService(
   private fun sendEmail(
     isExternalUser: Boolean,
     application: Cas2ApplicationEntity,
+    assessment: Cas2AssessmentEntity,
     savedNote: Cas2ApplicationNoteEntity,
   ) {
     val emailChangesEnabled = futureFlagService.getBooleanFlag("isr-email-changes-enabled")
 
     when {
       emailChangesEnabled && isExternalUser ->
-        cas2ApplicationNoteEmailService.assessorNoteAdded(application, savedNote)
+        cas2ApplicationNoteEmailService.assessorNoteAdded(application, assessment, savedNote)
 
       emailChangesEnabled ->
-        cas2ApplicationNoteEmailService.refererNoteAdded(application, savedNote)
+        cas2ApplicationNoteEmailService.refererNoteAdded(application, assessment, savedNote)
 
       isExternalUser ->
         sendEmailToReferrer(application, savedNote)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationNoteService.kt
@@ -75,10 +75,10 @@ class Cas2ApplicationNoteService(
 
     when {
       emailChangesEnabled && isExternalUser ->
-        cas2ApplicationNoteEmailService.refererNoteAdded(application, savedNote)
+        cas2ApplicationNoteEmailService.assessorNoteAdded(application, savedNote)
 
       emailChangesEnabled ->
-        cas2ApplicationNoteEmailService.assessorNoteAdded(application, savedNote)
+        cas2ApplicationNoteEmailService.refererNoteAdded(application, savedNote)
 
       isExternalUser ->
         sendEmailToReferrer(application, savedNote)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationStatusUpdateEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationStatusUpdateEmailService.kt
@@ -33,7 +33,7 @@ class Cas2ApplicationStatusUpdateEmailService(
       "dateApplicationReceived" to dateReceived,
       "nacroReferenceId" to cas2Application.id.toString(),
       "viewSubmittedApplicationUrl" to applicationOverviewUrlTemplate
-        .resolve("applicationId", cas2Application.id.toString()),
+        .resolve("id", cas2Application.id.toString()),
     )
 
     cas2EmailService.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2AssessmentNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2AssessmentNotesTest.kt
@@ -74,6 +74,7 @@ class Cas2AssessmentNotesTest(
 
           val assessment = cas2AssessmentEntityFactory.produceAndPersist {
             withApplication(application)
+            withNacroReferralId("OH789")
             withServiceOrigin(Cas2ServiceOrigin.BAIL)
           }
 
@@ -89,15 +90,15 @@ class Cas2AssessmentNotesTest(
             .responseBody
             .blockFirst()
 
-          val responseBody = jsonMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+          jsonMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
 
           emailAsserter.assertEmailRequested(
             toEmailAddress = referrer.email!!,
-            templateId = "71fd8007-87a0-49b8-9099-7919b6ca4716", // CAS2_BAIL_APPLICATION_REFERRER_NOTE_ADDED
+            templateId = "0919a001-7b83-44c0-b0d0-a617d84012bb", // CAS2_BAIL_APPLICATION_ASSESSOR_NOTE_ADDED
             personalisation = mapOf(
               "cohort" to "Prison Bail",
               "crn" to "CRN123",
-              "nacroReferenceId" to application.id.toString(),
+              "nacroReferenceId" to "OH789",
               "viewSubmittedApplicationUrl" to applicationUrlTemplate.resolve("id", application.id.toString()),
             ),
           )
@@ -170,6 +171,7 @@ class Cas2AssessmentNotesTest(
 
         val assessment = cas2AssessmentEntityFactory.produceAndPersist {
           withApplication(application)
+          withNacroReferralId("OH789")
           withServiceOrigin(Cas2ServiceOrigin.BAIL)
         }
 
@@ -185,15 +187,16 @@ class Cas2AssessmentNotesTest(
           .responseBody
           .blockFirst()
 
-        val responseBody = jsonMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
+        jsonMapper.readValue(rawResponseBody, object : TypeReference<Cas2ApplicationNote>() {})
 
         emailAsserter.assertEmailRequested(
           toEmailAddress = "assessors@example.com",
-          templateId = "0919a001-7b83-44c0-b0d0-a617d84012bb", // CAS2_BAIL_APPLICATION_ASSESSOR_NOTE_ADDED
+          templateId = "71fd8007-87a0-49b8-9099-7919b6ca4716", // CAS2_BAIL_APPLICATION_REFERRER_NOTE_ADDED
           personalisation = mapOf(
             "cohort" to "Prison Bail",
             "crn" to "CRN123",
-            "nacroReferenceId" to application.id.toString(),
+            "nacroReferenceId" to "OH789",
+            "nacroReferenceIdInSubject" to "(OH789)",
             "viewSubmittedApplicationUrl" to assessmentUrlTemplate.resolve("applicationId", application.id.toString()),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ApplicationSubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ApplicationSubmissionTest.kt
@@ -45,7 +45,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class Cas2v2SubmissionTest : IntegrationTestBase() {
+class Cas2v2ApplicationSubmissionTest : IntegrationTestBase() {
   @MockkSpyBean
   lateinit var cas2RealApplicationRepository: Cas2ApplicationRepository
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2StatusUpdateTest.kt
@@ -364,8 +364,7 @@ class Cas2v2StatusUpdateTest(
                   "timeApplicationReceived" to application.submittedAt!!.format(DateTimeFormatter.ofPattern("HH:mm")),
                   "dateApplicationReceived" to application.submittedAt!!.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                   "nacroReferenceId" to application.id.toString(),
-                  "viewSubmittedApplicationUrl" to applicationOverviewUrlTemplate
-                    .replace("applicationId", application.id.toString()),
+                  "viewSubmittedApplicationUrl" to "http://localhost:3000/applications/${application.id}/overview",
                 ),
                 replyToEmailId = notifyConfig.emailAddresses.cas2ReplyToId,
               )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationEmailServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.unit.service
 
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
@@ -9,16 +10,20 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2Appl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.Cas2NotifyTemplates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.EmailAddressConfig
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.UrlTemplate
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class Cas2ApplicationEmailServiceTest {
   private val mockCas2EmailService = mockk<Cas2EmailService>(relaxed = true)
+  private val mockNotifyConfig = mockk<NotifyConfig>()
   private val submittedApplicationUrlTemplate = UrlTemplate("http://frontend/applications/#applicationId")
 
   private val service = Cas2ApplicationEmailService(
     cas2EmailService = mockCas2EmailService,
+    notifyConfig = mockNotifyConfig,
     submittedApplicationUrlTemplate = submittedApplicationUrlTemplate,
   )
 
@@ -28,6 +33,10 @@ class Cas2ApplicationEmailServiceTest {
 
   @Test
   fun `applicationSubmitted sends submitted and assessed emails`() {
+    val emailConfig = EmailAddressConfig()
+    emailConfig.cas2Assessors = "assessors@example.com"
+    every { mockNotifyConfig.emailAddresses } returns emailConfig
+
     val applicationId = UUID.randomUUID()
     val submittedAt = OffsetDateTime.parse("2024-06-24T16:07:00Z")
     val application = Cas2ApplicationEntityFactory()
@@ -58,7 +67,7 @@ class Cas2ApplicationEmailServiceTest {
 
     verify(exactly = 1) {
       mockCas2EmailService.sendEmail(
-        recipientEmailAddress = user.email!!,
+        recipientEmailAddress = "assessors@example.com",
         templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_TO_ASSESS,
         personalisation = mapOf(
           "cohort" to "HDC",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteEmailServiceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2ApplicationNoteEmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2EmailService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2ApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2AssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2NoteEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.Cas2UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2Cohort
@@ -44,6 +45,10 @@ class Cas2ApplicationNoteEmailServiceTest {
     .withCohort(Cas2Cohort.PRISON_BAIL)
     .produce()
 
+  private val assessment = Cas2AssessmentEntityFactory()
+    .withNacroReferralId("NACROREF1")
+    .produce()
+
   private val note = Cas2NoteEntityFactory()
     .withApplication(application)
     .withCreatedByUser(user)
@@ -55,17 +60,19 @@ class Cas2ApplicationNoteEmailServiceTest {
     val emailConfig = EmailAddressConfig()
     emailConfig.cas2Assessors = "assessors@example.com"
     every { mockNotifyConfig.emailAddresses } returns emailConfig
+
+    application.assessment = assessment
   }
 
   @Nested
   inner class Assessor {
     @Test
-    fun `when assessor note is added then assessors are notified`() {
+    fun `when assessor note is added then referrer is notified`() {
       service.assessorNoteAdded(application, note)
 
       verify(exactly = 1) {
         mockCas2EmailService.sendEmail(
-          recipientEmailAddress = "assessors@example.com",
+          recipientEmailAddress = user.email!!,
           templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_ASSESSOR_NOTE_ADDED,
           personalisation = mapOf(
             "dateNoteAdded" to "25 June 2024",
@@ -74,33 +81,8 @@ class Cas2ApplicationNoteEmailServiceTest {
             "crn" to "CRN123",
             "timeApplicationReceived" to "16:07",
             "dateApplicationReceived" to "24/06/2024",
-            "nacroReferenceId" to application.id.toString(),
-            "viewSubmittedApplicationUrl" to "http://frontend/assessments/${application.id}",
-          ),
-          cas2Application = application,
-        )
-      }
-    }
-  }
-
-  @Nested
-  inner class Referrer {
-    @Test
-    fun `when referer note is added then application creator is notified`() {
-      service.refererNoteAdded(application, note)
-
-      verify(exactly = 1) {
-        mockCas2EmailService.sendEmail(
-          recipientEmailAddress = user.email!!,
-          templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_REFERRER_NOTE_ADDED,
-          personalisation = mapOf(
-            "dateNoteAdded" to "25 June 2024",
-            "timeNoteAdded" to "10:30am",
-            "cohort" to "Prison Bail",
-            "crn" to "CRN123",
-            "timeApplicationReceived" to "16:07",
-            "dateApplicationReceived" to "24/06/2024",
-            "nacroReferenceId" to application.id.toString(),
+            "nacroReferenceId" to "NACROREF1",
+            "nacroReferenceIdInSubject" to "(NACROREF1)",
             "viewSubmittedApplicationUrl" to "http://frontend/applications/${application.id}",
           ),
           cas2Application = application,
@@ -109,10 +91,37 @@ class Cas2ApplicationNoteEmailServiceTest {
     }
 
     @Test
-    fun `when referer note is added but creator has no email then no email is sent`() {
+    fun `when assessor note is added then referrer is notified, no nacro reference`() {
+      assessment.nacroReferralId = null
+
+      service.assessorNoteAdded(application, note)
+
+      verify(exactly = 1) {
+        mockCas2EmailService.sendEmail(
+          recipientEmailAddress = user.email!!,
+          templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_ASSESSOR_NOTE_ADDED,
+          personalisation = mapOf(
+            "dateNoteAdded" to "25 June 2024",
+            "timeNoteAdded" to "10:30am",
+            "cohort" to "Prison Bail",
+            "crn" to "CRN123",
+            "timeApplicationReceived" to "16:07",
+            "dateApplicationReceived" to "24/06/2024",
+            "nacroReferenceId" to "Unknown. The Nacro CAS-2 reference number has not been added to the application yet.",
+            "nacroReferenceIdInSubject" to "",
+            "viewSubmittedApplicationUrl" to "http://frontend/applications/${application.id}",
+          ),
+          cas2Application = application,
+        )
+      }
+    }
+
+    @Test
+    fun `when assessor note is added but referrer has no email then no email is sent`() {
       val userNoEmail = Cas2UserEntityFactory()
         .withEmail(null)
         .produce()
+
       val applicationNoEmail = Cas2ApplicationEntityFactory()
         .withId(UUID.randomUUID())
         .withCreatedByUser(userNoEmail)
@@ -120,10 +129,63 @@ class Cas2ApplicationNoteEmailServiceTest {
         .withCohort(Cas2Cohort.PRISON_BAIL)
         .produce()
 
-      service.refererNoteAdded(applicationNoEmail, note)
+      service.assessorNoteAdded(applicationNoEmail, note)
 
       verify(exactly = 0) {
         mockCas2EmailService.sendEmail(any(), any(), any(), any())
+      }
+    }
+  }
+
+  @Nested
+  inner class Referrer {
+    @Test
+    fun `when referer note is added then assessors are notified`() {
+      service.refererNoteAdded(application, note)
+
+      verify(exactly = 1) {
+        mockCas2EmailService.sendEmail(
+          recipientEmailAddress = "assessors@example.com",
+          templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_REFERRER_NOTE_ADDED,
+          personalisation = mapOf(
+            "dateNoteAdded" to "25 June 2024",
+            "timeNoteAdded" to "10:30am",
+            "cohort" to "Prison Bail",
+            "crn" to "CRN123",
+            "timeApplicationReceived" to "16:07",
+            "dateApplicationReceived" to "24/06/2024",
+            "nacroReferenceId" to "NACROREF1",
+            "nacroReferenceIdInSubject" to "(NACROREF1)",
+            "viewSubmittedApplicationUrl" to "http://frontend/assessments/${application.id}",
+          ),
+          cas2Application = application,
+        )
+      }
+    }
+
+    @Test
+    fun `when referer note is added then assessors are notified, no nacro reference`() {
+      assessment.nacroReferralId = null
+
+      service.refererNoteAdded(application, note)
+
+      verify(exactly = 1) {
+        mockCas2EmailService.sendEmail(
+          recipientEmailAddress = "assessors@example.com",
+          templateId = Cas2NotifyTemplates.CAS2_BAIL_APPLICATION_REFERRER_NOTE_ADDED,
+          personalisation = mapOf(
+            "dateNoteAdded" to "25 June 2024",
+            "timeNoteAdded" to "10:30am",
+            "cohort" to "Prison Bail",
+            "crn" to "CRN123",
+            "timeApplicationReceived" to "16:07",
+            "dateApplicationReceived" to "24/06/2024",
+            "nacroReferenceId" to "Unknown. The Nacro CAS-2 reference number has not been added to the application yet.",
+            "nacroReferenceIdInSubject" to "",
+            "viewSubmittedApplicationUrl" to "http://frontend/assessments/${application.id}",
+          ),
+          cas2Application = application,
+        )
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteEmailServiceTest.kt
@@ -68,7 +68,7 @@ class Cas2ApplicationNoteEmailServiceTest {
   inner class Assessor {
     @Test
     fun `when assessor note is added then referrer is notified`() {
-      service.assessorNoteAdded(application, note)
+      service.assessorNoteAdded(application, assessment, note)
 
       verify(exactly = 1) {
         mockCas2EmailService.sendEmail(
@@ -94,7 +94,7 @@ class Cas2ApplicationNoteEmailServiceTest {
     fun `when assessor note is added then referrer is notified, no nacro reference`() {
       assessment.nacroReferralId = null
 
-      service.assessorNoteAdded(application, note)
+      service.assessorNoteAdded(application, assessment, note)
 
       verify(exactly = 1) {
         mockCas2EmailService.sendEmail(
@@ -129,7 +129,7 @@ class Cas2ApplicationNoteEmailServiceTest {
         .withCohort(Cas2Cohort.PRISON_BAIL)
         .produce()
 
-      service.assessorNoteAdded(applicationNoEmail, note)
+      service.assessorNoteAdded(applicationNoEmail, assessment, note)
 
       verify(exactly = 0) {
         mockCas2EmailService.sendEmail(any(), any(), any(), any())
@@ -141,7 +141,7 @@ class Cas2ApplicationNoteEmailServiceTest {
   inner class Referrer {
     @Test
     fun `when referer note is added then assessors are notified`() {
-      service.refererNoteAdded(application, note)
+      service.refererNoteAdded(application, assessment, note)
 
       verify(exactly = 1) {
         mockCas2EmailService.sendEmail(
@@ -167,7 +167,7 @@ class Cas2ApplicationNoteEmailServiceTest {
     fun `when referer note is added then assessors are notified, no nacro reference`() {
       assessment.nacroReferralId = null
 
-      service.refererNoteAdded(application, note)
+      service.refererNoteAdded(application, assessment, note)
 
       verify(exactly = 1) {
         mockCas2EmailService.sendEmail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteServiceTest.kt
@@ -176,7 +176,7 @@ class Cas2ApplicationNoteServiceTest {
   @Nested
   inner class SendEmail {
     @Test
-    fun `sends email via Cas2ApplicationNoteEmailService when flag is enabled and user is external`() {
+    fun `sends assessor note added email via Cas2ApplicationNoteEmailService when flag is enabled and user is external`() {
       val externalUser = Cas2UserEntityFactory().withUserType(Cas2UserType.EXTERNAL).produce()
       every { mockFeatureFlagService.getBooleanFlag("isr-email-changes-enabled") } returns true
       every { mockCas2AssessmentRepository.findByIdAndServiceOrigin(assessment.id, Cas2ServiceOrigin.BAIL) } returns assessment
@@ -187,11 +187,11 @@ class Cas2ApplicationNoteServiceTest {
 
       service.createAssessmentNote(assessment.id, NewCas2ApplicationNote(note = "some note"))
 
-      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.refererNoteAdded(application, any()) }
+      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.assessorNoteAdded(application, any()) }
     }
 
     @Test
-    fun `sends email via Cas2ApplicationNoteEmailService when flag is enabled and user is internal`() {
+    fun `sends referrer note added email via Cas2ApplicationNoteEmailService when flag is enabled and user is internal`() {
       val nomisUser = Cas2UserEntityFactory().withUserType(Cas2UserType.NOMIS).produce()
       every { mockFeatureFlagService.getBooleanFlag("isr-email-changes-enabled") } returns true
       every { mockCas2AssessmentRepository.findByIdAndServiceOrigin(assessment.id, Cas2ServiceOrigin.BAIL) } returns assessment
@@ -202,7 +202,7 @@ class Cas2ApplicationNoteServiceTest {
 
       service.createAssessmentNote(assessment.id, NewCas2ApplicationNote(note = "some note"))
 
-      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.assessorNoteAdded(application, any()) }
+      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.refererNoteAdded(application, any()) }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationNoteServiceTest.kt
@@ -187,7 +187,7 @@ class Cas2ApplicationNoteServiceTest {
 
       service.createAssessmentNote(assessment.id, NewCas2ApplicationNote(note = "some note"))
 
-      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.assessorNoteAdded(application, any()) }
+      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.assessorNoteAdded(application, assessment, any()) }
     }
 
     @Test
@@ -202,7 +202,7 @@ class Cas2ApplicationNoteServiceTest {
 
       service.createAssessmentNote(assessment.id, NewCas2ApplicationNote(note = "some note"))
 
-      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.refererNoteAdded(application, any()) }
+      verify(exactly = 1) { mockCas2ApplicationNoteEmailService.refererNoteAdded(application, assessment, any()) }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationStatusUpdateEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/unit/service/Cas2ApplicationStatusUpdateEmailServiceTest.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 
 class Cas2ApplicationStatusUpdateEmailServiceTest {
   private val mockCas2EmailService = mockk<Cas2EmailService>(relaxed = true)
-  private val applicationOverviewUrlTemplate = UrlTemplate("http://frontend/applications/#applicationId")
+  private val applicationOverviewUrlTemplate = UrlTemplate("http://frontend/applications/#id")
 
   private val service = Cas2ApplicationStatusUpdateEmailService(
     cas2EmailService = mockCas2EmailService,


### PR DESCRIPTION
**Application Submitted Fixes**

* Send cas2 application to assess email to assessors

**Assessment Note Fixes**

* Assessor notes should trigger an email to the referrer (not assessors)
* Refererrer notes should trigger an email to the assessors (not referrer)
* Nacro reference ID should come from the specific field on assessment (this was a fault in the original ticket)
* Add a simpler nacro reference ID value for subject header (this was a fault in the original ticket)

**Assessment Status Update Fixes**

* Fix application url in cas2 status update email