### PR TITLE
FM-951: Enable case-insensitive CRN handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/migration/BackfillCasesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/jobs/migration/BackfillCasesJob.kt
@@ -40,7 +40,7 @@ class BackfillCasesJob(
       batch.forEach { dto ->
         runCatching {
           transactionTemplate.executeWithoutResult {
-            processCase(dto, missingCasesSummary[dto.crn])
+            processCase(dto, missingCasesSummary[dto.crn.uppercase()])
           }
         }.onFailure {
           migrationLogger.error("Unable to process case for CRN ${dto.crn}", it)
@@ -70,7 +70,7 @@ class BackfillCasesJob(
   private fun fetchSummariesForMissingCases(
     newCaseDtos: List<BackfillCaseSummaryMigrationDto>,
   ): Map<String, PersonSummaryInfoResult> {
-    val crns = newCaseDtos.map { it.crn }.toSet()
+    val crns = newCaseDtos.map { it.crn.uppercase() }.toSet()
 
     if (crns.isEmpty()) return emptyMap()
 
@@ -78,7 +78,7 @@ class BackfillCasesJob(
       offenderService.getPersonSummaryInfoResultsInBatches(
         crns,
         LaoStrategy.NeverRestricted,
-      ).associateBy { it.crn }
+      ).associateBy { it.crn.uppercase() }
     } catch (exception: Exception) {
       migrationLogger.error("Unable to retrieve person summaries for batch, continuing with DTO values", exception)
       emptyMap()
@@ -101,13 +101,14 @@ class BackfillCasesJob(
       return
     }
 
-    migrationLogger.info("Updating missing tiers for CRN ${dto.crn}")
+    val normalizedCrn = dto.crn.uppercase()
+    migrationLogger.info("Updating missing tiers for CRN $normalizedCrn")
 
-    val existingCase = caseRepository.findByCrn(dto.crn)!!
+    val existingCase = caseRepository.findByCrn(normalizedCrn)!!
 
     existingCase.apply {
-      if (!dto.hasTierV2) tierV2 = fetchTierOrNull(dto.crn, TierVersion.V2)
-      if (!dto.hasTierV3) tierV3 = fetchTierOrNull(dto.crn, TierVersion.V3)
+      if (!dto.hasTierV2) tierV2 = fetchTierOrNull(normalizedCrn, TierVersion.V2)
+      if (!dto.hasTierV3) tierV3 = fetchTierOrNull(normalizedCrn, TierVersion.V3)
       lastUpdatedAt = OffsetDateTime.now()
     }
 
@@ -118,7 +119,8 @@ class BackfillCasesJob(
     dto: BackfillCaseSummaryMigrationDto,
     summaryResult: PersonSummaryInfoResult?,
   ) {
-    migrationLogger.info("Creating case for CRN ${dto.crn}")
+    val normalizedCrn = dto.crn.uppercase()
+    migrationLogger.info("Creating case for CRN $normalizedCrn")
 
     val personDetails = resolvePersonDetails(dto, summaryResult)
 
@@ -127,11 +129,11 @@ class BackfillCasesJob(
     caseRepository.save(
       CaseEntity(
         id = UUID.randomUUID(),
-        crn = dto.crn,
+        crn = normalizedCrn,
         name = personDetails.name,
         nomsNumber = personDetails.nomsNumber,
-        tierV2 = fetchTierOrNull(dto.crn, TierVersion.V2),
-        tierV3 = fetchTierOrNull(dto.crn, TierVersion.V3),
+        tierV2 = fetchTierOrNull(normalizedCrn, TierVersion.V2),
+        tierV3 = fetchTierOrNull(normalizedCrn, TierVersion.V3),
         createdAt = now,
         lastUpdatedAt = now,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -54,10 +54,11 @@ class CaseService(
     get() = featureFlagService.getBooleanFlag(FEATURE_FLAG_USE_TIER_V3)
 
   fun ensureCaseExists(crn: String): CaseDto {
-    val caseSummary = getCaseSummary(crn)
-    val tiers = fetchAvailableTiers(crn)
+    val normalizedCrn = crn.uppercase()
+    val caseSummary = getCaseSummary(normalizedCrn)
+    val tiers = fetchAvailableTiers(normalizedCrn)
 
-    val caseEntity = caseRepository.findByCrn(caseSummary.crn)
+    val caseEntity = caseRepository.findByCrn(caseSummary.crn.uppercase())
       ?.updateFrom(caseSummary, tiers)
       ?: newCaseEntity(caseSummary, tiers)
 
@@ -65,14 +66,15 @@ class CaseService(
   }
 
   fun reviseTier(crn: String): Boolean {
-    val case = caseRepository.findByCrn(crn) ?: return false
+    val normalizedCrn = crn.uppercase()
+    val case = caseRepository.findByCrn(normalizedCrn) ?: return false
 
-    case.tierV2 = fetchTierOrError(crn, TierVersion.V2)
-    log.info("Have updated tierV2 for $crn to $case.tierV2")
+    case.tierV2 = fetchTierOrError(normalizedCrn, TierVersion.V2)
+    log.info("Have updated tierV2 for $normalizedCrn to $case.tierV2")
 
     if (includeTierV3) {
-      case.tierV3 = fetchTierOrError(crn, TierVersion.V3)
-      log.info("Have updated tierV3 for $crn to $case.tierV3")
+      case.tierV3 = fetchTierOrError(normalizedCrn, TierVersion.V3)
+      log.info("Have updated tierV3 for $normalizedCrn to $case.tierV3")
     }
     caseRepository.save(case)
     return true
@@ -84,9 +86,10 @@ class CaseService(
    * alert will be raised so we can investigate this, as it should never happen
    */
   fun getCase(crn: String): CaseDto? {
-    val case = caseRepository.findByCrn(crn)?.toDto()
+    val normalizedCrn = crn.uppercase()
+    val case = caseRepository.findByCrn(normalizedCrn)?.toDto()
     if (case == null) {
-      alertCaseNotFound(crn)
+      alertCaseNotFound(normalizedCrn)
     }
     return case
   }
@@ -95,11 +98,16 @@ class CaseService(
    * If a case can't be found for a given CRN there will be no corresponding entry in the result
    */
   fun getCases(crns: List<String>): List<CaseDto> {
-    val result = caseRepository.findByCrnIn(crns).map { it.toDto() }
+    val normalizedCrn = crns.map(String::uppercase)
+    val cases = caseRepository.findByCrnIn(normalizedCrn).map { it.toDto() }
 
-    crns.subtract(result.map { it.crn }.toSet()).forEach { alertCaseNotFound(it) }
+    val foundCrns = cases.map(CaseDto::crn).toSet()
 
-    return result
+    normalizedCrn
+      .subtract(foundCrns)
+      .forEach(::alertCaseNotFound)
+
+    return cases
   }
 
   private data class CaseTiers(
@@ -125,7 +133,7 @@ class CaseService(
 
   private fun newCaseEntity(caseSummary: CaseSummary, tiers: CaseTiers) = CaseEntity(
     id = UUID.randomUUID(),
-    crn = caseSummary.crn,
+    crn = caseSummary.crn.uppercase(),
     createdAt = OffsetDateTime.now(),
     lastUpdatedAt = OffsetDateTime.now(),
     name = caseSummary.buildName(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/givens/GivenACase.kt
@@ -11,7 +11,7 @@ fun IntegrationTestBase.givenACase(
   tierV3: Tier? = TierFactory().produce(),
 ): CaseEntity {
   val case = caseEntityFactory.produceAndPersist {
-    withCrn(crn)
+    withCrn(crn.uppercase())
     withTierV2(tierV2)
     withTierV3(tierV3)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/BackfillCasesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/migration/BackfillCasesJobTest.kt
@@ -258,4 +258,36 @@ class BackfillCasesJobTest : MigrationJobTestBase() {
     assertThat(c.tierV2!!.tierScore).isEqualTo("A1")
     assertThat(c.tierV3!!.tierScore).isEqualTo("A1")
   }
+
+  @Test
+  fun `backfill job uppercases CRN when creating new case`() {
+    val crn = "lowercrn"
+    val uppercasedCrn = "LOWERCRN"
+
+    val probationRegion = givenAProbationRegion()
+    userEntityFactory.produceAndPersist {
+      withProbationRegion(probationRegion)
+    }
+
+    offlineApplicationEntityFactory.produceAndPersist {
+      withCrn(crn)
+    }
+
+    val caseSummary = CaseSummaryFactory()
+      .withCrn(uppercasedCrn)
+      .withName(NameFactory().withForename("John").withSurname("Smith").produce())
+      .withNomsId("NOMS123")
+      .produce()
+
+    apDeliusContextCaseSummariesMultipleCases(listOf(caseSummary))
+
+    hmppsTierMockSuccessfulTierCall(uppercasedCrn, UpstreamTier("A1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
+    hmppsTierMockSuccessfulV3TierCall(uppercasedCrn, UpstreamTier("C1", UUID.randomUUID(), LocalDateTime.now(), changeReason = "reason1"))
+
+    migrationJobService.runMigrationJob(MigrationJobType.backfillCases, 10)
+
+    val c = caseRepository.findByCrn(uppercasedCrn)!!
+    assertThat(c.crn).isEqualTo(uppercasedCrn)
+    assertThat(c.name).isEqualTo("JOHN SMITH")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/CaseServiceTest.kt
@@ -325,6 +325,39 @@ class CaseServiceTest {
         .hasMessageContaining(crn)
         .hasMessageContaining("Offender")
     }
+
+    @Test
+    fun `should uppercase CRN when ensuring case exists`() {
+      val crn = "crn123"
+      val uppercasedCrn = "CRN123"
+
+      val caseSummary = CaseSummaryFactory()
+        .withCrn(uppercasedCrn)
+        .withName(NameFactory().withForename("John").withSurname("Smith").produce())
+        .withNomsId("NOMS123")
+        .produce()
+
+      every { mockCaseRepository.findByCrn(uppercasedCrn) } returns null
+      val createdCase = slot<CaseEntity>()
+      every { mockCaseRepository.saveAndFlush(capture(createdCase)) } returnsArgument 0
+      every { mockApDeliusContextApiClient.getCaseSummaries(listOf(uppercasedCrn)) } returns ClientResult.Success(
+        HttpStatus.OK,
+        CaseSummaries(listOf(caseSummary)),
+      )
+
+      every { mockHMPPSTierApiClient.getTier(uppercasedCrn, any()) } returns ClientResult.Failure.Other(
+        HttpMethod.GET,
+        "/tier",
+        RuntimeException("Fail"),
+      )
+
+      service.ensureCaseExists(crn)
+
+      assertThat(createdCase.captured.crn).isEqualTo(uppercasedCrn)
+      verify { mockCaseRepository.findByCrn(uppercasedCrn) }
+      verify { mockApDeliusContextApiClient.getCaseSummaries(listOf(uppercasedCrn)) }
+      verify { mockHMPPSTierApiClient.getTier(uppercasedCrn, TierVersion.V2) }
+    }
   }
 
   @Nested
@@ -422,6 +455,29 @@ class CaseServiceTest {
         service.reviseTier(crn)
       }.isInstanceOf(RuntimeException::class.java)
     }
+
+    @Test
+    fun `should uppercase CRN when revising tier`() {
+      val crn = "crn123"
+      val uppercasedCrn = "CRN123"
+      every { mockFeatureFlagService.getBooleanFlag("include-tier-v3") } returns false
+      val caseEntity = CaseEntityFactory().withCrn(uppercasedCrn).produce()
+
+      every { mockCaseRepository.findByCrn(uppercasedCrn) } returns caseEntity
+      every { mockHMPPSTierApiClient.getTier(uppercasedCrn, any()) } returns ClientResult.Failure.StatusCode(
+        status = HttpStatus.INTERNAL_SERVER_ERROR,
+        method = HttpMethod.GET,
+        path = "/crn/$uppercasedCrn/tier",
+        body = null,
+      )
+
+      assertThatThrownBy {
+        service.reviseTier(crn)
+      }.isInstanceOf(RuntimeException::class.java)
+
+      verify { mockCaseRepository.findByCrn(uppercasedCrn) }
+      verify { mockHMPPSTierApiClient.getTier(uppercasedCrn, TierVersion.V2) }
+    }
   }
 
   @Nested
@@ -485,6 +541,19 @@ class CaseServiceTest {
       assertThat(result).isNotNull
       assertThat(result!!.tier?.tierScore).isEqualTo("V3")
     }
+
+    @Test
+    fun `should uppercase CRN when getting case`() {
+      val crn = "crn123"
+      val uppercasedCrn = "CRN123"
+
+      every { mockCaseRepository.findByCrn(uppercasedCrn) } returns null
+
+      service.getCase(crn)
+
+      verify { mockCaseRepository.findByCrn(uppercasedCrn) }
+      verify { mockSentryService.captureException(any<CaseService.CaseNotFound>()) }
+    }
   }
 
   @Nested
@@ -509,6 +578,26 @@ class CaseServiceTest {
       verify { mockSentryService.captureException(capture(thrownExceptionSlot)) }
 
       assertThat(thrownExceptionSlot.captured.message).isEqualTo("Case with CRN CRN456 not found")
+    }
+
+    @Test
+    fun `should uppercase CRNs when getting multiple cases`() {
+      val crn1 = "crn123"
+      val crn2 = "crn456"
+      val uppercasedCrn1 = "CRN123"
+      val uppercasedCrn2 = "CRN456"
+
+      val caseEntity1 = CaseEntityFactory().withCrn(uppercasedCrn1).produce()
+
+      every { mockCaseRepository.findByCrnIn(listOf(uppercasedCrn1, uppercasedCrn2)) } returns listOf(caseEntity1)
+
+      val result = service.getCases(listOf(crn1, crn2))
+
+      assertThat(result).hasSize(1)
+      assertThat(result[0].crn).isEqualTo(uppercasedCrn1)
+
+      verify { mockCaseRepository.findByCrnIn(listOf(uppercasedCrn1, uppercasedCrn2)) }
+      verify { mockSentryService.captureException(any<CaseService.CaseNotFound>()) }
     }
   }
 }


### PR DESCRIPTION
Convert CRNs to uppercase to ensure case creation and retrieval are case-insensitive.