### PR TITLE
Alert in CasesService if requested crn is missing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.CaseRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.Tier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.entity.model.TierVersion
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.jobs.migration.BackfillCasesJob
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.problem.NotFoundProblem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.transformer.toDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
@@ -21,12 +22,19 @@ import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier as UpstreamTier
 
 /**
- * An entry in the `cases` table should exist for every CRN for which an application exists,
- * regardless of the CAS it originated from
+ * CAS maintains a local copy of NDelius Case data, allowing us to perform queries
+ * across sets of that data and minimise upstream calls (e.g. sorting and searching
+ * on tier and name)
  *
- * The tier value for a case will always be up-to date
+ * CAS only tracks cases that have been explicitly registered as 'of interest'. This
+ * typically happens when an application is created via a call to
+ * [ensureCaseExists]
  *
- * Currently the names and noms number are not updated after the entry has been created
+ * The tier values for a case are kept up-to-date by listening for tier update events
+ *
+ * The [BackfillCasesJob] migration job was used to seed this table originally, and can be
+ * used if for some reason there are entries missing from this table (e.g. new CRNs were
+ * introduced without a call to [ensureCaseExists])
  */
 @Service
 class CaseService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.transformer.toDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService.Companion.FEATURE_FLAG_INCLUDE_TIER_V3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService.Companion.FEATURE_FLAG_USE_TIER_V3
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.time.OffsetDateTime
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.hmppstier.Tier as UpstreamTier
@@ -42,6 +43,7 @@ class CaseService(
   private val apDeliusContextApiClient: ApDeliusContextApiClient,
   private val hmppsTierApiClient: HMPPSTierApiClient,
   private val featureFlagService: FeatureFlagService,
+  private val sentryService: SentryService,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -76,12 +78,29 @@ class CaseService(
     return true
   }
 
-  fun getCase(crn: String): CaseDto? = caseRepository.findByCrn(crn)?.toDto()
+  /**
+   * Get a case by CRN. Note that a case must have been previously registered via
+   * a call to [ensureCaseExists] to be returned here. If a case isn't found an
+   * alert will be raised so we can investigate this, as it should never happen
+   */
+  fun getCase(crn: String): CaseDto? {
+    val case = caseRepository.findByCrn(crn)?.toDto()
+    if (case == null) {
+      alertCaseNotFound(crn)
+    }
+    return case
+  }
 
   /**
    * If a case can't be found for a given CRN there will be no corresponding entry in the result
    */
-  fun getCases(crns: List<String>): List<CaseDto> = caseRepository.findByCrnIn(crns).map { it.toDto() }
+  fun getCases(crns: List<String>): List<CaseDto> {
+    val result = caseRepository.findByCrnIn(crns).map { it.toDto() }
+
+    crns.subtract(result.map { it.crn }.toSet()).forEach { alertCaseNotFound(it) }
+
+    return result
+  }
 
   private data class CaseTiers(
     val v2: Tier?,
@@ -158,4 +177,10 @@ class CaseService(
 
     is ClientResult.Failure -> caseSummariesResponse.throwException()
   }
+
+  private fun alertCaseNotFound(crn: String) {
+    sentryService.captureException(CaseNotFound("Case with CRN $crn not found"))
+  }
+
+  class CaseNotFound(message: String) : Exception(message)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -94,9 +94,7 @@ class CaseService(
   )
 
   private fun CaseEntity.updateFrom(caseSummary: CaseSummary, tiers: CaseTiers): CaseEntity = apply {
-    name = "${caseSummary.name.forename} ${caseSummary.name.surname}"
-      .uppercase()
-      .trim()
+    name = caseSummary.buildName()
     nomsNumber = caseSummary.nomsId
     lastUpdatedAt = OffsetDateTime.now()
     if (tiers.v2 != null) {
@@ -112,13 +110,13 @@ class CaseService(
     crn = caseSummary.crn,
     createdAt = OffsetDateTime.now(),
     lastUpdatedAt = OffsetDateTime.now(),
-    name = "${caseSummary.name.forename} ${caseSummary.name.surname}"
-      .uppercase()
-      .trim(),
+    name = caseSummary.buildName(),
     nomsNumber = caseSummary.nomsId,
     tierV2 = tiers.v2,
     tierV3 = tiers.v3,
   )
+
+  private fun CaseSummary.buildName() = "${name.forename} ${name.surname}".uppercase().trim()
 
   private fun CaseEntity.toDto() = CaseDto(
     crn = crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.slot
 import io.mockk.verify
@@ -31,6 +32,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseSummaryFacto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NameFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TierFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.SentryService
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -47,8 +49,11 @@ class CaseServiceTest {
   @MockK
   private lateinit var mockApDeliusContextApiClient: ApDeliusContextApiClient
 
-  @MockK
+  @RelaxedMockK
   private lateinit var mockFeatureFlagService: FeatureFlagService
+
+  @RelaxedMockK
+  private lateinit var mockSentryService: SentryService
 
   @InjectMockKs
   private lateinit var service: CaseService
@@ -423,6 +428,21 @@ class CaseServiceTest {
   inner class GetCase {
 
     @Test
+    fun `if case is missing, raise an alert`() {
+      val crn = "CRN123"
+      every { mockCaseRepository.findByCrn(crn) } returns null
+
+      val result = service.getCase(crn)
+
+      assertThat(result).isNull()
+
+      val thrownExceptionSlot = slot<CaseService.CaseNotFound>()
+      verify { mockSentryService.captureException(capture(thrownExceptionSlot)) }
+
+      assertThat(thrownExceptionSlot.captured.message).isEqualTo("Case with CRN CRN123 not found")
+    }
+
+    @Test
     fun `if feature flag 'use-tier-v3' is false, should return tierV2`() {
       val crn = "CRN123"
       every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns true
@@ -464,6 +484,31 @@ class CaseServiceTest {
 
       assertThat(result).isNotNull
       assertThat(result!!.tier?.tierScore).isEqualTo("V3")
+    }
+  }
+
+  @Nested
+  inner class GetCases {
+    @Test
+    fun `should return all cases for given CRNs, raising alerts for missing cases`() {
+      val crn1 = "CRN123"
+      val crn2 = "CRN456"
+      val crn3 = "CRN789"
+
+      val caseEntity1 = CaseEntityFactory().withCrn(crn1).produce()
+      val caseEntity3 = CaseEntityFactory().withCrn(crn3).produce()
+
+      every { mockCaseRepository.findByCrnIn(listOf(crn1, crn2, crn3)) } returns listOf(caseEntity1, caseEntity3)
+
+      val result = service.getCases(listOf(crn1, crn2, crn3))
+
+      assertThat(result).hasSize(2)
+      assertThat(result.map { it.crn }).containsExactlyInAnyOrder(crn1, crn3)
+
+      val thrownExceptionSlot = slot<CaseService.CaseNotFound>()
+      verify { mockSentryService.captureException(capture(thrownExceptionSlot)) }
+
+      assertThat(thrownExceptionSlot.captured.message).isEqualTo("Case with CRN CRN456 not found")
     }
   }
 }


### PR DESCRIPTION
Any case requested from the `CaseService` should have already been initialised via a call to `CaseService.ensureCaseExists`. This commit adds an alert if a CRN is requested for which a case entry does not exist, because this indicates a coding/logic error.

The alert is raised an exception because this will provide a stack trace we can use to determine what requested the case