### PR TITLE
Make site survey room loading less confusing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1SeedRoomsFromSiteSurveyXlsxJob.kt
@@ -53,13 +53,16 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
 
     val siteSurveyBedsInfo = Cas1SiteSurveyBedFactory().load(file)
 
+    // Returns room info retrieved from each column. Because columns reflect beds and not rooms,
+    // the same room may appear multiple times in this list. In the following check we ensure
+    // that these repeating rooms have identical characteristics and fail if they don't
     val rooms = resolveRooms(qCode, siteSurveyBedsInfo)
-    checkRoomCharacteristics(rooms)
+    checkForMismatchedRoomCharacteristics(rooms)
 
     val beds = resolveBeds(qCode, siteSurveyBedsInfo)
     checkBedNamesUnique(beds)
 
-    rooms.forEach {
+    rooms.distinctBy { it.roomCode }.forEach {
       val existingRoom = roomRepository.findByCode(it.roomCode)
       if (existingRoom == null) {
         createRoom(premises, it)
@@ -103,8 +106,8 @@ class Cas1SeedRoomsFromSiteSurveyXlsxJob(
     )
   }
 
-  private fun checkRoomCharacteristics(rooms: List<RoomInfo>) {
-    rooms.groupBy { room -> room.roomCode }.forEach { (_, rooms) ->
+  private fun checkForMismatchedRoomCharacteristics(roomColumns: List<RoomInfo>) {
+    roomColumns.groupBy { room -> room.roomCode }.forEach { (_, rooms) ->
       rooms.all { it.characteristics == rooms.first().characteristics } || error("1 or more beds in room '${rooms.first().roomName}' have different characteristics.")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/seed/SeedCas1RoomsFromSiteSurveyXlsxTest.kt
@@ -464,6 +464,72 @@ class SeedCas1RoomsFromSiteSurveyXlsxTest : SeedTestBase() {
   }
 
   @Test
+  fun `Updating an existing room with multiple existing beds and a characteristic succeeds`() {
+    val qCode = "Q999"
+    val premises = givenAnApprovedPremises(qCode = qCode)
+    val roomCode = "$qCode-1"
+    val room = cas1RoomEntityFactory.produceAndPersist {
+      withPremises(premises)
+      withCode(roomCode)
+    }
+    cas1BedEntityFactory.produceAndPersist {
+      withRoom(room)
+      withCode("SWABI01")
+      withName("1 - 1")
+    }
+    cas1BedEntityFactory.produceAndPersist {
+      withRoom(room)
+      withCode("SWABI02")
+      withName("1 - 2")
+    }
+
+    val values = mutableListOf<List<Any>>(
+      listOf("Unique Reference Number for Bed", "SWABI01", "SWABI02"),
+      listOf(
+        "Room Number / Name",
+        "1",
+        "1",
+      ),
+      listOf(
+        "Bed Number (in this room i.e if this is a single room insert 1.  If this is a shared room separate entries will need to be made for bed 1 and bed 2)",
+        "1",
+        "2",
+      ),
+    ).addQuestionsAndAnswers(listOf("Is this room located on the ground floor?", "Yes", "Yes"))
+
+    val roomsSheet = dataFrameForHeadersAndRows(values)
+
+    createXlsxForSeeding(
+      fileName = "example.xlsx",
+      sheets = mapOf(
+        "Sheet2" to createNameValueDataFrame("AP Identifier (Q No.)", qCode),
+        "Sheet3" to roomsSheet,
+      ),
+    )
+
+    seedXlsxService.seedFile(
+      SeedFromExcelFileType.CAS1_IMPORT_SITE_SURVEY_ROOMS,
+      "example.xlsx",
+    )
+
+    val updatedRoom = roomRepository.findByCode(roomCode)
+    assertThat(updatedRoom!!.characteristics).anyMatch {
+      it.name == "Is this room located on the ground floor?" &&
+        it.propertyName == "isGroundFloor"
+    }
+
+    val existingBed1 = bedRepository.findByCode("SWABI01")
+    assertThat(existingBed1!!.name).isEqualTo("1 - 1")
+    assertThat(existingBed1.room.id).isEqualTo(updatedRoom.id)
+    assertThat(existingBed1.room.code).isEqualTo("Q999-1")
+
+    val existingBed2 = bedRepository.findByCode("SWABI02")
+    assertThat(existingBed2!!.name).isEqualTo("1 - 2")
+    assertThat(existingBed2.room.id).isEqualTo(updatedRoom.id)
+    assertThat(existingBed2.room.code).isEqualTo("Q999-1")
+  }
+
+  @Test
   fun `Creating a new room with two beds with the same name fails`() {
     val qCode = "Q999"
     val premises = givenAnApprovedPremises(qCode = qCode)


### PR DESCRIPTION
The site survey rooms worksheet has a seperate column for each bed, but as a room may have multiple beds, the same room information will repeat across those columns.

Whilst we have protections in the site survey update logic to ensure this room information is identical across each column before loading in any changes, the code still loops through the room information taken from each column, creating confusing logs e.g.

* Changes for existing room 1 with code QXYZ
* No changes for existing room 1 with code QXYZ

This log happens because the room information was succesfully updated in the database for the first bed that referred to it, so no changes required when updating room information for the second bed.

This is confusing. The code now only attempts to update the room information once, removing the confusing logging