### PR TITLE
Upgrade to hmpps gradle spring boot 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "11.0.1"
   kotlin("plugin.spring") version "2.4.0"
   kotlin("plugin.jpa") version "2.4.0"
   id("dev.detekt") version "2.0.0-alpha.5"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -16,12 +16,12 @@ class ClientCachingOAuth2AuthorizedClientService(
 ) : OAuth2AuthorizedClientService {
   private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
 
-  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+  override fun <T : OAuth2AuthorizedClient> loadAuthorizedClient(
     clientRegistrationId: String,
     principalName: String,
   ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
     @Suppress("UNCHECKED_CAST")
-    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as? T
   }
 
   override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -213,30 +213,28 @@ class LoggingInMemoryOAuth2AuthorizedClientService(clientRegistrationRepository:
   private val backingImplementation = InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository)
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
-    clientRegistrationId: String?,
-    principalName: String?,
-  ): T = backingImplementation.loadAuthorizedClient<T>(clientRegistrationId, principalName)
+  override fun <T : OAuth2AuthorizedClient> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = backingImplementation.loadAuthorizedClient(clientRegistrationId, principalName)
 
-  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient?, principal: Authentication?) {
-    val tokenValue = authorizedClient?.accessToken?.tokenValue
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    val tokenValue = authorizedClient.accessToken.tokenValue
 
-    if (tokenValue != null) {
-      try {
-        val tokenBodyBase64 = tokenValue.split(".")[1]
-        val tokenBodyRaw = Base64.getDecoder().decode(tokenBodyBase64)
-        val info = jsonMapper.readValue(tokenBodyRaw, JwtLogInfo::class.java)
-        log.info("Retrieved a client_credentials JWT for service->service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")
-      } catch (exception: Exception) {
-        // Deliberately not logging exception message
-        log.error("Unable to get token info to log, exception of type: ${exception::class.java.name}")
-      }
+    try {
+      val tokenBodyBase64 = tokenValue.split(".")[1]
+      val tokenBodyRaw = Base64.getDecoder().decode(tokenBodyBase64)
+      val info = jsonMapper.readValue(tokenBodyRaw, JwtLogInfo::class.java)
+      log.info("Retrieved a client_credentials JWT for service->service calls for client ${authorizedClient.clientRegistration.clientId} with authorities: ${info.authorities}, scopes: ${info.scope}, expiry: ${info.exp}")
+    } catch (exception: Exception) {
+      // Deliberately not logging exception message
+      log.error("Unable to get token info to log, exception of type: ${exception::class.java.name}")
     }
 
     backingImplementation.saveAuthorizedClient(authorizedClient, principal)
   }
 
-  override fun removeAuthorizedClient(clientRegistrationId: String?, principalName: String?) = backingImplementation.removeAuthorizedClient(clientRegistrationId, principalName)
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) = backingImplementation.removeAuthorizedClient(clientRegistrationId, principalName)
 }
 
 @Configuration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/WebClientConfiguration.kt
@@ -11,11 +11,11 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
+import uk.gov.justice.hmpps.kotlin.auth.ServletRequestResponseNonNullFilterFunction
 import java.time.Duration
 
 data class WebClientConfig(
@@ -56,6 +56,7 @@ class WebClientConfiguration(
     return WebClientConfig(
       WebClient.builder()
         .baseUrl(cas1UiBaseUrl)
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -87,6 +88,7 @@ class WebClientConfiguration(
     return WebClientConfig(
       WebClient.builder()
         .baseUrl(apDeliusContextApiBaseUrl)
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -127,6 +129,7 @@ class WebClientConfiguration(
               .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(tierApiUpstreamTimeoutMs).toMillis().toInt()),
           ),
         )
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .build(),
       retryOnReadTimeout = true,
@@ -161,6 +164,7 @@ class WebClientConfiguration(
             it.defaultCodecs().maxInMemorySize(prisonApiMaxResponseInMemorySizeBytes)
           }.build(),
         )
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .build(),
       retryOnReadTimeout = true,
@@ -196,6 +200,7 @@ class WebClientConfiguration(
             it.defaultCodecs().maxInMemorySize(prisonerAlertsApiMaxResponseInMemorySizeBytes)
           }.build(),
         )
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .build(),
       retryOnReadTimeout = true,
@@ -204,12 +209,11 @@ class WebClientConfiguration(
 
   @Bean(name = ["caseNotesWebClient"])
   fun caseNotesWebClient(
-    clientRegistrations: ClientRegistrationRepository,
-    authorizedClients: OAuth2AuthorizedClientRepository,
+    authorizedClients: OAuth2AuthorizedClientManager,
     @Value("\${services.case-notes.base-url}") caseNotesBaseUrl: String,
     @Value("\${services.case-notes.timeout-ms}") caseNotesServiceUpstreamTimeoutMs: Long,
   ): WebClientConfig {
-    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients)
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClients)
 
     oauth2Client.setDefaultClientRegistrationId("case-notes")
 
@@ -224,6 +228,7 @@ class WebClientConfiguration(
               .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(caseNotesServiceUpstreamTimeoutMs).toMillis().toInt()),
           ),
         )
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .build(),
       retryOnReadTimeout = true,
@@ -251,6 +256,7 @@ class WebClientConfiguration(
               .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Duration.ofMillis(apAndOasysUpstreamTimeoutMs).toMillis().toInt()),
           ),
         )
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .build(),
       retryOnReadTimeout = true,
@@ -305,6 +311,7 @@ class WebClientConfiguration(
     return WebClientConfig(
       WebClient.builder()
         .baseUrl(nomisUserRolesBaseUrl)
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -353,6 +360,7 @@ class WebClientConfiguration(
 
     return WebClientConfig(
       WebClient.builder()
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -384,6 +392,7 @@ class WebClientConfiguration(
 
     return WebClientConfig(
       WebClient.builder()
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -417,6 +426,7 @@ class WebClientConfiguration(
     return WebClientConfig(
       WebClient.builder()
         .baseUrl(prisonSearchBaseUrl)
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -450,6 +460,7 @@ class WebClientConfiguration(
     return WebClientConfig(
       WebClient.builder()
         .baseUrl(licenceApiBaseUrl)
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(
@@ -483,6 +494,7 @@ class WebClientConfiguration(
     return WebClientConfig(
       WebClient.builder()
         .baseUrl(healthAndMedicationApiBaseUrl)
+        .filter(ServletRequestResponseNonNullFilterFunction())
         .filter(oauth2Client)
         .clientConnector(
           ReactorClientHttpConnector(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -241,7 +241,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons returns 200 with correct body`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     val departureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10)
     val expectedJson = jsonMapper.writeValueAsString(
@@ -262,7 +262,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons for only approved premises returns 200 with correct body`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     departureReasonEntityFactory.produceAndPersistMultiple(10)
 
@@ -317,7 +317,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons returns only active departure reasons by default`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     val departureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10) {
       withIsActive(true)
@@ -346,7 +346,7 @@ class ReferenceDataTest : IntegrationTestBase() {
 
   @Test
   fun `Get Departure Reasons returns both active and inactive departure reasons when 'includeInactive' query is true`() {
-    departureReasonRepository.deleteAll()
+    departureReasonRepository.deleteAllRecursively()
 
     val activeDepartureReasons = departureReasonEntityFactory.produceAndPersistMultiple(10) {
       withIsActive(true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ReferenceDataTest.kt
@@ -373,7 +373,7 @@ class Cas1ReferenceDataTest : IntegrationTestBase() {
 
     @Test
     fun success() {
-      departureReasonRepository.deleteAll()
+      departureReasonRepository.deleteAllRecursively()
 
       val compareByDepartureReasonNameAsc = compareBy(String.CASE_INSENSITIVE_ORDER, DepartureReasonEntity::name)
       val compareByDepartureReasonNameDesc = compareByDescending(String.CASE_INSENSITIVE_ORDER, DepartureReasonEntity::name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DepartureReasonTestRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/repository/DepartureReasonTestRepository.kt
@@ -1,9 +1,29 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.repository
 
+import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
 import java.util.UUID
 
 @Repository
-interface DepartureReasonTestRepository : JpaRepository<DepartureReasonEntity, UUID>
+interface DepartureReasonTestRepository : JpaRepository<DepartureReasonEntity, UUID> {
+  @Modifying
+  @Query(
+    value = """
+    WITH RECURSIVE tree AS (
+      SELECT id FROM departure_reasons
+      UNION
+      SELECT d.id
+      FROM departure_reasons d
+      JOIN tree t ON d.parent_reason_id = t.id
+    )
+    DELETE FROM departure_reasons WHERE id IN (SELECT id FROM tree)
+  """,
+    nativeQuery = true,
+  )
+  @Transactional
+  fun deleteAllRecursively()
+}


### PR DESCRIPTION
This required some tweaks to our OAuth2 config classes as the spring boot interfaces no longer support nullable values. A change was also required to upstream oauth client configuration, as noted on https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/11.x.md[#1100](https://github.com/ministryofjustice/hmpps-approved-premises-api/issues/1100)

This also upgraded hibernate from 7.2.12 to 7.4.1.Final. This caused some change in behaviour wrt. deleteall() with FKs that referenced entries in the same table.