### PR TITLE
FM-926 Check tier on app creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1CreateApplicationOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1CreateApplicationOutcome.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 import java.util.UUID
 
 data class Cas1CreateApplicationOutcome(
-  val applicationId: UUID? = null,
-  val tier: TierDto? = null,
+  val applicationId: UUID,
+  val tier: TierDto,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
@@ -136,36 +136,29 @@ class Cas1ApplicationCreationService(
     offenceId: String,
   ): CasResult<Cas1CreateApplicationOutcome> {
     val case = caseService.ensureCaseExists(crn)
+    case.tier ?: throw InternalServerErrorProblem("Could not find risk tier for offender with CRN $crn")
 
-    if (case.tier == null) {
-      return CasResult.Success(
-        Cas1CreateApplicationOutcome(
-          tier = null,
-        ),
-      )
-    } else {
-      val riskRatings = offenderRisksService.getPersonRisks(crn)
+    val riskRatings = offenderRisksService.getPersonRisks(crn)
 
-      val createdApplicationId = applicationRepository.saveAndFlush(
-        createApprovedPremisesApplicationEntity(
-          crn,
-          user,
-          convictionId,
-          deliusEventNumber,
-          offenceId,
-          riskRatings,
-          case.nomsNumber,
-          case.name?.uppercase() ?: error("name is null"),
-        ),
-      ).id
+    val createdApplicationId = applicationRepository.saveAndFlush(
+      createApprovedPremisesApplicationEntity(
+        crn,
+        user,
+        convictionId,
+        deliusEventNumber,
+        offenceId,
+        riskRatings,
+        case.nomsNumber,
+        case.name?.uppercase() ?: error("name is null"),
+      ),
+    ).id
 
-      return CasResult.Success(
-        Cas1CreateApplicationOutcome(
-          applicationId = createdApplicationId,
-          tier = case.tier,
-        ),
-      )
-    }
+    return CasResult.Success(
+      Cas1CreateApplicationOutcome(
+        applicationId = createdApplicationId,
+        tier = case.tier!!,
+      ),
+    )
   }
 
   fun createApprovedPremisesApplicationEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -77,6 +77,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.ap
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessAddCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.apDeliusContextUserAccessSingleCase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.govUKBankHolidaysAPIMockSuccessfullCallWithEmptyResponse
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock404TierCall
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMock404V3TierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulTierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.httpmocks.hmppsTierMockSuccessfulV3TierCall
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationEntity
@@ -103,6 +105,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesAp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.RiskWithStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.domainevent.SnsEventPersonReference
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService.Companion.FEATURE_FLAG_USE_TIER_V3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationTimelineNoteTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1ApplicationTimelineTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.service.cas1.DomainEventSummaryImpl
@@ -2049,9 +2052,15 @@ class Cas1ApplicationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Create new application without risks returns 201 with correct body and Location header`() {
+    fun `Create new application throw error when tier v3 is not available`() {
+      mockFeatureFlagService.setFlag(FEATURE_FLAG_USE_TIER_V3, true)
       givenAUser { _, jwt ->
         givenAnOffender { offenderDetails, _ ->
+
+          apAndOASysMockSuccessfulNeedsDetailsCall(
+            offenderDetails.otherIds.crn,
+            NeedsDetailsFactory().produce(),
+          )
 
           apAndOASysMockSuccessfulRoshRatingsCall(
             offenderDetails.otherIds.crn,
@@ -2065,18 +2074,10 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             tier,
           )
 
-          hmppsTierMockSuccessfulV3TierCall(
-            offenderDetails.otherIds.crn,
-            tier,
-          )
+          hmppsTierMock404V3TierCall(offenderDetails.otherIds.crn)
 
-          apAndOASysMockSuccessfulNeedsDetailsCall(
-            offenderDetails.otherIds.crn,
-            NeedsDetailsFactory().produce(),
-          )
-
-          val result = webTestClient.post()
-            .uri("/cas1/applications/create?createWithRisks=false")
+          webTestClient.post()
+            .uri("/cas1/applications/create")
             .header("Authorization", "Bearer $jwt")
             .bodyValue(
               Cas1NewApplication(
@@ -2088,16 +2089,43 @@ class Cas1ApplicationTest : IntegrationTestBase() {
             )
             .exchange()
             .expectStatus()
-            .isCreated
-            .returnResult(Cas1CreateApplicationOutcome::class.java)
-            .responseBody
-            .blockFirst()
+            .is5xxServerError
+        }
+      }
+    }
 
-          assertThat(result!!.applicationId).isNotNull
-          assertThat(result.tier!!.tierScore).isEqualTo(tier.tierScore)
-          assertThat(result.tier.calculationDate).isEqualTo(tier.calculationDate)
-          assertThat(result.tier.provisional).isNull()
-          assertThat(result.tier.version.name).isEqualTo(TierVersion.V2.name)
+    @Test
+    fun `Create new application throw error when tier v2 is not available`() {
+      mockFeatureFlagService.setFlag(FEATURE_FLAG_USE_TIER_V3, false)
+      givenAUser { _, jwt ->
+        givenAnOffender { offenderDetails, _ ->
+
+          apAndOASysMockSuccessfulNeedsDetailsCall(
+            offenderDetails.otherIds.crn,
+            NeedsDetailsFactory().produce(),
+          )
+
+          apAndOASysMockSuccessfulRoshRatingsCall(
+            offenderDetails.otherIds.crn,
+            RoshRatingsFactory().produce(),
+          )
+
+          hmppsTierMock404TierCall(offenderDetails.otherIds.crn)
+
+          webTestClient.post()
+            .uri("/cas1/applications/create")
+            .header("Authorization", "Bearer $jwt")
+            .bodyValue(
+              Cas1NewApplication(
+                crn = offenderDetails.otherIds.crn,
+                convictionId = 123,
+                deliusEventNumber = "1",
+                offenceId = "789",
+              ),
+            )
+            .exchange()
+            .expectStatus()
+            .is5xxServerError
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationCreationServiceTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
@@ -229,7 +230,7 @@ class Cas1ApplicationCreationServiceTest {
   inner class CreateApprovedPremisesEligibleApplication {
 
     @Test
-    fun `Returns tier not eligible and no application created if tier is null`() {
+    fun `Does not create application when tier is null`() {
       val crn = "CRN345"
       val username = "SOMEPERSON"
       val user = userWithUsername(username)
@@ -249,12 +250,7 @@ class Cas1ApplicationCreationServiceTest {
 
       every { mockOffenderRisksService.getPersonRisks(crn) } returns riskRatings
 
-      val result = applicationService.createApplication(crn, user, 123, "1", "A12HI")
-
-      assertThatCasResult(result).isSuccess().with {
-        val outcome = it
-        assertThat(outcome.tier).isNull()
-      }
+      assertThrows<RuntimeException> { applicationService.createApplication(crn, user, 123, "1", "A12HI") }
 
       verify { mockApplicationRepository wasNot Called }
     }
@@ -319,8 +315,8 @@ class Cas1ApplicationCreationServiceTest {
 
       assertThatCasResult(result).isSuccess().with {
         val outcome = it
-        assertThat(outcome.tier?.version).isEqualTo(TierVersionDto.V2)
-        assertThat(outcome.tier?.tierScore).isEqualTo("A0")
+        assertThat(outcome.tier.version).isEqualTo(TierVersionDto.V2)
+        assertThat(outcome.tier.tierScore).isEqualTo("A0")
       }
 
       val createdApplication = savedApplication.captured as ApprovedPremisesApplicationEntity
@@ -388,8 +384,8 @@ class Cas1ApplicationCreationServiceTest {
 
       assertThatCasResult(result).isSuccess().with {
         val outcome = it
-        assertThat(outcome.tier?.version).isEqualTo(TierVersionDto.V2)
-        assertThat(outcome.tier?.tierScore).isEqualTo("A0")
+        assertThat(outcome.tier.version).isEqualTo(TierVersionDto.V2)
+        assertThat(outcome.tier.tierScore).isEqualTo("A0")
       }
 
       val createdApplication = savedApplication.captured as ApprovedPremisesApplicationEntity
@@ -458,8 +454,8 @@ class Cas1ApplicationCreationServiceTest {
 
       assertThatCasResult(result).isSuccess().with {
         val outcome = it
-        assertThat(outcome.tier?.version).isEqualTo(TierVersionDto.V2)
-        assertThat(outcome.tier?.tierScore).isEqualTo(tierScore)
+        assertThat(outcome.tier.version).isEqualTo(TierVersionDto.V2)
+        assertThat(outcome.tier.tierScore).isEqualTo(tierScore)
       }
 
       val createdApplication = savedApplication.captured as ApprovedPremisesApplicationEntity


### PR DESCRIPTION
Check tier availability when creating a new application and throw an error if the tier cannot be retrieved.