### PR TITLE
FM-860-add-unconstrained-tier-filtering-for-CRU-dashboard

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1PlacementRequestsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1PlacementRequestsController.kt
@@ -74,7 +74,7 @@ class Cas1PlacementRequestsController(
   fun search(
     @RequestParam status: PlacementRequestStatus?,
     @RequestParam crnOrName: String?,
-    @Schema(description = "Filter on the tier captured when the application was created")
+    @Schema(deprecated = true, description = "Deprecated, use tierOnApplicationCreation instead")
     @RequestParam tier: RiskTierLevel?,
     @Schema(description = "Filter on the person's live tier")
     @RequestParam personTier: String?,
@@ -86,6 +86,8 @@ class Cas1PlacementRequestsController(
     @Schema(description = PlacementRequestSortFieldConstants.DESCRIPTION)
     @RequestParam sortBy: PlacementRequestSortField?,
     @RequestParam sortDirection: SortDirection?,
+    @Schema(description = "Filter on the tier captured when the application was created")
+    @RequestParam tierOnApplicationCreation: String?,
   ): ResponseEntity<List<Cas1PlacementRequestSummary>> {
     val user = getUserForRequest()
 
@@ -97,7 +99,7 @@ class Cas1PlacementRequestsController(
       Cas1PlacementRequestService.AllActiveSearchCriteria(
         status = status,
         crnOrName = crnOrName,
-        tierOnApplicationCreation = tier?.value,
+        tierOnApplicationCreation = tierOnApplicationCreation ?: tier?.value,
         personTier = personTier,
         arrivalDateStart = arrivalDateStart,
         arrivalDateEnd = arrivalDateEnd,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1PlacementRequestTest.kt
@@ -629,6 +629,78 @@ class Cas1PlacementRequestTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `It searches by tierOnApplicationCreation where user is manager`() {
+      val (user, jwt) = givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER))
+      val (offender1Details, _) = givenAnOffender()
+      val (offender2Details, inmate2Details) = givenAnOffender()
+      val (offender3Details, _) = givenAnOffender()
+
+      createPlacementRequest(offender1Details, user, tierOnApplicationCreation = RiskTierLevel.a0)
+      val placementRequestA1 = createPlacementRequest(offender2Details, user, tierOnApplicationCreation = RiskTierLevel.a1)
+      createPlacementRequest(offender3Details, user, tierOnApplicationCreation = RiskTierLevel.a2)
+
+      webTestClient.get()
+        .uri("/cas1/placement-requests?tierOnApplicationCreation=A1")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          jackson3JsonMapper.writeValueAsString(
+            listOf(
+              transformNotMatchedPlacementRequestJpaToApiSummary(
+                placementRequestA1,
+                PersonInfoResult.Success.Full(offender2Details.otherIds.crn, offender2Details, inmate2Details, tier = null),
+              ),
+            ),
+          ),
+        )
+    }
+
+    @Test
+    fun `tierOnApplicationCreation takes precedence over deprecated tier`() {
+      val (user, jwt) = givenAUser(roles = listOf(UserRole.CAS1_CRU_MEMBER))
+      val (offender1Details, inmate1Details) = givenAnOffender()
+      val (offender2Details, _) = givenAnOffender()
+
+      val placementRequestA0 = createPlacementRequest(
+        offender1Details,
+        user,
+        tierOnApplicationCreation = RiskTierLevel.a0,
+      )
+
+      createPlacementRequest(
+        offender2Details,
+        user,
+        tierOnApplicationCreation = RiskTierLevel.a1,
+      )
+
+      webTestClient.get()
+        .uri("/cas1/placement-requests?tier=A1&tierOnApplicationCreation=A0")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(
+          jackson3JsonMapper.writeValueAsString(
+            listOf(
+              transformNotMatchedPlacementRequestJpaToApiSummary(
+                placementRequestA0,
+                PersonInfoResult.Success.Full(
+                  offender1Details.otherIds.crn,
+                  offender1Details,
+                  inmate1Details,
+                  tier = null,
+                ),
+              ),
+            ),
+          ),
+        )
+    }
+
+    @Test
     fun `It searches by person tier v2 where user is manager`() {
       mockFeatureFlagService.setFlag("use-tier-v3", false)
 


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-860

# Changes in this PR
Added a `@RequestParam tierOnApplicationCreation: String?` to `Cas1PlacementRequestsController.search` 

Deprecated the existing `@RequestParam tier: RiskTierLevel?`