### PR TITLE
feature/SAS-651-CAS1-Provide-extra-box-content

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/RequestForPlacement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/RequestForPlacement.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import java.time.LocalDate
 
 data class RequestForPlacement(
@@ -16,11 +18,13 @@ data class RequestForPlacement(
   val type: RequestForPlacementType,
   @Schema(description = "Deprecated. Requests for placements only have one set of placement dates, use 'requestedPlacementPeriod' or 'authorisedPlacementPeriod' instead", deprecated = true)
   val placementDates: List<PlacementDates>,
+  val canonicalPlacementPeriod: Cas1RequestedPlacementPeriod,
   val requestedPlacementPeriod: Cas1RequestedPlacementPeriod,
   val authorisedPlacementPeriod: Cas1RequestedPlacementPeriod?,
   val status: RequestForPlacementStatus,
   val statusSetDate: LocalDate,
   val submittedAt: java.time.Instant? = null,
+  val submittedBy: Cas1StaffDto? = null,
   @Schema(description = "If `type` is `\"manual\"`, provides the value of `PlacementApplication.decisionMadeAt`. If `type` is `\"automatic\"` this field provides the value of `PlacementRequest.assessmentCompletedAt`. ")
   val requestReviewedAt: java.time.Instant? = null,
   val document: Any? = null,
@@ -29,4 +33,5 @@ data class RequestForPlacement(
   val releaseType: ReleaseTypeOption? = null,
   val situation: SituationOption? = null,
   var placements: List<Cas1SpaceBookingShortSummary> = emptyList(),
+  val decision: PlacementApplicationDecision?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/external/Cas1ExternalReferralsController.kt
@@ -19,8 +19,8 @@ class Cas1ExternalReferralsController(
   @GetMapping("/referrals/{crn}")
   fun getReferralsByCrn(@PathVariable crn: String): ResponseEntity<List<Cas1ReferralHistory>> = ResponseEntity.ok(
     cas1AssessmentService.getApprovedPremisesAssessmentsByCrnNotReallocated(crn).flatMap {
-      val placementHistories = cas1ExternalApplicationService.getPlacementHistories(it.application.id)
-      cas1AssessmentTransformer.transformDomainToApiCas1ReferralHistory(it, placementHistories)
+      val placementHistory = cas1ExternalApplicationService.getPlacementPairs(it.application.id)
+      cas1AssessmentTransformer.transformDomainToApiCas1ReferralHistory(it, placementHistory)
     },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -58,7 +57,7 @@ data class Cas1ExternalAssessmentDto(
 
 data class Cas1ExternalRequestForPlacementDto(
   val status: RequestForPlacementStatus?,
-  val decision: PlacementApplicationDecision?,
+  val decision: PlacementApplicationDecisionDto?,
   val rejectionReason: String?,
   val submittedBy: Cas1StaffDto?,
   val submittedAt: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import java.time.LocalDate
 import java.time.OffsetDateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/dto/Cas1SuitableApplication.kt
@@ -1,17 +1,79 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
+@Schema(description = "Details about the most current application, with associated assessment, request for placement and placement")
 data class Cas1SuitableApplication(
-  val id: UUID,
-  val applicationStatus: ApprovedPremisesApplicationStatus,
-  val requestForPlacementStatus: RequestForPlacementStatus?,
-  val placementStatus: Cas1SpaceBookingStatus?,
-  val premises: Cas1ExternalPremisesDto?,
   val uiUrl: String,
+  val application: Cas1ExternalApplicationDto,
+  val assessment: Cas1ExternalAssessmentDto?,
+  val requestForPlacement: Cas1ExternalRequestForPlacementDto?,
+  val placement: Cas1ExternalPlacementDto?,
+  val placementHistory: List<Cas1PlacementPairDto>,
+
+  @Deprecated("This field will be removed once SAS is updated to use application.id")
+  val id: UUID,
+
+  @Deprecated("This field will be removed once SAS is updated to use application.status")
+  val applicationStatus: ApprovedPremisesApplicationStatus,
+
+  @Deprecated("This field will be removed once SAS is updated to use requestForPlacement.status")
+  val requestForPlacementStatus: RequestForPlacementStatus?,
+
+  @Deprecated("This field will be removed once SAS is updated to use placement.status")
+  val placementStatus: Cas1SpaceBookingStatus?,
+
+  @Deprecated("This field will be removed once SAS is updated to use placement.premises")
+  val premises: Cas1ExternalPremisesDto?,
+)
+
+@Schema(description = "Details about a placement, with it's associated request for placement")
+data class Cas1PlacementPairDto(
+  val requestForPlacement: Cas1ExternalRequestForPlacementDto?,
+  val placement: Cas1ExternalPlacementDto?,
+  val dateApplied: LocalDate,
+)
+
+data class Cas1ExternalApplicationDto(
+  val id: UUID,
+  val status: ApprovedPremisesApplicationStatus,
+  val createdAt: OffsetDateTime,
+  val createdBy: Cas1StaffDto,
+  val submittedAt: OffsetDateTime?,
+  val expiresAt: LocalDate?,
+)
+
+data class Cas1ExternalAssessmentDto(
+  val decision: AssessmentDecision?,
+  val rejectionRationale: String?,
+)
+
+data class Cas1ExternalRequestForPlacementDto(
+  val status: RequestForPlacementStatus?,
+  val decision: PlacementApplicationDecision?,
+  val rejectionReason: String?,
+  val submittedBy: Cas1StaffDto?,
+  val submittedAt: LocalDate?,
+  val withdrawalReason: WithdrawPlacementRequestReason?,
+  val withdrawalDate: LocalDate?,
+  val expectedArrivalDate: LocalDate?,
+  val durationDays: Int?,
+)
+
+data class Cas1ExternalPlacementDto(
+  val status: Cas1SpaceBookingStatus?,
+  val actualArrivalDate: LocalDate?,
+  val actualDepartureDate: LocalDate?,
+  val cancellationReason: String?,
+  val premises: Cas1ExternalPremisesDto?,
 )
 
 data class Cas1ExternalPremisesDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -47,6 +47,10 @@ import kotlin.time.toKotlinDuration
 @Repository
 interface ApplicationRepository : JpaRepository<ApplicationEntity, UUID> {
 
+  companion object {
+    const val APPLICATION_EXPIRY_DAYS = 365
+  }
+
   @Modifying
   @Query("UPDATE ApprovedPremisesApplicationEntity ap set ap.status = :status where ap.id = :applicationId")
   fun updateStatus(applicationId: UUID, status: ApprovedPremisesApplicationStatus)
@@ -248,11 +252,11 @@ WHERE a.created_by_user_id = :userId and a.deleted_at IS NULL
         de.type = 'APPROVED_PREMISES_APPLICATION_ASSESSED'
         AND de.data -> 'eventDetails' ->> 'decision' = 'ACCEPTED'
         AND apa.status <> 'EXPIRED'
-        AND de.occurred_at < current_date - 365
+        AND de.occurred_at < current_date - :expiryDays
     """,
     nativeQuery = true,
   )
-  fun findAllExpiredApplications(): List<UUID>
+  fun findAllExpiredApplications(expiryDays: Int): List<UUID>
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/AssessmentEntity.kt
@@ -31,6 +31,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as AssessmentDecisionApi
 
 @Repository
 interface AssessmentRepository : JpaRepository<AssessmentEntity, UUID> {
@@ -413,9 +414,9 @@ enum class DomainAssessmentSummaryStatus {
   UNALLOCATED,
 }
 
-enum class AssessmentDecision {
-  ACCEPTED,
-  REJECTED,
+enum class AssessmentDecision(val apiValue: AssessmentDecisionApi) {
+  ACCEPTED(AssessmentDecisionApi.accepted),
+  REJECTED(AssessmentDecisionApi.rejected),
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -18,6 +18,7 @@ interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity,
     val CAS1_RELATED_APP_WITHDRAWN_ID: UUID = UUID.fromString("bcb90030-b2d3-47d1-b289-a8b8c8898576")
     val CAS1_RELATED_OTHER_ID: UUID = UUID.fromString("1d6f3c6e-3a86-49b4-bfca-2513a078aba3")
     val CAS1_BOOKING_SUCCESSFULLY_APPEALED_ID: UUID = UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")
+    val CAS1_OTHER_NAME: String = "Other"
   }
 
   @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*' ORDER by c.sortOrder ASC, c.name ASC")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/CancellationReasonEntity.kt
@@ -18,7 +18,7 @@ interface CancellationReasonRepository : JpaRepository<CancellationReasonEntity,
     val CAS1_RELATED_APP_WITHDRAWN_ID: UUID = UUID.fromString("bcb90030-b2d3-47d1-b289-a8b8c8898576")
     val CAS1_RELATED_OTHER_ID: UUID = UUID.fromString("1d6f3c6e-3a86-49b4-bfca-2513a078aba3")
     val CAS1_BOOKING_SUCCESSFULLY_APPEALED_ID: UUID = UUID.fromString("acba3547-ab22-442d-acec-2652e49895f2")
-    val CAS1_OTHER_NAME: String = "Other"
+    const val CAS1_OTHER_NAME: String = "Other"
   }
 
   @Query("SELECT c FROM CancellationReasonEntity c WHERE c.serviceScope = :serviceName OR c.serviceScope = '*' ORDER by c.sortOrder ASC, c.name ASC")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/DomainEventEntity.kt
@@ -101,6 +101,33 @@ interface DomainEventRepository : JpaRepository<DomainEventEntity, UUID> {
   fun findByType(type: DomainEventType): List<DomainEventEntity>
 
   @Query(
+    value = """
+    SELECT *
+    FROM domain_events as d
+    WHERE (d.type = 'APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN' OR d.type = 'APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN')
+    AND (d.data -> 'eventDetails' ->> 'matchRequestId' = CAST(:placementRequestId AS text)
+    OR d.data -> 'eventDetails' ->> 'placementApplicationId' = CAST(:placementRequestId AS text))
+  ORDER BY d.created_at DESC
+  LIMIT 1
+  """,
+    nativeQuery = true,
+  )
+  fun findWithdrawnRequestForPlacement(placementRequestId: UUID): DomainEventEntity?
+
+  @Query(
+    value = """
+    SELECT *
+    FROM domain_events as d
+    WHERE d.type = 'APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED'
+    AND d.data -> 'eventDetails' ->> 'placementApplicationId' = CAST(:placementApplicationId AS text)
+  ORDER BY d.created_at DESC
+  LIMIT 1
+  """,
+    nativeQuery = true,
+  )
+  fun findAssessedRequestForPlacement(placementApplicationId: UUID): DomainEventEntity?
+
+  @Query(
     """
     SELECT d
     FROM DomainEventEntity d

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationRe
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getPageableOrAllPages
+import java.time.LocalDate
 import java.util.UUID
 
 @SuppressWarnings("TooGenericExceptionThrown")
@@ -43,6 +45,12 @@ class Cas1ApplicationService(
   private val offenderService: OffenderService,
   private val featureFlagService: FeatureFlagService,
 ) {
+  fun getApplicationExpiresAt(application: ApprovedPremisesApplicationEntity): LocalDate? {
+    val latestAssessment = application.getLatestAssessment()
+    val possibleExpiryDate = latestAssessment?.submittedAt?.toLocalDate()?.plusDays(ApplicationRepository.APPLICATION_EXPIRY_DAYS.toLong())
+    return if (latestAssessment?.decision == AssessmentDecision.ACCEPTED) possibleExpiryDate else null
+  }
+
   fun getApplication(applicationId: UUID) = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)
 
   fun getApplicationForUsername(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1DomainEventService.kt
@@ -8,7 +8,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpired
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationExpiredManually
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmitted
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationSubmittedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.ApplicationWithdrawn
@@ -86,7 +85,6 @@ class Cas1DomainEventService(
   fun getBookingKeyWorkerAssignedEvent(id: UUID) = get(id, BookingKeyWorkerAssigned::class)
   fun getApplicationWithdrawnEvent(id: UUID) = get(id, ApplicationWithdrawn::class)
   fun getApplicationExpiredEvent(id: UUID) = get(id, ApplicationExpired::class)
-  fun getApplicationExpiredManuallyEvent(id: UUID) = get(id, ApplicationExpiredManually::class)
   fun getPlacementApplicationWithdrawnEvent(id: UUID) = get(id, PlacementApplicationWithdrawn::class)
   fun getPlacementApplicationAllocatedEvent(id: UUID) = get(id, PlacementApplicationAllocated::class)
   fun getMatchRequestWithdrawnEvent(id: UUID) = get(id, MatchRequestWithdrawn::class)
@@ -281,7 +279,7 @@ class Cas1DomainEventService(
     if (emittable && domainEvent.emit) {
       emit(domainEventEntity)
     } else {
-      log.debug("Not emitting domain event of type $eventType. Type emittable? $emittable. Emit? ${domainEvent.emit}")
+      log.debug("Not emitting domain event of type {}. Type emittable? {}. Emit? {}", eventType, emittable, domainEvent.emit)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1RequestForPlacementService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1
 
 import org.springframework.stereotype.Component
+import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessedEnvelope
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
@@ -10,6 +12,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -27,7 +30,9 @@ class Cas1RequestForPlacementService(
   private val cas1WithdrawableService: Cas1WithdrawableService,
   private val cas1SpaceBookingRepository: Cas1SpaceBookingRepository,
   private val cas1SpaceBookingTransformer: Cas1SpaceBookingTransformer,
+  private val domainEventRepository: DomainEventRepository,
   private val caseService: CaseService,
+  private val jsonMapper: JsonMapper,
 ) {
   fun getRequestsForPlacementByApplication(applicationId: UUID, requestingUser: UserEntity?): CasResult<List<RequestForPlacement>> {
     val application = applicationService.getApplication(applicationId)
@@ -120,6 +125,12 @@ class Cas1RequestForPlacementService(
       }
     }
   }
+
+  fun getRequestForPlacementWithdrawalDate(rfp: RequestForPlacement) = domainEventRepository.findWithdrawnRequestForPlacement(rfp.id)?.occurredAt?.toLocalDate()
+
+  fun getRequestForPlacementRejectionReason(rfp: RequestForPlacement) = domainEventRepository.findAssessedRequestForPlacement(rfp.id)?.let {
+    jsonMapper.readValue(it.data, RequestForPlacementAssessedEnvelope::class.java)
+  }?.eventDetails?.decisionSummary
 
   @SuppressWarnings("MaxLineLength")
   private fun createDurationCalculation(period: Period, maxDurationDays: Int?): CasResult.Success<Cas1RequestsForPlacementDurationsCalculationResponseDto> = CasResult.Success(Cas1RequestsForPlacementDurationsCalculationResponseDto(period.days, maxDurationDays))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1PlacementPairDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/external/Cas1ExternalApplicationService.kt
@@ -1,18 +1,20 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1PlacementPairDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1RequestForPlacementService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.external.Cas1ExternalApplicationTransformer
 import java.time.LocalDate
 import java.util.UUID
 
@@ -22,47 +24,38 @@ class Cas1ExternalApplicationService(
   private val approvedPremisesApplicationRepository: ApprovedPremisesApplicationRepository,
   private val cas1RequestForPlacementService: Cas1RequestForPlacementService,
   private val cas1PremisesService: Cas1PremisesService,
-  @Value($$"${url-templates.frontend.application}") private val cas1ApplicationUrlTemplate: String,
+  private val transformer: Cas1ExternalApplicationTransformer,
 ) {
 
   private val mostSuitableApplication = compareBy<ApprovedPremisesApplicationEntity> { suitableStatusesAsc[it.status] }
     .thenBy { it.submittedAt ?: it.createdAt }
 
-  fun getPlacementHistories(applicationId: UUID): List<Cas1PlacementHistory> {
+  fun getPlacementPairs(applicationId: UUID): List<Cas1PlacementPairDto> {
     val rfps = (cas1RequestForPlacementService.getRequestsForPlacementByApplication(applicationId, requestingUser = null) as CasResult.Success).value
 
     return rfps.flatMap { rfp ->
+      val withdrawalDate = if (rfp.isWithdrawn) cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(rfp) else null
 
       if (rfp.placements.isEmpty()) {
+        val rejectionReason = if (rfp.decision == PlacementApplicationDecision.REJECTED) cas1RequestForPlacementService.getRequestForPlacementRejectionReason(rfp) else null
+
         listOf(
-          Cas1PlacementHistory(
-            dateApplied = rfp.statusSetDate,
-            requestForPlacementStatus = rfp.status,
-            withdrawalReason = rfp.withdrawalReason,
-            placementStatus = null,
-            premises = null,
+          transformer.transformToCas1PlacementPair(
+            rfp = rfp,
+            rejectionReason = rejectionReason,
+            withdrawalDate = withdrawalDate,
           ),
         )
       } else {
         rfp.placements.map { placement ->
-          val premises = cas1PremisesService.findPremisesById(placement.premises.id)
-            ?.let {
-              Cas1ExternalPremisesDto(
-                startDate = placement.actualArrivalDate ?: placement.expectedArrivalDate,
-                endDate = placement.actualDepartureDate ?: placement.expectedDepartureDate,
-                postcode = it.postcode,
-                addressLine1 = it.addressLine1,
-                addressLine2 = it.addressLine2,
-                town = it.town,
-              )
-            }
+          val premisesEntity = cas1PremisesService.findPremisesById(placement.premises.id)
 
-          Cas1PlacementHistory(
-            dateApplied = requireNotNull(placement.statusSetDate),
-            requestForPlacementStatus = rfp.status,
-            withdrawalReason = rfp.withdrawalReason,
-            placementStatus = placement.status,
-            premises = premises,
+          transformer.transformToCas1PlacementPair(
+            rfp = rfp,
+            rejectionReason = null,
+            withdrawalDate = withdrawalDate,
+            placement = placement,
+            premises = premisesEntity,
           )
         }
       }
@@ -72,29 +65,32 @@ class Cas1ExternalApplicationService(
   fun getSuitableApplicationByCrn(crn: String): Cas1SuitableApplication? = approvedPremisesApplicationRepository.findByCrn(crn)
     .maxWithOrNull(mostSuitableApplication)
     ?.let { application ->
-
-      val placementHistories = getPlacementHistories(application.id)
+      val placementPairs = getPlacementPairs(application.id)
 
       val today = LocalDate.now()
 
-      val suitablePlacement =
-        placementHistories.lastOrNull { it.dateApplied >= today }
-          ?: placementHistories.firstOrNull { it.dateApplied < today }
+      val pastPairs = placementPairs
+        .filter { it.dateApplied < today }
+        .sortedByDescending { it.dateApplied }
 
-      Cas1SuitableApplication(
-        id = application.id,
-        applicationStatus = application.status,
-        requestForPlacementStatus = suitablePlacement?.requestForPlacementStatus,
-        placementStatus = suitablePlacement?.placementStatus,
-        premises = suitablePlacement?.premises,
-        uiUrl = cas1ApplicationUrlTemplate.replace("#id", application.id.toString()),
+      val suitablePlacementPair = placementPairs
+        .lastOrNull { it.dateApplied >= today }
+        ?: pastPairs.firstOrNull()
+
+      val placementHistory = pastPairs
+        .filterNot { it == suitablePlacementPair }
+
+      transformer.transformToCas1SuitableApplication(
+        application = application,
+        suitablePlacementPair = suitablePlacementPair,
+        placementHistory = placementHistory,
       )
     }
 
   fun getCurrentPremisesByCrn(crn: String): Cas1ExternalPremisesDto? = approvedPremisesApplicationRepository.findByCrn(crn)
     .sortedWith(mostSuitableApplication).firstNotNullOfOrNull { application ->
-      getPlacementHistories(application.id)
-        .firstOrNull { it.placementStatus == Cas1SpaceBookingStatus.ARRIVED }?.premises
+      getPlacementPairs(application.id)
+        .firstOrNull { it.placement?.status == Cas1SpaceBookingStatus.ARRIVED }?.placement?.premises
     }
 
   @SuppressWarnings("MagicNumber")
@@ -111,13 +107,5 @@ class Cas1ExternalApplicationService(
     ApprovedPremisesApplicationStatus.PENDING_PLACEMENT_REQUEST to 9,
     ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT to 10,
     ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED to 11,
-  )
-
-  data class Cas1PlacementHistory(
-    val dateApplied: LocalDate,
-    val requestForPlacementStatus: RequestForPlacementStatus,
-    val placementStatus: Cas1SpaceBookingStatus?,
-    val premises: Cas1ExternalPremisesDto?,
-    val withdrawalReason: WithdrawPlacementRequestReason?,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/scheduled/Cas1ExpiredApplicationsScheduledJob.kt
@@ -29,7 +29,7 @@ class Cas1ExpiredApplicationsScheduledJob(
   @Scheduled(cron = "0 0 2 * * ?")
   @SchedulerLock(name = "cas1_expire_applications", lockAtMostFor = "5m", lockAtLeastFor = "1m")
   fun expireApplications() {
-    val applicationIds = applicationRepository.findAllExpiredApplications()
+    val applicationIds = applicationRepository.findAllExpiredApplications(ApplicationRepository.APPLICATION_EXPIRY_DAYS)
 
     log.info("There are ${applicationIds.size} applications to update.")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/RequestForPlacementTransformer.kt
@@ -13,17 +13,31 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBook
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
 import java.time.LocalDate
 
 @Component
 class RequestForPlacementTransformer(
   private val jsonMapper: JsonMapper,
+  private val cas1AssessmentTransformer: Cas1AssessmentTransformer,
 ) {
   fun transformPlacementApplicationEntityToApi(
     placementApplicationEntity: PlacementApplicationEntity,
     canBeDirectlyWithdrawn: Boolean,
   ): RequestForPlacement {
     val statusAndWhen = placementApplicationEntity.deriveStatus()
+    val requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
+      arrival = placementApplicationEntity.expectedArrival!!,
+      arrivalFlexible = placementApplicationEntity.expectedArrivalFlexible,
+      duration = placementApplicationEntity.requestedDuration!!,
+    )
+    val authorisedPlacementPeriod = placementApplicationEntity.authorisedDuration?.let {
+      Cas1RequestedPlacementPeriod(
+        arrival = placementApplicationEntity.expectedArrival!!,
+        arrivalFlexible = placementApplicationEntity.expectedArrivalFlexible,
+        duration = it,
+      )
+    }
     return RequestForPlacement(
       id = placementApplicationEntity.id,
       createdByUserId = placementApplicationEntity.createdByUser.id,
@@ -35,18 +49,8 @@ class RequestForPlacementTransformer(
         RequestForPlacementType.manual
       },
       placementDates = listOf(placementApplicationEntity.placementDates()!!.toApiType()),
-      requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
-        arrival = placementApplicationEntity.expectedArrival!!,
-        arrivalFlexible = placementApplicationEntity.expectedArrivalFlexible,
-        duration = placementApplicationEntity.requestedDuration!!,
-      ),
-      authorisedPlacementPeriod = placementApplicationEntity.authorisedDuration?.let {
-        Cas1RequestedPlacementPeriod(
-          arrival = placementApplicationEntity.expectedArrival!!,
-          arrivalFlexible = placementApplicationEntity.expectedArrivalFlexible,
-          duration = it,
-        )
-      },
+      requestedPlacementPeriod = requestedPlacementPeriod,
+      authorisedPlacementPeriod = authorisedPlacementPeriod,
       submittedAt = placementApplicationEntity.submittedAt?.toInstant(),
       requestReviewedAt = placementApplicationEntity.decisionMadeAt?.toInstant(),
       document = placementApplicationEntity.document?.let(jsonMapper::readTree),
@@ -57,8 +61,13 @@ class RequestForPlacementTransformer(
       sentenceType = placementApplicationEntity.sentenceType?.let { SentenceTypeOption.valueOf(it) },
       releaseType = placementApplicationEntity.releaseType?.apiType,
       situation = placementApplicationEntity.situation?.let { SituationOption.valueOf(it) },
+      decision = placementApplicationEntity.decision,
+      submittedBy = cas1AssessmentTransformer.transformToStaffDto(placementApplicationEntity.createdByUser),
+      canonicalPlacementPeriod = getCanonicalPlacementPeriod(authorisedPlacementPeriod, requestedPlacementPeriod),
     )
   }
+
+  private fun getCanonicalPlacementPeriod(authorisedPlacementPeriod: Cas1RequestedPlacementPeriod?, requestedPlacementPeriod: Cas1RequestedPlacementPeriod) = authorisedPlacementPeriod ?: requestedPlacementPeriod
 
   /**
    * This should only be used for placement requests for the application's arrival date.
@@ -78,23 +87,24 @@ class RequestForPlacementTransformer(
 
     val application = placementRequestEntity.application
     val statusAndWhen = placementRequestEntity.deriveStatus()
-
+    val requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
+      arrival = placementRequestEntity.expectedArrival,
+      arrivalFlexible = null,
+      duration = placementRequestEntity.duration,
+    )
+    val authorisedPlacementPeriod = Cas1RequestedPlacementPeriod(
+      arrival = placementRequestEntity.expectedArrival,
+      arrivalFlexible = null,
+      duration = placementRequestEntity.duration,
+    )
     return RequestForPlacement(
       id = placementRequestEntity.id,
       createdByUserId = placementRequestEntity.application.createdByUser.id,
       createdAt = placementRequestEntity.createdAt.toInstant(),
       isWithdrawn = placementRequestEntity.isWithdrawn,
       type = RequestForPlacementType.automatic,
-      requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
-        arrival = placementRequestEntity.expectedArrival,
-        arrivalFlexible = null,
-        duration = placementRequestEntity.duration,
-      ),
-      authorisedPlacementPeriod = Cas1RequestedPlacementPeriod(
-        arrival = placementRequestEntity.expectedArrival,
-        arrivalFlexible = null,
-        duration = placementRequestEntity.duration,
-      ),
+      requestedPlacementPeriod = requestedPlacementPeriod,
+      authorisedPlacementPeriod = authorisedPlacementPeriod,
       placementDates = listOf(
         PlacementDates(
           expectedArrival = placementRequestEntity.expectedArrival,
@@ -111,6 +121,9 @@ class RequestForPlacementTransformer(
       sentenceType = application.sentenceType?.let { SentenceTypeOption.valueOf(it) },
       releaseType = application.releaseType?.apiType,
       situation = application.situation?.let { SituationOption.valueOf(it) },
+      decision = PlacementApplicationDecision.ACCEPTED,
+      submittedBy = cas1AssessmentTransformer.transformToStaffDto(application.createdByUser),
+      canonicalPlacementPeriod = getCanonicalPlacementPeriod(authorisedPlacementPeriod, requestedPlacementPeriod),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/Cas1AssessmentTransformer.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1Assessment
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1AssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1PlacementPairDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ReferralHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
@@ -19,7 +20,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessm
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonInfoResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.PersonRisks
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external.Cas1ExternalApplicationService.Cas1PlacementHistory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApplicationsTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.PersonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RisksTransformer
@@ -82,7 +82,7 @@ class Cas1AssessmentTransformer(
     dueAt = ase.dueAt!!,
   )
 
-  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity, placementHistories: List<Cas1PlacementHistory>): List<Cas1ReferralHistory> {
+  fun transformDomainToApiCas1ReferralHistory(entity: ApprovedPremisesAssessmentEntity, placementHistory: List<Cas1PlacementPairDto>): List<Cas1ReferralHistory> {
     val application = entity.cas1Application()
 
     val referralHistory = Cas1ReferralHistory(
@@ -102,13 +102,13 @@ class Cas1AssessmentTransformer(
       withdrawalReason = null,
     )
 
-    return placementHistories.map {
+    return placementHistory.map {
       referralHistory.copy(
         date = it.dateApplied,
-        placementAddress = toPlacementAddress(it.premises),
-        placementStatus = it.placementStatus,
-        requestForPlacementStatus = it.requestForPlacementStatus,
-        withdrawalReason = it.withdrawalReason,
+        placementAddress = toPlacementAddress(it.placement?.premises),
+        placementStatus = it.placement?.status,
+        requestForPlacementStatus = it.requestForPlacement?.status,
+        withdrawalReason = it.requestForPlacement?.withdrawalReason,
       )
     }.ifEmpty { listOf(referralHistory) }
   }
@@ -155,5 +155,5 @@ class Cas1AssessmentTransformer(
     else -> null
   }
 
-  private fun transformToStaffDto(user: UserEntity) = Cas1StaffDto(user.name, user.deliusUsername, user.deliusStaffCode)
+  fun transformToStaffDto(user: UserEntity) = Cas1StaffDto(user.name, user.deliusUsername, user.deliusStaffCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
@@ -81,7 +81,11 @@ class Cas1ExternalApplicationTransformer(
     )
   }
 
-  private fun getCancellationReason(placement: Cas1SpaceBookingShortSummary?): String? = if (placement?.cancellation?.reason?.name == CancellationReasonRepository.CAS1_OTHER_NAME) placement.cancellation.reasonNotes else placement?.cancellation?.reason?.name
+  private fun getCancellationReason(placement: Cas1SpaceBookingShortSummary?): String? = if (placement?.cancellation?.reason?.name == CancellationReasonRepository.CAS1_OTHER_NAME) {
+    placement.cancellation.reasonNotes
+  } else {
+    placement?.cancellation?.reason?.name
+  }
 
   fun transformToCas1SuitableApplication(
     application: ApprovedPremisesApplicationEntity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
@@ -44,7 +44,7 @@ class Cas1ExternalApplicationTransformer(
     withdrawalDate: LocalDate?,
     placement: Cas1SpaceBookingShortSummary?,
   ) = Cas1ExternalRequestForPlacementDto(
-    decision = rfp.decision,
+    decision = rfp.decision?.apiValue,
     rejectionReason = rejectionReason,
     submittedBy = rfp.submittedBy,
     submittedAt = rfp.submittedAt?.toLocalDate(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
@@ -80,7 +81,7 @@ class Cas1ExternalApplicationTransformer(
     )
   }
 
-  private fun getCancellationReason(placement: Cas1SpaceBookingShortSummary?): String? = if (placement?.cancellation?.reason?.name == "Other") placement.cancellation.reasonNotes else placement?.cancellation?.reason?.name
+  private fun getCancellationReason(placement: Cas1SpaceBookingShortSummary?): String? = if (placement?.cancellation?.reason?.name == CancellationReasonRepository.CAS1_OTHER_NAME) placement.cancellation.reasonNotes else placement?.cancellation?.reason?.name
 
   fun transformToCas1SuitableApplication(
     application: ApprovedPremisesApplicationEntity,
@@ -117,7 +118,7 @@ class Cas1ExternalApplicationTransformer(
   private fun transformToAssessment(
     latestAssessment: AssessmentEntity,
   ) = Cas1ExternalAssessmentDto(
-    decision = latestAssessment.decision,
+    decision = cas1AssessmentTransformer.transformJpaDecisionToApi(latestAssessment.decision),
     rejectionRationale = latestAssessment.rejectionRationale,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas1/external/Cas1ExternalApplicationTransformer.kt
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.external
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalApplicationDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalAssessmentDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPlacementDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalRequestForPlacementDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1PlacementPairDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ApprovedPremisesEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
+import java.time.LocalDate
+
+@Component
+class Cas1ExternalApplicationTransformer(
+  private val cas1AssessmentTransformer: Cas1AssessmentTransformer,
+  private val cas1ApplicationService: Cas1ApplicationService,
+  @Value($$"${url-templates.frontend.application}") private val cas1ApplicationUrlTemplate: String,
+) {
+
+  fun transformToCas1PlacementPair(
+    rfp: RequestForPlacement,
+    rejectionReason: String? = null,
+    withdrawalDate: LocalDate? = null,
+    placement: Cas1SpaceBookingShortSummary? = null,
+    premises: ApprovedPremisesEntity? = null,
+  ) = Cas1PlacementPairDto(
+    dateApplied = placement?.statusSetDate ?: rfp.statusSetDate,
+    requestForPlacement = transformToRequestForPlacement(rfp, rejectionReason, withdrawalDate, placement),
+    placement = placement?.let { transformToPlacement(it, premises) },
+  )
+
+  private fun transformToRequestForPlacement(
+    rfp: RequestForPlacement,
+    rejectionReason: String?,
+    withdrawalDate: LocalDate?,
+    placement: Cas1SpaceBookingShortSummary?,
+  ) = Cas1ExternalRequestForPlacementDto(
+    decision = rfp.decision,
+    rejectionReason = rejectionReason,
+    submittedBy = rfp.submittedBy,
+    submittedAt = rfp.submittedAt?.toLocalDate(),
+    withdrawalReason = if (rfp.isWithdrawn) rfp.withdrawalReason else null,
+    withdrawalDate = withdrawalDate,
+    expectedArrivalDate = placement?.expectedArrivalDate ?: rfp.canonicalPlacementPeriod.arrival,
+    durationDays = rfp.canonicalPlacementPeriod.duration,
+    status = rfp.status,
+  )
+
+  private fun transformToPlacement(
+    placement: Cas1SpaceBookingShortSummary,
+    premises: ApprovedPremisesEntity?,
+  ) = Cas1ExternalPlacementDto(
+    actualArrivalDate = placement.actualArrivalDate,
+    actualDepartureDate = placement.actualDepartureDate,
+    cancellationReason = getCancellationReason(placement),
+    premises = premises?.let { transformToPremises(placement, it) },
+    status = placement.status,
+  )
+
+  private fun transformToPremises(
+    placement: Cas1SpaceBookingShortSummary?,
+    premises: ApprovedPremisesEntity?,
+  ) = premises?.let {
+    Cas1ExternalPremisesDto(
+      startDate = placement?.actualArrivalDate ?: placement?.expectedArrivalDate,
+      endDate = placement?.actualDepartureDate ?: placement?.expectedDepartureDate,
+      postcode = it.postcode,
+      addressLine1 = it.addressLine1,
+      addressLine2 = it.addressLine2,
+      town = it.town,
+    )
+  }
+
+  private fun getCancellationReason(placement: Cas1SpaceBookingShortSummary?): String? = if (placement?.cancellation?.reason?.name == "Other") placement.cancellation.reasonNotes else placement?.cancellation?.reason?.name
+
+  fun transformToCas1SuitableApplication(
+    application: ApprovedPremisesApplicationEntity,
+    suitablePlacementPair: Cas1PlacementPairDto?,
+    placementHistory: List<Cas1PlacementPairDto>,
+  ): Cas1SuitableApplication {
+    val latestAssessment = application.getLatestAssessment()
+    return Cas1SuitableApplication(
+      id = application.id,
+      uiUrl = cas1ApplicationUrlTemplate.replace("#id", application.id.toString()),
+      applicationStatus = application.status,
+      requestForPlacementStatus = suitablePlacementPair?.requestForPlacement?.status,
+      placementStatus = suitablePlacementPair?.placement?.status,
+      premises = suitablePlacementPair?.placement?.premises,
+      application = transformToApplication(application),
+      assessment = latestAssessment?.let { transformToAssessment(it) },
+      requestForPlacement = suitablePlacementPair?.requestForPlacement,
+      placement = suitablePlacementPair?.placement,
+      placementHistory = placementHistory,
+    )
+  }
+
+  private fun transformToApplication(
+    application: ApprovedPremisesApplicationEntity,
+  ) = Cas1ExternalApplicationDto(
+    createdAt = application.createdAt,
+    createdBy = cas1AssessmentTransformer.transformToStaffDto(application.createdByUser),
+    submittedAt = application.submittedAt,
+    expiresAt = cas1ApplicationService.getApplicationExpiresAt(application),
+    status = application.status,
+    id = application.id,
+  )
+
+  private fun transformToAssessment(
+    latestAssessment: AssessmentEntity,
+  ) = Cas1ExternalAssessmentDto(
+    decision = latestAssessment.decision,
+    rejectionRationale = latestAssessment.rejectionRationale,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
@@ -38,6 +37,8 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as AssessmentDecisionApi
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as AssessmentDecisionJpa
 
 class Cas1ExternalApplicationsTest : IntegrationTestBase() {
   private val crn = "ABC1234"
@@ -78,7 +79,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecision.ACCEPTED,
+            decision = AssessmentDecisionJpa.ACCEPTED,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED
@@ -158,7 +159,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = assessment.decision,
+                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
@@ -213,7 +214,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecision.REJECTED,
+            decision = AssessmentDecisionJpa.REJECTED,
           ) { assessment, application ->
 
             assessment.rejectionRationale = "NO SPACE"
@@ -239,7 +240,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = assessment.decision,
+                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
                 rejectionRationale = assessment.rejectionRationale,
               ),
               requestForPlacement = null,
@@ -271,7 +272,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecision.ACCEPTED,
+            decision = AssessmentDecisionJpa.ACCEPTED,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.REJECTED
@@ -325,7 +326,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = assessment.decision,
+                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
@@ -367,7 +368,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecision.ACCEPTED,
+            decision = AssessmentDecisionJpa.ACCEPTED,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.WITHDRAWN
@@ -472,7 +473,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = assessment.decision,
+                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
@@ -527,7 +528,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecision.ACCEPTED,
+            decision = AssessmentDecisionJpa.ACCEPTED,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.WITHDRAWN
@@ -613,7 +614,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = assessment.decision,
+                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalReq
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.PlacementApplicationDecisionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.MatchRequestWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementAssessedFactory
@@ -161,8 +162,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
-
-                decision = placementApplication.decision,
+                decision = placementApplication.decision?.apiValue,
                 rejectionReason = null,
                 submittedBy = transformToStaffDto(placementApplication.createdByUser),
                 submittedAt = placementApplication.submittedAt?.toLocalDate(),
@@ -329,7 +329,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
-                decision = placementApplication.decision,
+                decision = placementApplication.decision?.apiValue,
                 rejectionReason = envelopedData.eventDetails.decisionSummary,
                 submittedBy = transformToStaffDto(placementApplication.createdByUser),
                 submittedAt = placementApplication.submittedAt?.toLocalDate(),
@@ -476,7 +476,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
-                decision = placementApplication.decision,
+                decision = placementApplication.decision?.apiValue,
                 rejectionReason = null,
                 submittedBy = transformToStaffDto(placementApplication.createdByUser),
                 submittedAt = placementApplication.submittedAt?.toLocalDate(),
@@ -617,7 +617,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
-                decision = PlacementApplicationDecision.ACCEPTED,
+                decision = PlacementApplicationDecisionDto.accepted,
                 rejectionReason = null,
                 submittedBy = transformToStaffDto(application.createdByUser),
                 submittedAt = placementRequest.createdAt.toLocalDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
@@ -37,7 +37,6 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as AssessmentDecisionApi
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as AssessmentDecisionJpa
 
 class Cas1ExternalApplicationsTest : IntegrationTestBase() {
@@ -73,13 +72,14 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
 
     @Test
     fun `Get suitable application returns ok`() {
+      val assessmentDecisionJpa = AssessmentDecisionJpa.ACCEPTED
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           givenAnAssessmentForApprovedPremises(
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecisionJpa.ACCEPTED,
+            decision = assessmentDecisionJpa,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED
@@ -159,7 +159,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
+                decision = assessmentDecisionJpa.apiValue,
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
@@ -208,13 +208,14 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
 
     @Test
     fun `Get suitable rejected application returns ok`() {
+      val assessmentDecisionJpa = AssessmentDecisionJpa.REJECTED
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           givenAnAssessmentForApprovedPremises(
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecisionJpa.REJECTED,
+            decision = assessmentDecisionJpa,
           ) { assessment, application ->
 
             assessment.rejectionRationale = "NO SPACE"
@@ -240,7 +241,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
+                decision = assessmentDecisionJpa.apiValue,
                 rejectionRationale = assessment.rejectionRationale,
               ),
               requestForPlacement = null,
@@ -266,13 +267,14 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
 
     @Test
     fun `Get suitable application returns ok and placement is rejected`() {
+      val assessmentDecisionJpa = AssessmentDecisionJpa.ACCEPTED
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           givenAnAssessmentForApprovedPremises(
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecisionJpa.ACCEPTED,
+            decision = assessmentDecisionJpa,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.REJECTED
@@ -326,7 +328,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
+                decision = assessmentDecisionJpa.apiValue,
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
@@ -362,13 +364,14 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
 
     @Test
     fun `Get suitable application with placement application withdrawn returns ok`() {
+      val assessmentDecisionJpa = AssessmentDecisionJpa.ACCEPTED
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           givenAnAssessmentForApprovedPremises(
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecisionJpa.ACCEPTED,
+            decision = assessmentDecisionJpa,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.WITHDRAWN
@@ -473,7 +476,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
+                decision = assessmentDecisionJpa.apiValue,
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(
@@ -522,13 +525,14 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
 
     @Test
     fun `Get suitable application with placement request withdrawn returns ok`() {
+      val assessmentDecisionJpa = AssessmentDecisionJpa.ACCEPTED
       givenAUser { user, _ ->
         givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
           givenAnAssessmentForApprovedPremises(
             allocatedToUser = null,
             createdByUser = user,
             submittedAt = assessmentSubmittedAt,
-            decision = AssessmentDecisionJpa.ACCEPTED,
+            decision = assessmentDecisionJpa,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.WITHDRAWN
@@ -614,7 +618,7 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 id = application.id,
               ),
               assessment = Cas1ExternalAssessmentDto(
-                decision = AssessmentDecisionApi.forValue(assessment.decision.toString()),
+                decision = assessmentDecisionJpa.apiValue,
                 rejectionRationale = null,
               ),
               requestForPlacement = Cas1ExternalRequestForPlacementDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/external/Cas1ExternalApplicationsTest.kt
@@ -3,10 +3,21 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.extern
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.Cas1DomainEventEnvelope
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalApplicationDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalAssessmentDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPlacementDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalRequestForPlacementDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.MatchRequestWithdrawnFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.PlacementApplicationWithdrawnFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.RequestForPlacementAssessedFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAProbationRegion
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenASingleAccommodationServiceClientCredentialsApiCall
@@ -14,12 +25,26 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.given
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnAssessmentForApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 class Cas1ExternalApplicationsTest : IntegrationTestBase() {
   private val crn = "ABC1234"
+  private val applicationSubmittedAt = OffsetDateTime.parse("2023-01-01T12:00:00.00Z")
+    .truncatedTo(ChronoUnit.MICROS)
+  private val assessmentSubmittedAt = OffsetDateTime.parse("2023-07-01T12:00:00.00Z")
+    .truncatedTo(ChronoUnit.MICROS)
+  fun transformToStaffDto(user: UserEntity) = Cas1StaffDto(user.name, user.deliusUsername, user.deliusStaffCode)
 
   @Nested
   inner class GetSuitableApplicationsByCrn {
@@ -51,9 +76,12 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
           givenAnAssessmentForApprovedPremises(
             allocatedToUser = null,
             createdByUser = user,
+            submittedAt = assessmentSubmittedAt,
+            decision = AssessmentDecision.ACCEPTED,
           ) { assessment, application ->
 
             application.status = ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED
+            application.submittedAt = applicationSubmittedAt
 
             approvedPremisesApplicationRepository.save(application)
 
@@ -65,11 +93,24 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
               withDesirableCriteria(listOf())
             }
 
+            val placementApplication = placementApplicationFactory.produceAndPersist {
+              withApplication(application)
+              withDecision(PlacementApplicationDecision.ACCEPTED)
+              withCreatedAt(OffsetDateTime.parse("2007-08-03T10:15:30+01"))
+              withCreatedByUser(user)
+              withSubmittedAt(OffsetDateTime.now())
+              withReallocatedAt(null)
+              withAuthorisedDuration(20)
+              withExpectedArrival(LocalDate.now().plusDays(10))
+              withRequestedDuration(10)
+            }
+
             val placementRequest = placementRequestFactory.produceAndPersist {
               withCreatedAt(OffsetDateTime.parse("2007-08-03T10:15:30+01"))
               withApplication(application)
               withAssessment(assessment)
               withPlacementRequirements(placementRequirements)
+              withPlacementApplication(placementApplication)
             }
 
             val region = givenAProbationRegion()
@@ -107,6 +148,500 @@ class Cas1ExternalApplicationsTest : IntegrationTestBase() {
                 postcode = premises.postcode,
               ),
               uiUrl = "http://frontend/applications/${application.id}",
+              application = Cas1ExternalApplicationDto(
+                createdAt = application.createdAt,
+                createdBy = transformToStaffDto(user),
+                submittedAt = applicationSubmittedAt,
+                expiresAt = assessment.submittedAt?.toLocalDate()?.plusDays(365),
+                status = ApprovedPremisesApplicationStatus.PLACEMENT_ALLOCATED,
+                id = application.id,
+              ),
+              assessment = Cas1ExternalAssessmentDto(
+                decision = assessment.decision,
+                rejectionRationale = null,
+              ),
+              requestForPlacement = Cas1ExternalRequestForPlacementDto(
+
+                decision = placementApplication.decision,
+                rejectionReason = null,
+                submittedBy = transformToStaffDto(placementApplication.createdByUser),
+                submittedAt = placementApplication.submittedAt?.toLocalDate(),
+                withdrawalReason = null,
+                withdrawalDate = null,
+                expectedArrivalDate = booking.expectedArrivalDate,
+                durationDays = 20,
+                status = RequestForPlacementStatus.placementBooked,
+              ),
+              placement = Cas1ExternalPlacementDto(
+                actualArrivalDate = booking.actualArrivalDate,
+                actualDepartureDate = booking.actualDepartureDate,
+                cancellationReason = booking.cancellationReason?.name,
+                premises = Cas1ExternalPremisesDto(
+                  startDate = booking.expectedArrivalDate,
+                  endDate = booking.expectedDepartureDate,
+                  addressLine1 = premises.addressLine1,
+                  addressLine2 = premises.addressLine2,
+                  town = premises.town,
+                  postcode = premises.postcode,
+                ),
+                status = Cas1SpaceBookingStatus.UPCOMING,
+              ),
+              placementHistory = emptyList(),
+            )
+
+            val response = webTestClient.get()
+              .uri("/cas1/external/cases/${application.crn}/applications/suitable")
+              .header("Authorization", "Bearer $clientCredentialsJwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody(Cas1SuitableApplication::class.java)
+              .returnResult()
+              .responseBody
+
+            assertThat(response).isEqualTo(suitableApplication)
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get suitable rejected application returns ok`() {
+      givenAUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          givenAnAssessmentForApprovedPremises(
+            allocatedToUser = null,
+            createdByUser = user,
+            submittedAt = assessmentSubmittedAt,
+            decision = AssessmentDecision.REJECTED,
+          ) { assessment, application ->
+
+            assessment.rejectionRationale = "NO SPACE"
+            application.status = ApprovedPremisesApplicationStatus.REJECTED
+            application.submittedAt = applicationSubmittedAt
+
+            approvedPremisesAssessmentRepository.save(assessment)
+            approvedPremisesApplicationRepository.save(application)
+
+            val suitableApplication = Cas1SuitableApplication(
+              id = application.id,
+              applicationStatus = ApprovedPremisesApplicationStatus.REJECTED,
+              requestForPlacementStatus = null,
+              placementStatus = null,
+              premises = null,
+              uiUrl = "http://frontend/applications/${application.id}",
+              application = Cas1ExternalApplicationDto(
+                createdAt = application.createdAt,
+                createdBy = transformToStaffDto(user),
+                submittedAt = applicationSubmittedAt,
+                expiresAt = null,
+                status = ApprovedPremisesApplicationStatus.REJECTED,
+                id = application.id,
+              ),
+              assessment = Cas1ExternalAssessmentDto(
+                decision = assessment.decision,
+                rejectionRationale = assessment.rejectionRationale,
+              ),
+              requestForPlacement = null,
+              placement = null,
+              placementHistory = emptyList(),
+            )
+
+            val response = webTestClient.get()
+              .uri("/cas1/external/cases/${application.crn}/applications/suitable")
+              .header("Authorization", "Bearer $clientCredentialsJwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody(Cas1SuitableApplication::class.java)
+              .returnResult()
+              .responseBody
+
+            assertThat(response).isEqualTo(suitableApplication)
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get suitable application returns ok and placement is rejected`() {
+      givenAUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          givenAnAssessmentForApprovedPremises(
+            allocatedToUser = null,
+            createdByUser = user,
+            submittedAt = assessmentSubmittedAt,
+            decision = AssessmentDecision.ACCEPTED,
+          ) { assessment, application ->
+
+            application.status = ApprovedPremisesApplicationStatus.REJECTED
+            application.submittedAt = applicationSubmittedAt
+
+            approvedPremisesApplicationRepository.save(application)
+
+            val placementApplication = placementApplicationFactory.produceAndPersist {
+              withApplication(application)
+              withDecision(PlacementApplicationDecision.REJECTED)
+              withCreatedAt(OffsetDateTime.parse("2007-08-03T10:15:30+01"))
+              withCreatedByUser(user)
+              withSubmittedAt(OffsetDateTime.now())
+              withReallocatedAt(null)
+              withAuthorisedDuration(20)
+              withExpectedArrival(LocalDate.now().plusDays(10))
+              withRequestedDuration(10)
+              withDecisionMadeAt(OffsetDateTime.now())
+            }
+
+            val envelopedData = Cas1DomainEventEnvelope(
+              id = UUID.randomUUID(),
+              timestamp = Instant.now(),
+              eventType = EventType.requestForPlacementAssessed,
+              eventDetails = RequestForPlacementAssessedFactory()
+                .withPlacementApplicationId(placementApplication.id)
+                .withDecisionSummary("NO SPACE")
+                .withApplicationId(application.id)
+                .produce(),
+            )
+
+            domainEventFactory.produceAndPersist {
+              withData(jsonMapper.writeValueAsString(envelopedData))
+              withType(DomainEventType.APPROVED_PREMISES_REQUEST_FOR_PLACEMENT_ASSESSED)
+              withOccurredAt(OffsetDateTime.now().minusDays(6))
+            }
+
+            val suitableApplication = Cas1SuitableApplication(
+              id = application.id,
+              applicationStatus = ApprovedPremisesApplicationStatus.REJECTED,
+              requestForPlacementStatus = RequestForPlacementStatus.requestRejected,
+              placementStatus = null,
+              premises = null,
+              uiUrl = "http://frontend/applications/${application.id}",
+              application = Cas1ExternalApplicationDto(
+                createdAt = application.createdAt,
+                createdBy = transformToStaffDto(user),
+                submittedAt = applicationSubmittedAt,
+                expiresAt = assessment.submittedAt?.toLocalDate()?.plusDays(365),
+                status = ApprovedPremisesApplicationStatus.REJECTED,
+                id = application.id,
+              ),
+              assessment = Cas1ExternalAssessmentDto(
+                decision = assessment.decision,
+                rejectionRationale = null,
+              ),
+              requestForPlacement = Cas1ExternalRequestForPlacementDto(
+                decision = placementApplication.decision,
+                rejectionReason = envelopedData.eventDetails.decisionSummary,
+                submittedBy = transformToStaffDto(placementApplication.createdByUser),
+                submittedAt = placementApplication.submittedAt?.toLocalDate(),
+                withdrawalReason = null,
+                withdrawalDate = null,
+                expectedArrivalDate = placementApplication.expectedArrival,
+                durationDays = 20,
+                status = RequestForPlacementStatus.requestRejected,
+              ),
+              placement = null,
+              placementHistory = emptyList(),
+            )
+
+            val response = webTestClient.get()
+              .uri("/cas1/external/cases/${application.crn}/applications/suitable")
+              .header("Authorization", "Bearer $clientCredentialsJwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody(Cas1SuitableApplication::class.java)
+              .returnResult()
+              .responseBody
+
+            assertThat(response).isEqualTo(suitableApplication)
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get suitable application with placement application withdrawn returns ok`() {
+      givenAUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          givenAnAssessmentForApprovedPremises(
+            allocatedToUser = null,
+            createdByUser = user,
+            submittedAt = assessmentSubmittedAt,
+            decision = AssessmentDecision.ACCEPTED,
+          ) { assessment, application ->
+
+            application.status = ApprovedPremisesApplicationStatus.WITHDRAWN
+            application.submittedAt = applicationSubmittedAt
+
+            approvedPremisesApplicationRepository.save(application)
+
+            val placementRequirements = placementRequirementsFactory.produceAndPersist {
+              withApplication(application)
+              withAssessment(assessment)
+              withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
+              withEssentialCriteria(listOf())
+              withDesirableCriteria(listOf())
+            }
+
+            val placementApplication = placementApplicationFactory.produceAndPersist {
+              withIsWithdrawn(true)
+              withWithdrawalReason(PlacementApplicationWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST)
+              withApplication(application)
+              withDecision(PlacementApplicationDecision.ACCEPTED)
+              withCreatedAt(OffsetDateTime.parse("2007-08-03T10:15:30+01"))
+              withCreatedByUser(user)
+              withSubmittedAt(OffsetDateTime.now())
+              withReallocatedAt(null)
+              withAuthorisedDuration(20)
+              withExpectedArrival(LocalDate.now().plusDays(10))
+              withRequestedDuration(10)
+            }
+
+            val placementRequest = placementRequestFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.parse("2007-08-03T10:15:30+01"))
+              withApplication(application)
+              withAssessment(assessment)
+              withPlacementRequirements(placementRequirements)
+              withPlacementApplication(placementApplication)
+            }
+
+            val region = givenAProbationRegion()
+
+            val premises = givenAnApprovedPremises(
+              region = region,
+              supportsSpaceBookings = true,
+            )
+
+            val (offender) = givenAnOffender()
+
+            val cancellationReason = cancellationReasonEntityFactory.produceAndPersist {
+              withName("A problem")
+            }
+
+            val booking = cas1SpaceBookingEntityFactory.produceAndPersist {
+              withCrn(offender.otherIds.crn)
+              withPremises(premises)
+              withPlacementRequest(placementRequest)
+              withApplication(placementRequest.application)
+              withCreatedBy(user)
+              withExpectedArrivalDate(LocalDate.now())
+              withExpectedDepartureDate(LocalDate.now().plusDays(10))
+              withActualDepartureDate(null)
+              withActualArrivalDate(null)
+              withCancellationReason(cancellationReason)
+              withCancellationOccurredAt(LocalDate.now().minusDays(10))
+              withCancellationRecordedAt(Instant.now())
+              withCancellationReasonNotes("Notes")
+            }
+
+            val envelopedData = Cas1DomainEventEnvelope(
+              id = UUID.randomUUID(),
+              timestamp = Instant.now(),
+              eventType = EventType.placementApplicationWithdrawn,
+              eventDetails = PlacementApplicationWithdrawnFactory()
+                .withPlacementApplicationId(placementApplication.id)
+                .produce(),
+            )
+
+            val withDrawnDomainEntity = domainEventFactory.produceAndPersist {
+              withData(jsonMapper.writeValueAsString(envelopedData))
+              withType(DomainEventType.APPROVED_PREMISES_PLACEMENT_APPLICATION_WITHDRAWN)
+              withOccurredAt(OffsetDateTime.now().minusDays(6))
+            }
+
+            val suitableApplication = Cas1SuitableApplication(
+              id = application.id,
+              applicationStatus = ApprovedPremisesApplicationStatus.WITHDRAWN,
+              requestForPlacementStatus = RequestForPlacementStatus.requestWithdrawn,
+              placementStatus = Cas1SpaceBookingStatus.CANCELLED,
+              premises = Cas1ExternalPremisesDto(
+                startDate = booking.expectedArrivalDate,
+                endDate = booking.expectedDepartureDate,
+                addressLine1 = premises.addressLine1,
+                addressLine2 = premises.addressLine2,
+                town = premises.town,
+                postcode = premises.postcode,
+              ),
+              uiUrl = "http://frontend/applications/${application.id}",
+              application = Cas1ExternalApplicationDto(
+                createdAt = application.createdAt,
+                createdBy = transformToStaffDto(user),
+                submittedAt = applicationSubmittedAt,
+                expiresAt = assessment.submittedAt?.toLocalDate()?.plusDays(365),
+                status = ApprovedPremisesApplicationStatus.WITHDRAWN,
+                id = application.id,
+              ),
+              assessment = Cas1ExternalAssessmentDto(
+                decision = assessment.decision,
+                rejectionRationale = null,
+              ),
+              requestForPlacement = Cas1ExternalRequestForPlacementDto(
+                decision = placementApplication.decision,
+                rejectionReason = null,
+                submittedBy = transformToStaffDto(placementApplication.createdByUser),
+                submittedAt = placementApplication.submittedAt?.toLocalDate(),
+                withdrawalReason = WithdrawPlacementRequestReason.errorInPlacementRequest,
+                withdrawalDate = withDrawnDomainEntity.occurredAt.toLocalDate(),
+                expectedArrivalDate = booking.expectedArrivalDate,
+                durationDays = 20,
+                status = RequestForPlacementStatus.requestWithdrawn,
+              ),
+              placement = Cas1ExternalPlacementDto(
+                actualArrivalDate = booking.actualArrivalDate,
+                actualDepartureDate = booking.actualDepartureDate,
+                cancellationReason = booking.cancellationReason?.name,
+                status = Cas1SpaceBookingStatus.CANCELLED,
+                premises = Cas1ExternalPremisesDto(
+                  startDate = booking.expectedArrivalDate,
+                  endDate = booking.expectedDepartureDate,
+                  addressLine1 = premises.addressLine1,
+                  addressLine2 = premises.addressLine2,
+                  town = premises.town,
+                  postcode = premises.postcode,
+                ),
+              ),
+              placementHistory = emptyList(),
+            )
+
+            val response = webTestClient.get()
+              .uri("/cas1/external/cases/${application.crn}/applications/suitable")
+              .header("Authorization", "Bearer $clientCredentialsJwt")
+              .exchange()
+              .expectStatus()
+              .isOk
+              .expectBody(Cas1SuitableApplication::class.java)
+              .returnResult()
+              .responseBody
+
+            assertThat(response).isEqualTo(suitableApplication)
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get suitable application with placement request withdrawn returns ok`() {
+      givenAUser { user, _ ->
+        givenASingleAccommodationServiceClientCredentialsApiCall { clientCredentialsJwt ->
+          givenAnAssessmentForApprovedPremises(
+            allocatedToUser = null,
+            createdByUser = user,
+            submittedAt = assessmentSubmittedAt,
+            decision = AssessmentDecision.ACCEPTED,
+          ) { assessment, application ->
+
+            application.status = ApprovedPremisesApplicationStatus.WITHDRAWN
+            application.submittedAt = applicationSubmittedAt
+
+            approvedPremisesApplicationRepository.save(application)
+
+            val placementRequirements = placementRequirementsFactory.produceAndPersist {
+              withApplication(application)
+              withAssessment(assessment)
+              withPostcodeDistrict(postCodeDistrictFactory.produceAndPersist())
+              withEssentialCriteria(listOf())
+              withDesirableCriteria(listOf())
+            }
+
+            val placementRequest = placementRequestFactory.produceAndPersist {
+              withCreatedAt(OffsetDateTime.parse("2007-08-03T10:15:30+01"))
+              withApplication(application)
+              withAssessment(assessment)
+              withPlacementRequirements(placementRequirements)
+              withPlacementApplication(null)
+              withIsWithdrawn(true)
+              withWithdrawalReason(PlacementRequestWithdrawalReason.ERROR_IN_PLACEMENT_REQUEST)
+              withDuration(30)
+            }
+
+            val region = givenAProbationRegion()
+
+            val premises = givenAnApprovedPremises(
+              region = region,
+              supportsSpaceBookings = true,
+            )
+
+            val (offender) = givenAnOffender()
+
+            val booking = cas1SpaceBookingEntityFactory.produceAndPersist {
+              withCrn(offender.otherIds.crn)
+              withPremises(premises)
+              withPlacementRequest(placementRequest)
+              withApplication(placementRequest.application)
+              withCreatedBy(user)
+              withExpectedArrivalDate(LocalDate.now())
+              withExpectedDepartureDate(LocalDate.now().plusDays(10))
+              withActualDepartureDate(null)
+              withActualArrivalDate(null)
+            }
+
+            val envelopedData = Cas1DomainEventEnvelope(
+              id = UUID.randomUUID(),
+              timestamp = Instant.now(),
+              eventType = EventType.matchRequestWithdrawn,
+              eventDetails = MatchRequestWithdrawnFactory()
+                .withMatchRequestId(placementRequest.id)
+                .produce(),
+            )
+
+            val withDrawnDomainEntity = domainEventFactory.produceAndPersist {
+              withData(jsonMapper.writeValueAsString(envelopedData))
+              withType(DomainEventType.APPROVED_PREMISES_MATCH_REQUEST_WITHDRAWN)
+              withOccurredAt(OffsetDateTime.now().minusDays(6))
+            }
+
+            val suitableApplication = Cas1SuitableApplication(
+              id = application.id,
+              applicationStatus = ApprovedPremisesApplicationStatus.WITHDRAWN,
+              requestForPlacementStatus = RequestForPlacementStatus.requestWithdrawn,
+              placementStatus = Cas1SpaceBookingStatus.UPCOMING,
+              premises = Cas1ExternalPremisesDto(
+                startDate = booking.expectedArrivalDate,
+                endDate = booking.expectedDepartureDate,
+                addressLine1 = premises.addressLine1,
+                addressLine2 = premises.addressLine2,
+                town = premises.town,
+                postcode = premises.postcode,
+              ),
+              uiUrl = "http://frontend/applications/${application.id}",
+              application = Cas1ExternalApplicationDto(
+                createdAt = application.createdAt,
+                createdBy = transformToStaffDto(user),
+                submittedAt = application.submittedAt,
+                status = ApprovedPremisesApplicationStatus.WITHDRAWN,
+                expiresAt = assessment.submittedAt?.toLocalDate()?.plusDays(365),
+                id = application.id,
+              ),
+              assessment = Cas1ExternalAssessmentDto(
+                decision = assessment.decision,
+                rejectionRationale = null,
+              ),
+              requestForPlacement = Cas1ExternalRequestForPlacementDto(
+                decision = PlacementApplicationDecision.ACCEPTED,
+                rejectionReason = null,
+                submittedBy = transformToStaffDto(application.createdByUser),
+                submittedAt = placementRequest.createdAt.toLocalDate(),
+                withdrawalReason = WithdrawPlacementRequestReason.errorInPlacementRequest,
+                withdrawalDate = withDrawnDomainEntity.occurredAt.toLocalDate(),
+                expectedArrivalDate = booking.expectedArrivalDate,
+                durationDays = placementRequest.duration,
+                status = RequestForPlacementStatus.requestWithdrawn,
+              ),
+              placement = Cas1ExternalPlacementDto(
+                actualArrivalDate = booking.actualArrivalDate,
+                actualDepartureDate = booking.actualDepartureDate,
+                cancellationReason = booking.cancellationReason?.name,
+                premises = Cas1ExternalPremisesDto(
+                  startDate = booking.expectedArrivalDate,
+                  endDate = booking.expectedDepartureDate,
+                  addressLine1 = premises.addressLine1,
+                  addressLine2 = premises.addressLine2,
+                  town = premises.town,
+                  postcode = premises.postcode,
+                ),
+                status = Cas1SpaceBookingStatus.UPCOMING,
+              ),
+              placementHistory = emptyList(),
             )
 
             val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingShortSummaryFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas1SpaceBookingShortSummaryFactory.kt
@@ -70,6 +70,10 @@ class Cas1SpaceBookingShortSummaryFactory : Factory<Cas1SpaceBookingShortSummary
     this.actualDepartureDate = { actualDepartureDate }
   }
 
+  fun withCancellation(cancellation: Cas1SpaceBookingCancellation?) = apply {
+    this.cancellation = { cancellation }
+  }
+
   fun withPremises(premises: NamedId) = apply {
     this.premises = { premises }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RequestForPlacementFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/RequestForPlacementFactory.kt
@@ -12,6 +12,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOp
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
 import java.time.Instant
 import java.time.LocalDate
@@ -28,6 +30,20 @@ class RequestForPlacementFactory : Factory<RequestForPlacement> {
   private var releaseType: Yielded<ReleaseTypeOption?> = { null }
   private var createdByUserId: Yielded<UUID> = { UUID.randomUUID() }
   private var canBeDirectlyWithdrawn: Yielded<Boolean> = { false }
+  private var requestedPlacementPeriod: Yielded<Cas1RequestedPlacementPeriod> = {
+    Cas1RequestedPlacementPeriod(
+      arrival = LocalDate.now(),
+      arrivalFlexible = null,
+      duration = 14,
+    )
+  }
+  private var canonicalPlacementPeriod: Yielded<Cas1RequestedPlacementPeriod> = {
+    Cas1RequestedPlacementPeriod(
+      arrival = LocalDate.now(),
+      arrivalFlexible = null,
+      duration = 14,
+    )
+  }
   private var type: Yielded<RequestForPlacementType> = { RequestForPlacementType.automatic }
   private var placementDates: Yielded<List<PlacementDates>> = {
     listOf(
@@ -37,16 +53,12 @@ class RequestForPlacementFactory : Factory<RequestForPlacement> {
       ),
     )
   }
-  private var requestedPlacementPeriod: Yielded<Cas1RequestedPlacementPeriod> = {
-    Cas1RequestedPlacementPeriod(
-      arrival = LocalDate.now(),
-      arrivalFlexible = null,
-      duration = 14,
-    )
-  }
+
   private var authorisedPlacementPeriod: Yielded<Cas1RequestedPlacementPeriod?> = { null }
   private var status: Yielded<RequestForPlacementStatus> = { RequestForPlacementStatus.placementBooked }
   private var statusSetDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var submittedBy: Yielded<Cas1StaffDto?> = { null }
+  private var decision: Yielded<PlacementApplicationDecision?> = { null }
   private var requestReviewedAt: Yielded<Instant?> = { null }
   private var placements: Yielded<List<Cas1SpaceBookingShortSummary>> = { emptyList() }
   private var situation: Yielded<SituationOption?> = { null }
@@ -57,6 +69,10 @@ class RequestForPlacementFactory : Factory<RequestForPlacement> {
 
   fun withStatus(status: RequestForPlacementStatus) = apply {
     this.status = { status }
+  }
+
+  fun withSubmittedBy(submittedBy: Cas1StaffDto?) = apply {
+    this.submittedBy = { submittedBy }
   }
 
   fun withStatusSetDate(statusSetDate: LocalDate) = apply {
@@ -79,12 +95,20 @@ class RequestForPlacementFactory : Factory<RequestForPlacement> {
     this.requestedPlacementPeriod = { requestedPlacementPeriod }
   }
 
+  fun withCanonicalPlacementPeriod(canonicalPlacementPeriod: Cas1RequestedPlacementPeriod) = apply {
+    this.canonicalPlacementPeriod = { canonicalPlacementPeriod }
+  }
+
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
 
   fun withDocument(document: String?) = apply {
     this.document = { document }
+  }
+
+  fun withDecision(decision: PlacementApplicationDecision?) = apply {
+    this.decision = { decision }
   }
 
   fun withCreatedAt(createdAt: Instant) = apply {
@@ -143,5 +167,8 @@ class RequestForPlacementFactory : Factory<RequestForPlacement> {
     requestReviewedAt = this.requestReviewedAt(),
     situation = this.situation(),
     placements = this.placements(),
+    submittedBy = this.submittedBy(),
+    decision = this.decision(),
+    canonicalPlacementPeriod = this.canonicalPlacementPeriod(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/MatchRequestWithdrawnFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/MatchRequestWithdrawnFactory.kt
@@ -47,6 +47,10 @@ class MatchRequestWithdrawnFactory : Factory<MatchRequestWithdrawn> {
     this.submittedAt = { submittedAt }
   }
 
+  fun withMatchRequestId(matchRequestId: UUID) = apply {
+    this.matchRequestId = { matchRequestId }
+  }
+
   fun withWithdrawnByStaffMember(staffMember: StaffMember) = apply {
     this.withdrawnByStaffMember = { staffMember }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlacementApplicationWithdrawnFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/events/PlacementApplicationWithdrawnFactory.kt
@@ -30,6 +30,10 @@ class PlacementApplicationWithdrawnFactory : Factory<PlacementApplicationWithdra
     this.applicationId = { applicationId }
   }
 
+  fun withPlacementApplicationId(placementApplicationId: UUID) = apply {
+    this.placementApplicationId = { placementApplicationId }
+  }
+
   fun withApplicationUrl(applicationUrl: String) = apply {
     this.applicationUrl = { applicationUrl }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1DomainEventServiceTest.kt
@@ -92,11 +92,6 @@ class Cas1DomainEventServiceTest {
       .filter { it.cas == DomainEventCas.CAS1 && it.cas1Info!!.emittable }
 
     @JvmStatic
-    fun allEmittableCas1DomainEventTypes() = DomainEventType
-      .entries
-      .filter { it.cas == DomainEventCas.CAS1 && it.cas1Info!!.emittable }
-
-    @JvmStatic
     fun allNonEmittableCas1DomainEventTypes() = DomainEventType
       .entries
       .filter { it.cas == DomainEventCas.CAS1 && !it.cas1Info!!.emittable }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1RequestForPlacementServiceTest.kt
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
+import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas1.model.RequestForPlacementAssessed
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
@@ -18,18 +20,24 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.TierVersionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.factory.TierDtoFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service.CaseService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CaseDtoFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RequestForPlacementFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.Cas1DomainEventEnvelopeFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.events.StaffMemberFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementApplicationService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PlacementRequestService
@@ -55,6 +63,8 @@ class Cas1RequestForPlacementServiceTest {
   private val cas1SpaceBookingRepository = mockk<Cas1SpaceBookingRepository>()
   private val cas1SpaceBookingTransformer = mockk<Cas1SpaceBookingTransformer>()
   private val caseService = mockk<CaseService>()
+  private val domainEventRepository = mockk<DomainEventRepository>()
+  private val jsonMapper = JsonMapper()
 
   private val cas1RequestForPlacementService = Cas1RequestForPlacementService(
     applicationService,
@@ -64,7 +74,9 @@ class Cas1RequestForPlacementServiceTest {
     cas1WithdrawableService,
     cas1SpaceBookingRepository,
     cas1SpaceBookingTransformer,
+    domainEventRepository,
     caseService,
+    jsonMapper,
   )
 
   @BeforeEach
@@ -75,6 +87,11 @@ class Cas1RequestForPlacementServiceTest {
 
   private fun mockRfp(): RequestForPlacement {
     val now = Instant.now()
+    val requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
+      arrival = LocalDate.now(),
+      arrivalFlexible = null,
+      duration = 14,
+    )
     return RequestForPlacement(
       id = UUID.randomUUID(),
       createdByUserId = user.id,
@@ -83,15 +100,18 @@ class Cas1RequestForPlacementServiceTest {
       isWithdrawn = false,
       type = RequestForPlacementType.manual,
       placementDates = listOf(PlacementDates(LocalDate.now(), 14)),
-      requestedPlacementPeriod = Cas1RequestedPlacementPeriod(
-        arrival = LocalDate.now(),
-        arrivalFlexible = null,
-        duration = 14,
-      ),
+      requestedPlacementPeriod = requestedPlacementPeriod,
       authorisedPlacementPeriod = null,
       status = RequestForPlacementStatus.requestSubmitted,
       submittedAt = now,
       statusSetDate = now.toLocalDate(),
+      submittedBy = Cas1StaffDto(
+        name = user.name,
+        staffCode = user.deliusStaffCode,
+        username = user.deliusUsername,
+      ),
+      decision = null,
+      canonicalPlacementPeriod = requestedPlacementPeriod,
     )
   }
 
@@ -99,6 +119,74 @@ class Cas1RequestForPlacementServiceTest {
     private val user = UserEntityFactory()
       .withDefaults()
       .produce()
+  }
+
+  @Nested
+  inner class GetRequestForPlacementRejectionReason {
+    @Test
+    fun `getRequestForPlacementRejectionReason returns null if request for placement event has no rejection reason`() {
+      val requestForPlacement = RequestForPlacementFactory().produce()
+
+      every { domainEventRepository.findAssessedRequestForPlacement(requestForPlacement.id) } returns null
+
+      val result = cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement)
+
+      assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getRequestForPlacementRejectionReason returns rejectionReason if request for placement event has rejection reason`() {
+      val requestForPlacement = RequestForPlacementFactory().produce()
+
+      val details = RequestForPlacementAssessed(
+        applicationId = UUID.randomUUID(),
+        applicationUrl = "url",
+        placementApplicationId = requestForPlacement.id,
+        assessedBy = StaffMemberFactory().produce(),
+        decision = RequestForPlacementAssessed.Decision.rejected,
+        expectedArrival = LocalDate.now(),
+        duration = 12,
+        decisionSummary = "No space",
+      )
+      val envelopedData = Cas1DomainEventEnvelopeFactory<RequestForPlacementAssessed>()
+        .withDetails(details)
+        .produce()
+
+      every { domainEventRepository.findAssessedRequestForPlacement(requestForPlacement.id) } returns DomainEventEntityFactory()
+        .withData(jsonMapper.writeValueAsString(envelopedData))
+        .produce()
+
+      val result = cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement)
+
+      assertThat(result).isEqualTo("No space")
+    }
+  }
+
+  @Nested
+  inner class GetRequestForPlacementWithdrawalDate {
+    @Test
+    fun `getRequestForPlacementWithdrawalDate returns null if request for placement event has not been withdrawn`() {
+      val requestForPlacement = RequestForPlacementFactory().produce()
+
+      every { domainEventRepository.findWithdrawnRequestForPlacement(requestForPlacement.id) } returns null
+
+      val result = cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement)
+
+      assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getRequestForPlacementWithdrawalDate returns withdrawalDate if request for placement event has been withdrawn`() {
+      val requestForPlacement = RequestForPlacementFactory().produce()
+
+      every { domainEventRepository.findWithdrawnRequestForPlacement(requestForPlacement.id) } returns DomainEventEntityFactory()
+        .withOccurredAt(OffsetDateTime.now().minusDays(1))
+        .produce()
+
+      val result = cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement)
+
+      assertThat(result).isEqualTo(LocalDate.now().minusDays(1))
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
@@ -37,7 +37,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RequestForPlacem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ApprovedPremisesEntity
@@ -51,6 +50,8 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.stream.Stream
 import kotlin.collections.emptyList
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as AssessmentDecisionApi
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as AssessmentDecisionJpa
 
 @SuppressWarnings("UnusedPrivateProperty")
 @ExtendWith(MockKExtension::class)
@@ -1167,12 +1168,12 @@ class Cas1ExternalApplicationServiceTest {
       createdAt = applicationEntity.createdAt,
       createdBy = transformToStaffDto(applicationEntity.createdByUser),
       submittedAt = applicationEntity.submittedAt,
-      expiresAt = if (applicationEntity.getLatestAssessment()?.decision == AssessmentDecision.ACCEPTED) applicationEntity.getLatestAssessment()?.submittedAt?.toLocalDate()?.plusDays(365) else null,
+      expiresAt = if (applicationEntity.getLatestAssessment()?.decision == AssessmentDecisionJpa.ACCEPTED) applicationEntity.getLatestAssessment()?.submittedAt?.toLocalDate()?.plusDays(365) else null,
       status = applicationEntity.status,
       id = applicationEntity.id,
     ),
     assessment = Cas1ExternalAssessmentDto(
-      decision = applicationEntity.getLatestAssessment()?.decision,
+      decision = AssessmentDecisionApi.valueOf(applicationEntity.getLatestAssessment()?.decision?.name ?: ""),
       rejectionRationale = applicationEntity.getLatestAssessment()?.rejectionRationale,
     ),
     placementHistory = emptyList(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
@@ -12,9 +12,18 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PlacementDates
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalApplicationDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalAssessmentDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPlacementDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalRequestForPlacementDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1PlacementPairDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingShortSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.results.CasResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
@@ -28,10 +37,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RequestForPlacem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ApprovedPremisesEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1PremisesService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1RequestForPlacementService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.external.Cas1ExternalApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.external.Cas1ExternalApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.stream.Stream
@@ -49,16 +64,19 @@ class Cas1ExternalApplicationServiceTest {
   @MockK
   private lateinit var cas1PremisesService: Cas1PremisesService
 
-  private val cas1ApplicationUrlTemplate: String = "http://localhost:3000/applications/#id"
+  @MockK
+  private lateinit var cas1ExternalApplicationTransformer: Cas1ExternalApplicationTransformer
 
   @InjectMockKs
   private lateinit var service: Cas1ExternalApplicationService
 
+  fun transformToStaffDto(user: UserEntity) = Cas1StaffDto(user.name, user.deliusUsername, user.deliusStaffCode)
+
   @Nested
-  inner class GetPlacementHistories {
+  inner class GetPlacementHistory {
 
     @Test
-    fun `getPlacementHistories returns requestForPlacement status and no placement status when no placements`() {
+    fun `getPlacementHistory returns requestForPlacement status and no placement status when no placements`() {
       val awaitingPlacementApplication = ApprovedPremisesApplicationEntityFactory()
         .withCreatedByUser(user)
         .withCrn(CRN)
@@ -67,16 +85,46 @@ class Cas1ExternalApplicationServiceTest {
 
       val requestForPlacement1 = RequestForPlacementFactory().withStatusSetDate(
         LocalDate.now().minusDays(4),
-      ).withStatus(RequestForPlacementStatus.placementBooked).produce()
+      ).withStatus(RequestForPlacementStatus.placementBooked)
+        .withPlacementDates(
+          listOf(
+            PlacementDates(
+              expectedArrival = LocalDate.now().plusDays(3),
+              duration = 10,
+            ),
+          ),
+        )
+        .produce()
       val requestForPlacement2 = RequestForPlacementFactory().withStatusSetDate(
         LocalDate.now().minusDays(1),
-      ).withStatus(RequestForPlacementStatus.requestUnsubmitted).produce()
+      ).withStatus(RequestForPlacementStatus.requestUnsubmitted).withPlacementDates(
+        emptyList(),
+      ).produce()
       val requestForPlacement3 = RequestForPlacementFactory().withStatusSetDate(
         LocalDate.now().minusDays(5),
-      ).withStatus(RequestForPlacementStatus.requestSubmitted).produce()
+      ).withStatus(RequestForPlacementStatus.requestSubmitted).withPlacementDates(
+        listOf(
+          PlacementDates(
+            expectedArrival = LocalDate.now().plusDays(2),
+            duration = 8,
+          ),
+        ),
+      ).produce()
       val requestForPlacement4 = RequestForPlacementFactory().withStatusSetDate(
         LocalDate.now().minusDays(2),
-      ).withStatus(RequestForPlacementStatus.awaitingMatch).produce()
+      ).withStatus(RequestForPlacementStatus.awaitingMatch).withPlacementDates(
+        listOf(
+          PlacementDates(
+            expectedArrival = LocalDate.now().plusDays(1),
+            duration = 11,
+          ),
+        ),
+      ).produce()
+
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1) } returns transformToPlacementHistory(requestForPlacement1)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2) } returns transformToPlacementHistory(requestForPlacement2)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3) } returns transformToPlacementHistory(requestForPlacement3)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement4) } returns transformToPlacementHistory(requestForPlacement4)
 
       every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(awaitingPlacementApplication.id, null) } returns CasResult.Success(
         listOf(
@@ -87,44 +135,20 @@ class Cas1ExternalApplicationServiceTest {
         ),
       )
 
-      val result = service.getPlacementHistories(awaitingPlacementApplication.id)
+      val result = service.getPlacementPairs(awaitingPlacementApplication.id)
 
       assertThat(result).isEqualTo(
         listOf(
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = requestForPlacement2.statusSetDate,
-            requestForPlacementStatus = requestForPlacement2.status,
-            placementStatus = null,
-            premises = null,
-            withdrawalReason = null,
-          ),
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = requestForPlacement4.statusSetDate,
-            requestForPlacementStatus = requestForPlacement4.status,
-            placementStatus = null,
-            premises = null,
-            withdrawalReason = null,
-          ),
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = requestForPlacement1.statusSetDate,
-            requestForPlacementStatus = requestForPlacement1.status,
-            placementStatus = null,
-            premises = null,
-            withdrawalReason = null,
-          ),
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = requestForPlacement3.statusSetDate,
-            requestForPlacementStatus = requestForPlacement3.status,
-            placementStatus = null,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement2),
+          transformToPlacementHistory(requestForPlacement4),
+          transformToPlacementHistory(requestForPlacement1),
+          transformToPlacementHistory(requestForPlacement3),
         ),
       )
     }
 
     @Test
-    fun `getPlacementHistories returns requestForPlacement status and placement status when placements`() {
+    fun `getPlacementHistory returns requestForPlacement status and placement status when placements`() {
       val premisesEntity = ApprovedPremisesEntityFactory()
         .withDefaults()
         .withSupportsSpaceBookings(true)
@@ -212,7 +236,12 @@ class Cas1ExternalApplicationServiceTest {
       ).withStatus(RequestForPlacementStatus.requestSubmitted).produce()
       val requestForPlacement4 = RequestForPlacementFactory().withStatusSetDate(
         LocalDate.now().minusDays(2),
-      ).withStatus(RequestForPlacementStatus.awaitingMatch).produce()
+      ).withStatus(RequestForPlacementStatus.requestRejected)
+        .withDecision(PlacementApplicationDecision.REJECTED).produce()
+      val requestForPlacement5 = RequestForPlacementFactory().withStatusSetDate(
+        LocalDate.now().minusDays(50),
+      ).withStatus(RequestForPlacementStatus.requestWithdrawn)
+        .withIsWithdrawn(true).produce()
 
       every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(awaitingPlacementApplication.id, null) } returns CasResult.Success(
         listOf(
@@ -220,6 +249,7 @@ class Cas1ExternalApplicationServiceTest {
           requestForPlacement2,
           requestForPlacement3,
           requestForPlacement4,
+          requestForPlacement5,
         ),
       )
       every {
@@ -229,106 +259,108 @@ class Cas1ExternalApplicationServiceTest {
       every {
         cas1PremisesService.findPremisesById(match { it != premisesEntity.id })
       } returns null
+      val withdrawalDate = LocalDate.now().minusDays(10)
+      val rejectionReason = "No space"
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement1) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement2) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement3) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement4) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(requestForPlacement5) } returns withdrawalDate
 
-      val result = service.getPlacementHistories(awaitingPlacementApplication.id)
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement1) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement2) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement3) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement4) } returns rejectionReason
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(requestForPlacement5) } returns null
 
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement2, null, null, placement8)
+      } returns
+        transformToPlacementHistory(requestForPlacement2, placement8)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement2, null, null, placement10)
+      } returns
+        transformToPlacementHistory(requestForPlacement2, placement10)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement2, null, null, placement9)
+      } returns
+        transformToPlacementHistory(requestForPlacement2, placement9)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement3, null, null, placement7, premisesEntity)
+      } returns
+        transformToPlacementHistory(requestForPlacement3, placement7, premisesEntity)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement1, null, null, placement1)
+      } returns
+        transformToPlacementHistory(requestForPlacement1, placement1)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement4, rejectionReason, null)
+      } returns
+        transformToPlacementHistory(requestForPlacement4, rejectionReason = rejectionReason)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement5, null, withdrawalDate)
+      } returns
+        transformToPlacementHistory(requestForPlacement5, withdrawalDate = withdrawalDate)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement1, null, null, placement2)
+      } returns
+        transformToPlacementHistory(requestForPlacement1, placement2)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement1, null, null, placement3)
+      } returns
+        transformToPlacementHistory(requestForPlacement1, placement3)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement3, null, null, placement4)
+      } returns
+        transformToPlacementHistory(requestForPlacement3, placement4)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement3, null, null, placement6)
+      } returns
+        transformToPlacementHistory(requestForPlacement3, placement6)
+      every {
+        cas1ExternalApplicationTransformer
+          .transformToCas1PlacementPair(requestForPlacement3, null, null, placement5)
+      } returns
+        transformToPlacementHistory(requestForPlacement3, placement5)
+
+      val result = service.getPlacementPairs(awaitingPlacementApplication.id)
       assertThat(result).isEqualTo(
         listOf(
           // placement8 (+3 days)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement8.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement2.status,
-            placementStatus = placement8.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement2, placement8),
           // placement10 (+2 days)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement10.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement2.status,
-            placementStatus = placement10.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement2, placement10),
           // placement9 (+1 day)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement9.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement2.status,
-            placementStatus = placement9.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement2, placement9),
           // placement7 (0 days)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement7.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement3.status,
-            placementStatus = placement7.status,
-            premises = Cas1ExternalPremisesDto(
-              startDate = placement7.expectedArrivalDate,
-              endDate = placement7.expectedDepartureDate,
-              addressLine1 = premisesEntity.addressLine1,
-              addressLine2 = premisesEntity.addressLine2,
-              town = premisesEntity.town,
-              postcode = premisesEntity.postcode,
-            ),
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement3, placement7, premisesEntity),
           // placement1 (-1)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement1.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement1.status,
-            placementStatus = placement1.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement1, placement1),
           // rfp4 (no placements) (-2)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = requestForPlacement4.statusSetDate,
-            requestForPlacementStatus = requestForPlacement4.status,
-            placementStatus = null,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement4, rejectionReason = rejectionReason),
           // placement2 (-3)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement2.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement1.status,
-            placementStatus = placement2.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement1, placement2),
           // placement3 (-4)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement3.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement1.status,
-            placementStatus = placement3.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement1, placement3),
           // placement4 (-10)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement4.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement3.status,
-            placementStatus = placement4.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement3, placement4),
           // placement6 (-15)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement6.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement3.status,
-            placementStatus = placement6.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement3, placement6),
           // placement5 (-20)
-          Cas1ExternalApplicationService.Cas1PlacementHistory(
-            dateApplied = placement5.statusSetDate!!,
-            requestForPlacementStatus = requestForPlacement3.status,
-            placementStatus = placement5.status,
-            premises = null,
-            withdrawalReason = null,
-          ),
+          transformToPlacementHistory(requestForPlacement3, placement5),
+          // rfp5 (no placements) (-50)
+          transformToPlacementHistory(requestForPlacement5, withdrawalDate = withdrawalDate),
         ),
       )
     }
@@ -380,18 +412,26 @@ class Cas1ExternalApplicationServiceTest {
           requestForPlacement4,
         ),
       )
+      val suitableApplication = transformToSuitableApplication(awaitingPlacementApplication, requestForPlacement2)
+      val suitablePlacementPair = transformToPlacementHistory(requestForPlacement2)
+      val placementHistory = listOf(
+        transformToPlacementHistory(requestForPlacement4),
+        transformToPlacementHistory(requestForPlacement1),
+        transformToPlacementHistory(requestForPlacement3),
+      )
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1) } returns transformToPlacementHistory(requestForPlacement1)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2) } returns suitablePlacementPair
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3) } returns transformToPlacementHistory(requestForPlacement3)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement4) } returns transformToPlacementHistory(requestForPlacement4)
+      every { cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(awaitingPlacementApplication, suitablePlacementPair, placementHistory) } returns
+        transformToSuitableApplication(awaitingPlacementApplication, requestForPlacement2)
 
       val result = service.getSuitableApplicationByCrn(awaitingPlacementApplication.crn)
 
       assertThat(result).isEqualTo(
-        Cas1SuitableApplication(
-          id = awaitingPlacementApplication.id,
-          applicationStatus = awaitingPlacementApplication.status,
-          requestForPlacementStatus = requestForPlacement2.status,
-          placementStatus = null,
-          premises = null,
-          uiUrl = "http://localhost:3000/applications/${awaitingPlacementApplication.id}",
-        ),
+        suitableApplication,
       )
     }
 
@@ -495,9 +535,34 @@ class Cas1ExternalApplicationServiceTest {
           requestForPlacement4,
         ),
       )
+      val suitableApplication = transformToSuitableApplication(awaitingPlacementApplication, requestForPlacement3, placement7, premisesEntity)
+      val suitablePlacementPair = transformToPlacementHistory(requestForPlacement3, placement7, premisesEntity)
+      val placementHistory = listOf(
+        transformToPlacementHistory(requestForPlacement1, placement1),
+        transformToPlacementHistory(requestForPlacement4),
+        transformToPlacementHistory(requestForPlacement1, placement2),
+        transformToPlacementHistory(requestForPlacement1, placement3),
+        transformToPlacementHistory(requestForPlacement3, placement4),
+        transformToPlacementHistory(requestForPlacement3, placement6),
+        transformToPlacementHistory(requestForPlacement3, placement5),
+      )
       every {
         cas1PremisesService.findPremisesById(match { it == premisesEntity.id })
       } returns premisesEntity
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1, null, null, placement1) } returns transformToPlacementHistory(requestForPlacement1, placement1)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1, null, null, placement2) } returns transformToPlacementHistory(requestForPlacement1, placement2)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1, null, null, placement3) } returns transformToPlacementHistory(requestForPlacement1, placement3)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement4) } returns transformToPlacementHistory(requestForPlacement3, placement4)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement5) } returns transformToPlacementHistory(requestForPlacement3, placement5)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement6) } returns transformToPlacementHistory(requestForPlacement3, placement6)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement7, premisesEntity) } returns suitablePlacementPair
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2, null, null, placement8) } returns transformToPlacementHistory(requestForPlacement2, placement8)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2, null, null, placement9) } returns transformToPlacementHistory(requestForPlacement2, placement9)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2, null, null, placement10) } returns transformToPlacementHistory(requestForPlacement2, placement10)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement4) } returns transformToPlacementHistory(requestForPlacement4)
+      every { cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(awaitingPlacementApplication, suitablePlacementPair, placementHistory) } returns suitableApplication
 
       every {
         cas1PremisesService.findPremisesById(match { it != premisesEntity.id })
@@ -505,22 +570,7 @@ class Cas1ExternalApplicationServiceTest {
       val result = service.getSuitableApplicationByCrn(awaitingPlacementApplication.crn)
 
       assertThat(result).isEqualTo(
-        Cas1SuitableApplication(
-          id = awaitingPlacementApplication.id,
-          applicationStatus = awaitingPlacementApplication.status,
-          requestForPlacementStatus = requestForPlacement3.status,
-          placementStatus = placement7.status,
-          premises = Cas1ExternalPremisesDto(
-            startDate = placement7.expectedArrivalDate,
-            endDate = placement7.expectedDepartureDate,
-            addressLine1 = premisesEntity.addressLine1,
-            addressLine2 = premisesEntity.addressLine2,
-            town = premisesEntity.town,
-            postcode = premisesEntity.postcode,
-          ),
-          uiUrl = "http://localhost:3000/applications/${awaitingPlacementApplication.id}",
-        ),
-
+        suitableApplication,
       )
     }
 
@@ -583,16 +633,12 @@ class Cas1ExternalApplicationServiceTest {
         ),
       )
         .withStatus(RequestForPlacementStatus.placementBooked).produce()
-
-      val premises = Cas1ExternalPremisesDto(
-        startDate = booking.expectedArrivalDate,
-        endDate = booking.expectedDepartureDate,
-        addressLine1 = premisesEntity.addressLine1,
-        addressLine2 = premisesEntity.addressLine2,
-        town = premisesEntity.town,
-        postcode = premisesEntity.postcode,
-      )
-
+      val suitableApplication = transformToSuitableApplication(application, requestForPlacement, placement, premisesEntity)
+      val suitablePlacementPair = transformToPlacementHistory(requestForPlacement, placement, premisesEntity)
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(application, suitablePlacementPair, emptyList()) } returns suitableApplication
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement, null, null, placement, premisesEntity) } returns suitablePlacementPair
       every { approvedPremisesApplicationRepository.findByCrn(application.crn) } returns listOf(application)
       every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(application.id, null) } returns CasResult.Success(
         listOf(
@@ -601,14 +647,6 @@ class Cas1ExternalApplicationServiceTest {
       )
       every { cas1PremisesService.findPremisesById(premisesEntity.id) } returns premisesEntity
 
-      val suitableApplication = Cas1SuitableApplication(
-        id = application.id,
-        applicationStatus = application.status,
-        requestForPlacementStatus = requestForPlacement.status,
-        placementStatus = placement.status,
-        premises = premises,
-        uiUrl = "http://localhost:3000/applications/${application.id}",
-      )
       val result = service.getSuitableApplicationByCrn(application.crn)
 
       assertThat(result).isEqualTo(suitableApplication)
@@ -621,16 +659,11 @@ class Cas1ExternalApplicationServiceTest {
       suitableApprovedPremisesApplication: ApprovedPremisesApplicationEntity,
     ) {
       every { approvedPremisesApplicationRepository.findByCrn(suitableApprovedPremisesApplication.crn) } returns applications
-      val suitableApplication = Cas1SuitableApplication(
-        id = suitableApprovedPremisesApplication.id,
-        applicationStatus = suitableApprovedPremisesApplication.status,
-        premises = null,
-        requestForPlacementStatus = null,
-        placementStatus = null,
-        uiUrl = "http://localhost:3000/applications/${suitableApprovedPremisesApplication.id}",
-      )
 
-      every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(suitableApplication.id, null) } returns CasResult.Success(emptyList())
+      val suitableApplication = transformToSuitableApplication(suitableApprovedPremisesApplication)
+
+      every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(suitableApplication.application.id, null) } returns CasResult.Success(emptyList())
+      every { cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(suitableApprovedPremisesApplication, null, emptyList()) } returns suitableApplication
 
       val result = service.getSuitableApplicationByCrn(suitableApprovedPremisesApplication.crn)
       assertThat(result).isEqualTo(suitableApplication)
@@ -669,18 +702,14 @@ class Cas1ExternalApplicationServiceTest {
         awaitingPlacementApplication2,
         unallocatedAssessment,
       )
+      val suitableApplication = transformToSuitableApplication(latestAwaitingPlacementApplication)
 
       every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(latestAwaitingPlacementApplication.id, null) } returns CasResult.Success(emptyList())
       every { cas1PremisesService.findPremisesById(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(latestAwaitingPlacementApplication, null, emptyList()) } returns suitableApplication
 
-      val suitableApplication = Cas1SuitableApplication(
-        id = latestAwaitingPlacementApplication.id,
-        applicationStatus = ApprovedPremisesApplicationStatus.AWAITING_PLACEMENT,
-        premises = null,
-        requestForPlacementStatus = null,
-        placementStatus = null,
-        uiUrl = "http://localhost:3000/applications/${latestAwaitingPlacementApplication.id}",
-      )
       val result = service.getSuitableApplicationByCrn(crn)
 
       assertThat(result).isEqualTo(suitableApplication)
@@ -719,18 +748,13 @@ class Cas1ExternalApplicationServiceTest {
         startedApplication2,
         inapplicableAssessment,
       )
+      val suitableApplication = transformToSuitableApplication(latestStartedApplication)
 
       every { cas1RequestForPlacementService.getRequestsForPlacementByApplication(latestStartedApplication.id, null) } returns CasResult.Success(emptyList())
       every { cas1PremisesService.findPremisesById(any()) } returns null
-
-      val suitableApplication = Cas1SuitableApplication(
-        id = latestStartedApplication.id,
-        applicationStatus = ApprovedPremisesApplicationStatus.STARTED,
-        premises = null,
-        requestForPlacementStatus = null,
-        placementStatus = null,
-        uiUrl = "http://localhost:3000/applications/${latestStartedApplication.id}",
-      )
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(latestStartedApplication, null, emptyList()) } returns suitableApplication
 
       val result = service.getSuitableApplicationByCrn(crn)
 
@@ -781,6 +805,12 @@ class Cas1ExternalApplicationServiceTest {
           requestForPlacement4,
         ),
       )
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1) } returns transformToPlacementHistory(requestForPlacement1)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2) } returns transformToPlacementHistory(requestForPlacement2)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3) } returns transformToPlacementHistory(requestForPlacement3)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement4) } returns transformToPlacementHistory(requestForPlacement4)
 
       val result = service.getCurrentPremisesByCrn(awaitingPlacementApplication.crn)
 
@@ -911,6 +941,37 @@ class Cas1ExternalApplicationServiceTest {
       every {
         cas1PremisesService.findPremisesById(match { it == premisesEntity.id })
       } returns premisesEntity
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1, null, null, placement1) } returns
+        transformToPlacementHistory(requestForPlacement1, placement1)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1, null, null, placement2, premisesEntity) } returns
+        transformToPlacementHistory(requestForPlacement1, placement2, premisesEntity)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement1, null, null, placement3, premisesEntity) } returns
+        transformToPlacementHistory(requestForPlacement1, placement3, premisesEntity)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement4) } returns
+        transformToPlacementHistory(requestForPlacement3, placement4)
+      every {
+        cas1ExternalApplicationTransformer.transformToCas1PlacementPair(
+          requestForPlacement3,
+          null,
+          null,
+          placement5,
+        )
+      } returns
+        transformToPlacementHistory(requestForPlacement3, placement5)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement6) } returns
+        transformToPlacementHistory(requestForPlacement3, placement6)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement3, null, null, placement7, premisesEntity) } returns
+        transformToPlacementHistory(requestForPlacement3, placement7, premisesEntity)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2, null, null, placement8) } returns
+        transformToPlacementHistory(requestForPlacement2, placement8)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2, null, null, placement9, premisesEntity) } returns
+        transformToPlacementHistory(requestForPlacement2, placement9, premisesEntity)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement2, null, null, placement10) } returns
+        transformToPlacementHistory(requestForPlacement2, placement10)
+      every { cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement4) } returns
+        transformToPlacementHistory(requestForPlacement4)
 
       every {
         cas1PremisesService.findPremisesById(match { it != premisesEntity.id })
@@ -996,12 +1057,126 @@ class Cas1ExternalApplicationServiceTest {
         ),
       )
       every { cas1PremisesService.findPremisesById(premisesEntity.id) } returns premisesEntity
+      every { cas1RequestForPlacementService.getRequestForPlacementWithdrawalDate(any()) } returns null
+      every { cas1RequestForPlacementService.getRequestForPlacementRejectionReason(any()) } returns null
+      every {
+        cas1ExternalApplicationTransformer.transformToCas1PlacementPair(
+          requestForPlacement,
+          null,
+          null,
+          placement,
+          premisesEntity,
+        )
+      } returns
+        transformToPlacementHistory(requestForPlacement, placement, premisesEntity)
 
       val result = service.getCurrentPremisesByCrn(application.crn)
 
       assertThat(result).isNull()
     }
   }
+
+  private fun transformToPlacementHistory(
+    requestForPlacement: RequestForPlacement,
+    placement: Cas1SpaceBookingShortSummary? = null,
+    premisesEntity: ApprovedPremisesEntity? = null,
+    rejectionReason: String? = null,
+    withdrawalDate: LocalDate? = null,
+  ) = Cas1PlacementPairDto(
+    dateApplied = placement?.statusSetDate ?: requestForPlacement.statusSetDate,
+    requestForPlacement = Cas1ExternalRequestForPlacementDto(
+      decision = requestForPlacement.decision,
+      submittedBy = requestForPlacement.submittedBy,
+      submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
+      withdrawalReason = requestForPlacement.withdrawalReason,
+      withdrawalDate = withdrawalDate,
+      rejectionReason = rejectionReason,
+      expectedArrivalDate =
+      placement?.expectedArrivalDate
+        ?: requestForPlacement.placementDates.firstOrNull()?.expectedArrival,
+      durationDays = requestForPlacement.placementDates.firstOrNull()?.duration,
+      status = requestForPlacement.status,
+    ),
+    placement = Cas1ExternalPlacementDto(
+      actualArrivalDate = placement?.actualArrivalDate,
+      actualDepartureDate = placement?.actualDepartureDate,
+      cancellationReason = placement?.cancellation?.reason?.name,
+      premises = premisesEntity?.let {
+        Cas1ExternalPremisesDto(
+          startDate = placement?.expectedArrivalDate,
+          endDate = placement?.expectedDepartureDate,
+          addressLine1 = it.addressLine1,
+          addressLine2 = it.addressLine2,
+          town = it.town,
+          postcode = it.postcode,
+        )
+      },
+      status = placement?.status,
+    ),
+  )
+
+  private fun transformToSuitableApplication(
+    applicationEntity: ApprovedPremisesApplicationEntity,
+    requestForPlacement: RequestForPlacement? = null,
+    placement: Cas1SpaceBookingShortSummary? = null,
+    premisesEntity: ApprovedPremisesEntity? = null,
+  ) = Cas1SuitableApplication(
+    requestForPlacementStatus = requestForPlacement?.status,
+    placementStatus = placement?.status,
+    premises = premisesEntity?.let {
+      Cas1ExternalPremisesDto(
+        startDate = placement?.expectedArrivalDate,
+        endDate = placement?.expectedDepartureDate,
+        addressLine1 = it.addressLine1,
+        addressLine2 = it.addressLine2,
+        town = it.town,
+        postcode = it.postcode,
+      )
+    },
+    requestForPlacement = Cas1ExternalRequestForPlacementDto(
+      decision = requestForPlacement?.decision,
+      rejectionReason = null,
+      submittedBy = requestForPlacement?.submittedBy,
+      submittedAt = requestForPlacement?.submittedAt?.toLocalDate(),
+      withdrawalReason = requestForPlacement?.withdrawalReason,
+      withdrawalDate = null,
+      expectedArrivalDate = placement?.expectedArrivalDate ?: requestForPlacement?.placementDates?.firstOrNull()?.expectedArrival,
+      durationDays = requestForPlacement?.placementDates?.firstOrNull()?.duration,
+      status = requestForPlacement?.status,
+    ),
+    placement = Cas1ExternalPlacementDto(
+      actualArrivalDate = placement?.actualArrivalDate,
+      actualDepartureDate = placement?.actualDepartureDate,
+      cancellationReason = placement?.cancellation?.reason?.name,
+      premises = premisesEntity?.let {
+        Cas1ExternalPremisesDto(
+          startDate = placement?.expectedArrivalDate,
+          endDate = placement?.expectedDepartureDate,
+          addressLine1 = it.addressLine1,
+          addressLine2 = it.addressLine2,
+          town = it.town,
+          postcode = it.postcode,
+        )
+      },
+      status = placement?.status,
+    ),
+    id = applicationEntity.id,
+    uiUrl = "http://localhost:3000/applications/${applicationEntity.id}",
+    applicationStatus = applicationEntity.status,
+    application = Cas1ExternalApplicationDto(
+      createdAt = applicationEntity.createdAt,
+      createdBy = transformToStaffDto(applicationEntity.createdByUser),
+      submittedAt = applicationEntity.submittedAt,
+      expiresAt = if (applicationEntity.getLatestAssessment()?.decision == AssessmentDecision.ACCEPTED) applicationEntity.getLatestAssessment()?.submittedAt?.toLocalDate()?.plusDays(365) else null,
+      status = applicationEntity.status,
+      id = applicationEntity.id,
+    ),
+    assessment = Cas1ExternalAssessmentDto(
+      decision = applicationEntity.getLatestAssessment()?.decision,
+      rejectionRationale = applicationEntity.getLatestAssessment()?.rejectionRationale,
+    ),
+    placementHistory = emptyList(),
+  )
 
   private companion object {
     const val CRN = "X99999"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
@@ -1085,7 +1085,7 @@ class Cas1ExternalApplicationServiceTest {
   ) = Cas1PlacementPairDto(
     dateApplied = placement?.statusSetDate ?: requestForPlacement.statusSetDate,
     requestForPlacement = Cas1ExternalRequestForPlacementDto(
-      decision = requestForPlacement.decision,
+      decision = requestForPlacement.decision?.apiValue,
       submittedBy = requestForPlacement.submittedBy,
       submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
       withdrawalReason = requestForPlacement.withdrawalReason,
@@ -1134,7 +1134,7 @@ class Cas1ExternalApplicationServiceTest {
       )
     },
     requestForPlacement = Cas1ExternalRequestForPlacementDto(
-      decision = requestForPlacement?.decision,
+      decision = requestForPlacement?.decision?.apiValue,
       rejectionReason = null,
       submittedBy = requestForPlacement?.submittedBy,
       submittedAt = requestForPlacement?.submittedAt?.toLocalDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/external/Cas1ExternalApplicationServiceTest.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RequestForPlacem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.ApprovedPremisesEntity
@@ -50,8 +51,6 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.stream.Stream
 import kotlin.collections.emptyList
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as AssessmentDecisionApi
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as AssessmentDecisionJpa
 
 @SuppressWarnings("UnusedPrivateProperty")
 @ExtendWith(MockKExtension::class)
@@ -1168,12 +1167,12 @@ class Cas1ExternalApplicationServiceTest {
       createdAt = applicationEntity.createdAt,
       createdBy = transformToStaffDto(applicationEntity.createdByUser),
       submittedAt = applicationEntity.submittedAt,
-      expiresAt = if (applicationEntity.getLatestAssessment()?.decision == AssessmentDecisionJpa.ACCEPTED) applicationEntity.getLatestAssessment()?.submittedAt?.toLocalDate()?.plusDays(365) else null,
+      expiresAt = if (applicationEntity.getLatestAssessment()?.decision == AssessmentDecision.ACCEPTED) applicationEntity.getLatestAssessment()?.submittedAt?.toLocalDate()?.plusDays(365) else null,
       status = applicationEntity.status,
       id = applicationEntity.id,
     ),
     assessment = Cas1ExternalAssessmentDto(
-      decision = AssessmentDecisionApi.valueOf(applicationEntity.getLatestAssessment()?.decision?.name ?: ""),
+      decision = applicationEntity.getLatestAssessment()?.decision?.apiValue,
       rejectionRationale = applicationEntity.getLatestAssessment()?.rejectionRationale,
     ),
     placementHistory = emptyList(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/RequestForPlacementTransformerTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlac
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SentenceTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
@@ -27,6 +28,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementAppl
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestWithdrawalReason
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1ReleaseType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.RequestForPlacementTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomOf
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDateTime
 import java.time.LocalDate
@@ -35,8 +37,8 @@ import java.time.temporal.ChronoUnit
 
 class RequestForPlacementTransformerTest {
   private val jsonMapper = mockk<JsonMapper>()
-
-  private val requestForPlacementTransformer = RequestForPlacementTransformer(jsonMapper)
+  private val cas1AssessmentTransformer = mockk<Cas1AssessmentTransformer>()
+  private val requestForPlacementTransformer = RequestForPlacementTransformer(jsonMapper, cas1AssessmentTransformer)
 
   @BeforeEach
   fun setupObjectMapperMock() {
@@ -67,12 +69,17 @@ class RequestForPlacementTransformerTest {
         .withExpectedArrivalFlexible(false)
         .withRequestedDuration(47)
         .withRequestedDuration(48)
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
         .withAuthorisedDuration(49)
         .withSentenceType(SentenceTypeOption.bailPlacement.name)
         .withReleaseType(Cas1ReleaseType.licence)
         .withSituation(SituationOption.bailSentence.name)
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.id).isEqualTo(placementApplication.id)
@@ -96,6 +103,9 @@ class RequestForPlacementTransformerTest {
       assertThat(result.placementDates).hasSize(1)
       assertThat(result.placementDates[0].expectedArrival).isEqualTo(LocalDate.of(2012, 9, 9))
       assertThat(result.placementDates[0].duration).isEqualTo(49)
+      assertThat(result.decision).isEqualTo(PlacementApplicationDecision.ACCEPTED)
+      assertThat(result.submittedBy?.name).isEqualTo(placementApplication.createdByUser.name)
+
       verify(exactly = 1) { jsonMapper.readTree(placementApplication.document) }
     }
 
@@ -119,7 +129,11 @@ class RequestForPlacementTransformerTest {
         .withAuthorisedDuration(7)
         .withAutomatic(false)
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestWithdrawn)
@@ -172,7 +186,11 @@ class RequestForPlacementTransformerTest {
         .apply {
           placementRequest.spaceBookings = mutableListOf(this)
         }
-
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.placementBooked)
@@ -200,6 +218,12 @@ class RequestForPlacementTransformerTest {
         .withAutomatic(false)
         .produce()
 
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
+
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestRejected)
@@ -226,7 +250,11 @@ class RequestForPlacementTransformerTest {
         .withAuthorisedDuration(7)
         .withAutomatic(false)
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.awaitingMatch)
@@ -252,6 +280,12 @@ class RequestForPlacementTransformerTest {
         .withAutomatic(false)
         .produce()
 
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
+
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestSubmitted)
@@ -272,7 +306,11 @@ class RequestForPlacementTransformerTest {
         .withRequestedDuration(47)
         .withAutomatic(true)
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(placementApplication, true)
 
       assertThat(result.type).isEqualTo(RequestForPlacementType.automatic)
@@ -295,6 +333,12 @@ class RequestForPlacementTransformerTest {
         .withAuthorisedDuration(7)
         .withAutomatic(false)
         .produce()
+
+      every { cas1AssessmentTransformer.transformToStaffDto(placementApplication.createdByUser) } returns Cas1StaffDto(
+        name = placementApplication.createdByUser.name,
+        username = placementApplication.createdByUser.deliusUsername,
+        staffCode = placementApplication.createdByUser.deliusStaffCode,
+      )
 
       val result = requestForPlacementTransformer.transformPlacementApplicationEntityToApi(
         placementApplication,
@@ -332,7 +376,11 @@ class RequestForPlacementTransformerTest {
         .withPlacementRequirements(placementRequirements)
         .withWithdrawalReason(randomOf(PlacementRequestWithdrawalReason.entries))
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(application.createdByUser) } returns Cas1StaffDto(
+        name = application.createdByUser.name,
+        username = application.createdByUser.deliusUsername,
+        staffCode = application.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.id).isEqualTo(placementRequest.id)
@@ -356,6 +404,8 @@ class RequestForPlacementTransformerTest {
       assertThat(result.sentenceType).isEqualTo(SentenceTypeOption.bailPlacement)
       assertThat(result.releaseType).isEqualTo(ReleaseTypeOption.rotl)
       assertThat(result.situation).isEqualTo(SituationOption.bailAssessment)
+      assertThat(result.decision).isEqualTo(PlacementApplicationDecision.ACCEPTED)
+      assertThat(result.submittedBy?.name).isEqualTo(application.createdByUser.name)
     }
 
     @Test
@@ -384,7 +434,11 @@ class RequestForPlacementTransformerTest {
         .withWithdrawalReason(randomOf(PlacementRequestWithdrawalReason.entries))
         .withCreatedAt(statusSetDate.toLocalDateTime().truncatedTo(ChronoUnit.SECONDS))
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(application.createdByUser) } returns Cas1StaffDto(
+        name = application.createdByUser.name,
+        username = application.createdByUser.deliusUsername,
+        staffCode = application.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.requestWithdrawn)
@@ -421,7 +475,11 @@ class RequestForPlacementTransformerTest {
         .apply {
           placementRequest.spaceBookings = mutableListOf(this)
         }
-
+      every { cas1AssessmentTransformer.transformToStaffDto(application.createdByUser) } returns Cas1StaffDto(
+        name = application.createdByUser.name,
+        username = application.createdByUser.deliusUsername,
+        staffCode = application.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.placementBooked)
@@ -453,7 +511,11 @@ class RequestForPlacementTransformerTest {
         .withIsWithdrawn(false)
         .withCreatedAt(statusSetDate.toLocalDateTime().truncatedTo(ChronoUnit.SECONDS))
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(application.createdByUser) } returns Cas1StaffDto(
+        name = application.createdByUser.name,
+        username = application.createdByUser.deliusUsername,
+        staffCode = application.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(placementRequest, true)
 
       assertThat(result.status).isEqualTo(RequestForPlacementStatus.awaitingMatch)
@@ -482,7 +544,11 @@ class RequestForPlacementTransformerTest {
         .withAssessment(assessment)
         .withPlacementRequirements(placementRequirements)
         .produce()
-
+      every { cas1AssessmentTransformer.transformToStaffDto(application.createdByUser) } returns Cas1StaffDto(
+        name = application.createdByUser.name,
+        username = application.createdByUser.deliusUsername,
+        staffCode = application.createdByUser.deliusStaffCode,
+      )
       val result = requestForPlacementTransformer.transformPlacementRequestEntityToApi(
         placementRequest,
         canBeDirectlyWithdrawn = canBeDirectlyWithdrawn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/external/Cas1ExternalApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/external/Cas1ExternalApplicationTransformerTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremises
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingShortSummaryFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RequestForPlacementFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
@@ -38,6 +37,8 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.AssessmentDecision as AssessmentDecisionApi
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision as AssessmentDecisionJpa
 
 class Cas1ExternalApplicationTransformerTest {
   private val cas1ApplicationUrlTemplate: String = "http://localhost:3000/applications/#id"
@@ -89,7 +90,7 @@ class Cas1ExternalApplicationTransformerTest {
         .produce()
       val assessment = ApprovedPremisesAssessmentEntityFactory()
         .withDefaults()
-        .withDecision(AssessmentDecision.ACCEPTED)
+        .withDecision(AssessmentDecisionJpa.ACCEPTED)
         .withApplication(application)
         .withRejectionRationale("Great")
         .withSubmittedAt(OffsetDateTime.now())
@@ -131,7 +132,7 @@ class Cas1ExternalApplicationTransformerTest {
           id = application.id,
         ),
         assessment = Cas1ExternalAssessmentDto(
-          decision = assessment.decision,
+          decision = AssessmentDecisionApi.accepted,
           rejectionRationale = assessment.rejectionRationale,
         ),
         requestForPlacement = suitablePlacementPair.requestForPlacement,
@@ -143,6 +144,7 @@ class Cas1ExternalApplicationTransformerTest {
       )
 
       every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns userStaff
+      every { mockCas1AssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns AssessmentDecisionApi.accepted
       every { mockCas1ApplicationTransformer.getApplicationExpiresAt(application) } returns assessment.submittedAt?.toLocalDate()?.plusDays(365)
 
       val result = cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(application, suitablePlacementPair, emptyList())
@@ -172,7 +174,7 @@ class Cas1ExternalApplicationTransformerTest {
         .produce()
       val assessment = ApprovedPremisesAssessmentEntityFactory()
         .withDefaults()
-        .withDecision(AssessmentDecision.ACCEPTED)
+        .withDecision(AssessmentDecisionJpa.ACCEPTED)
         .withApplication(application)
         .withRejectionRationale("Great")
         .withSubmittedAt(OffsetDateTime.now())
@@ -193,7 +195,7 @@ class Cas1ExternalApplicationTransformerTest {
           id = application.id,
         ),
         assessment = Cas1ExternalAssessmentDto(
-          decision = assessment.decision,
+          decision = AssessmentDecisionApi.accepted,
           rejectionRationale = assessment.rejectionRationale,
         ),
         requestForPlacementStatus = null,
@@ -205,6 +207,7 @@ class Cas1ExternalApplicationTransformerTest {
       )
 
       every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns userStaff
+      every { mockCas1AssessmentTransformer.transformJpaDecisionToApi(assessment.decision) } returns AssessmentDecisionApi.accepted
       every { mockCas1ApplicationTransformer.getApplicationExpiresAt(application) } returns assessment.submittedAt?.toLocalDate()?.plusDays(365)
 
       val result = cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(application, null, emptyList())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/external/Cas1ExternalApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/external/Cas1ExternalApplicationTransformerTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.PlacementApplicationDecisionDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
@@ -98,7 +99,7 @@ class Cas1ExternalApplicationTransformerTest {
 
       val suitablePlacementPair = Cas1PlacementPairDto(
         requestForPlacement = Cas1ExternalRequestForPlacementDto(
-          decision = PlacementApplicationDecision.REJECTED,
+          decision = PlacementApplicationDecisionDto.rejected,
           rejectionReason = "No space",
           submittedBy = requestSubmittedBy,
           submittedAt = LocalDate.now(),
@@ -271,7 +272,7 @@ class Cas1ExternalApplicationTransformerTest {
 
       val expected = Cas1PlacementPairDto(
         requestForPlacement = Cas1ExternalRequestForPlacementDto(
-          decision = requestForPlacement.decision,
+          decision = requestForPlacement.decision?.apiValue,
           rejectionReason = rejectionReason,
           submittedBy = requestSubmittedBy,
           submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
@@ -359,7 +360,7 @@ class Cas1ExternalApplicationTransformerTest {
       val expected = Cas1PlacementPairDto(
         requestForPlacement = Cas1ExternalRequestForPlacementDto(
           status = requestForPlacement.status,
-          decision = requestForPlacement.decision,
+          decision = requestForPlacement.decision?.apiValue,
           rejectionReason = rejectionReason,
           submittedBy = requestSubmittedBy,
           submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
@@ -458,7 +459,7 @@ class Cas1ExternalApplicationTransformerTest {
       val expected = Cas1PlacementPairDto(
         requestForPlacement = Cas1ExternalRequestForPlacementDto(
           status = requestForPlacement.status,
-          decision = requestForPlacement.decision,
+          decision = requestForPlacement.decision?.apiValue,
           rejectionReason = rejectionReason,
           submittedBy = requestSubmittedBy,
           submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
@@ -556,7 +557,7 @@ class Cas1ExternalApplicationTransformerTest {
 
       val expected = Cas1PlacementPairDto(
         requestForPlacement = Cas1ExternalRequestForPlacementDto(
-          decision = requestForPlacement.decision,
+          decision = requestForPlacement.decision?.apiValue,
           rejectionReason = rejectionReason,
           submittedBy = requestSubmittedBy,
           submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
@@ -612,7 +613,7 @@ class Cas1ExternalApplicationTransformerTest {
         .produce()
       val expected = Cas1PlacementPairDto(
         requestForPlacement = Cas1ExternalRequestForPlacementDto(
-          decision = requestForPlacement.decision,
+          decision = requestForPlacement.decision?.apiValue,
           rejectionReason = rejectionReason,
           submittedBy = requestSubmittedBy,
           submittedAt = requestForPlacement.submittedAt?.toLocalDate(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/external/Cas1ExternalApplicationTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/cas1/external/Cas1ExternalApplicationTransformerTest.kt
@@ -1,0 +1,635 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.unit.transformer.cas1.external
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas1.Cas1RequestedPlacementPeriod
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.CancellationReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacementStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.WithdrawPlacementRequestReason
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalApplicationDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalAssessmentDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPlacementDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalPremisesDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ExternalRequestForPlacementDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1PlacementPairDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingCancellation
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SpaceBookingStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1StaffDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1SuitableApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingShortSummaryFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RequestForPlacementFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationDecision
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.Cas1AssessmentTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas1.external.Cas1ExternalApplicationTransformer
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.minusDays
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.toLocalDate
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas1ExternalApplicationTransformerTest {
+  private val cas1ApplicationUrlTemplate: String = "http://localhost:3000/applications/#id"
+  private val mockCas1AssessmentTransformer = mockk<Cas1AssessmentTransformer>()
+  private val mockCas1ApplicationTransformer = mockk<Cas1ApplicationService>()
+  private val cas1ExternalApplicationTransformer = Cas1ExternalApplicationTransformer(
+    mockCas1AssessmentTransformer,
+    mockCas1ApplicationTransformer,
+    cas1ApplicationUrlTemplate,
+  )
+
+  @Nested
+  inner class TransformToCas1SuitableApplication {
+    @Test
+    fun `Transforms to suitable application`() {
+      val premises = Cas1ExternalPremisesDto(
+        startDate = LocalDate.now().minusDays(1),
+        endDate = LocalDate.now().plusDays(12),
+        addressLine1 = "Test House",
+        addressLine2 = "Test Lane",
+        town = "Test Town",
+        postcode = "TE57 8PP",
+      )
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Tom")
+        .produce()
+
+      val requestSubmittedBy = Cas1StaffDto(
+        name = "Bob",
+        username = "bob1",
+        staffCode = "bob123",
+      )
+
+      val userStaff = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withDefaults()
+        .withStatus(ApprovedPremisesApplicationStatus.EXPIRED)
+        .withCreatedAt(OffsetDateTime.now().minusDays(100))
+        .withSubmittedAt(OffsetDateTime.now().minusDays(50))
+        .withCreatedByUser(user)
+        .withArrivalDate(OffsetDateTime.now().plusDays(20))
+        .withDuration(20)
+        .produce()
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withDefaults()
+        .withDecision(AssessmentDecision.ACCEPTED)
+        .withApplication(application)
+        .withRejectionRationale("Great")
+        .withSubmittedAt(OffsetDateTime.now())
+        .produce()
+
+      application.assessments.add(assessment)
+
+      val suitablePlacementPair = Cas1PlacementPairDto(
+        requestForPlacement = Cas1ExternalRequestForPlacementDto(
+          decision = PlacementApplicationDecision.REJECTED,
+          rejectionReason = "No space",
+          submittedBy = requestSubmittedBy,
+          submittedAt = LocalDate.now(),
+          withdrawalReason = WithdrawPlacementRequestReason.noCapacityDueToLostBed,
+          withdrawalDate = LocalDate.now().minusDays(1),
+          expectedArrivalDate = LocalDate.now().minusDays(2),
+          durationDays = 12,
+          status = RequestForPlacementStatus.awaitingMatch,
+        ),
+        placement = Cas1ExternalPlacementDto(
+          actualArrivalDate = LocalDate.now().minusDays(3),
+          actualDepartureDate = LocalDate.now().plusDays(3),
+          cancellationReason = "Other",
+          premises = premises,
+          status = Cas1SpaceBookingStatus.CANCELLED,
+        ),
+        dateApplied = LocalDate.now(),
+      )
+      val expected = Cas1SuitableApplication(
+        id = application.id,
+        uiUrl = "http://localhost:3000/applications/${application.id}",
+        applicationStatus = application.status,
+        application = Cas1ExternalApplicationDto(
+          createdAt = application.createdAt,
+          createdBy = userStaff,
+          submittedAt = application.submittedAt,
+          expiresAt = assessment.submittedAt?.toLocalDate()?.plusDays(365),
+          status = application.status,
+          id = application.id,
+        ),
+        assessment = Cas1ExternalAssessmentDto(
+          decision = assessment.decision,
+          rejectionRationale = assessment.rejectionRationale,
+        ),
+        requestForPlacement = suitablePlacementPair.requestForPlacement,
+        requestForPlacementStatus = suitablePlacementPair.requestForPlacement?.status,
+        placementStatus = suitablePlacementPair.placement?.status,
+        placement = suitablePlacementPair.placement,
+        premises = premises,
+        placementHistory = emptyList(),
+      )
+
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns userStaff
+      every { mockCas1ApplicationTransformer.getApplicationExpiresAt(application) } returns assessment.submittedAt?.toLocalDate()?.plusDays(365)
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(application, suitablePlacementPair, emptyList())
+
+      assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Transforms to suitable application with no placements`() {
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Tom")
+        .produce()
+      val userStaff = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+      val application = ApprovedPremisesApplicationEntityFactory()
+        .withDefaults()
+        .withStatus(ApprovedPremisesApplicationStatus.EXPIRED)
+        .withCreatedAt(OffsetDateTime.now().minusDays(100))
+        .withSubmittedAt(OffsetDateTime.now().minusDays(50))
+        .withCreatedByUser(user)
+        .withArrivalDate(OffsetDateTime.now().plusDays(20))
+        .withDuration(20)
+        .produce()
+      val assessment = ApprovedPremisesAssessmentEntityFactory()
+        .withDefaults()
+        .withDecision(AssessmentDecision.ACCEPTED)
+        .withApplication(application)
+        .withRejectionRationale("Great")
+        .withSubmittedAt(OffsetDateTime.now())
+        .produce()
+
+      application.assessments.add(assessment)
+
+      val expected = Cas1SuitableApplication(
+        id = application.id,
+        uiUrl = "http://localhost:3000/applications/${application.id}",
+        applicationStatus = application.status,
+        application = Cas1ExternalApplicationDto(
+          createdAt = application.createdAt,
+          createdBy = userStaff,
+          submittedAt = application.submittedAt,
+          expiresAt = assessment.submittedAt?.toLocalDate()?.plusDays(365),
+          status = application.status,
+          id = application.id,
+        ),
+        assessment = Cas1ExternalAssessmentDto(
+          decision = assessment.decision,
+          rejectionRationale = assessment.rejectionRationale,
+        ),
+        requestForPlacementStatus = null,
+        requestForPlacement = null,
+        placementStatus = null,
+        placement = null,
+        premises = null,
+        placementHistory = emptyList(),
+      )
+
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns userStaff
+      every { mockCas1ApplicationTransformer.getApplicationExpiresAt(application) } returns assessment.submittedAt?.toLocalDate()?.plusDays(365)
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1SuitableApplication(application, null, emptyList())
+
+      assertThat(result).isEqualTo(expected)
+    }
+  }
+
+  @Nested
+  inner class TransformToCas1PlacementPair {
+    @Test
+    fun `Transforms to placement history that is departed`() {
+      val duration = 12
+      val expectedArrivalDate = LocalDate.now().minusDays(100)
+      val expectedDepartureDate = expectedArrivalDate.plusWeeks(duration.toLong())
+      val actualDepartureDate = expectedDepartureDate.minusDays(1)
+      val rejectionReason = null
+      val withdrawalDate = null
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Bob")
+        .produce()
+      val requestSubmittedBy = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+      val canonicalPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = expectedArrivalDate,
+        arrivalFlexible = false,
+        duration = duration,
+      )
+      val requestForPlacement = RequestForPlacementFactory()
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
+        .withStatus(RequestForPlacementStatus.placementBooked)
+        .withSubmittedBy(requestSubmittedBy)
+        .withSubmittedAt(Instant.now().minusDays(110))
+        .withWithdrawalReason(null)
+        .withCanonicalPlacementPeriod(canonicalPlacementPeriod)
+        .produce()
+
+      val placement = Cas1SpaceBookingShortSummaryFactory()
+        .withStatus(Cas1SpaceBookingStatus.DEPARTED)
+        .withStatusSetDate(actualDepartureDate)
+        .withExpectedArrivalDate(expectedArrivalDate)
+        .withActualArrivalDate(expectedArrivalDate.plusDays(1))
+        .withActualDepartureDate(actualDepartureDate)
+        .produce()
+      val premisesEntity = ApprovedPremisesEntityFactory()
+        .withAddressLine1("Test House")
+        .withAddressLine2("Test Lane")
+        .withTown("Test Town")
+        .withPostcode("TE57 8PP")
+        .withDefaults()
+        .produce()
+
+      val premises = Cas1ExternalPremisesDto(
+        startDate = placement.actualArrivalDate,
+        endDate = placement.actualDepartureDate,
+        addressLine1 = premisesEntity.addressLine1,
+        addressLine2 = premisesEntity.addressLine2,
+        town = premisesEntity.town,
+        postcode = premisesEntity.postcode,
+      )
+
+      val expected = Cas1PlacementPairDto(
+        requestForPlacement = Cas1ExternalRequestForPlacementDto(
+          decision = requestForPlacement.decision,
+          rejectionReason = rejectionReason,
+          submittedBy = requestSubmittedBy,
+          submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
+          withdrawalReason = requestForPlacement.withdrawalReason,
+          withdrawalDate = withdrawalDate,
+          expectedArrivalDate = placement.expectedArrivalDate,
+          durationDays = duration,
+          status = requestForPlacement.status,
+        ),
+
+        placement = Cas1ExternalPlacementDto(
+          actualArrivalDate = placement.actualArrivalDate,
+          actualDepartureDate = placement.actualDepartureDate,
+          cancellationReason = placement.cancellation?.reason?.name,
+          status = placement.status,
+          premises = premises,
+        ),
+        dateApplied = placement.statusSetDate!!,
+      )
+
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns requestSubmittedBy
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement, rejectionReason, withdrawalDate, placement, premisesEntity)
+
+      assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Transforms to placement history that is arrived`() {
+      val duration = 12
+      val expectedArrivalDate = LocalDate.now().minusDays(100)
+      val actualArrivalDate = expectedArrivalDate.plusDays(1)
+      val expectedDepartureDate = expectedArrivalDate.plusWeeks(duration.toLong())
+      val actualDepartureDate = null
+      val canonicalPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = expectedArrivalDate,
+        arrivalFlexible = false,
+        duration = duration,
+      )
+      val rejectionReason = null
+      val withdrawalDate = null
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Bob")
+        .produce()
+      val requestSubmittedBy = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+      val requestForPlacement = RequestForPlacementFactory()
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
+        .withStatus(RequestForPlacementStatus.placementBooked)
+        .withSubmittedBy(requestSubmittedBy)
+        .withSubmittedAt(Instant.now().minusDays(110))
+        .withWithdrawalReason(null)
+        .withCanonicalPlacementPeriod(canonicalPlacementPeriod)
+        .produce()
+
+      val placement = Cas1SpaceBookingShortSummaryFactory()
+        .withStatus(Cas1SpaceBookingStatus.ARRIVED)
+        .withStatusSetDate(actualArrivalDate)
+        .withExpectedArrivalDate(expectedArrivalDate)
+        .withActualArrivalDate(actualArrivalDate)
+        .withExpectedDepartureDate(expectedDepartureDate)
+        .withActualDepartureDate(actualDepartureDate)
+        .produce()
+      val premisesEntity = ApprovedPremisesEntityFactory()
+        .withAddressLine1("Test House")
+        .withAddressLine2("Test Lane")
+        .withTown("Test Town")
+        .withPostcode("TE57 8PP")
+        .withDefaults()
+        .produce()
+
+      val premises = Cas1ExternalPremisesDto(
+        startDate = placement.actualArrivalDate,
+        endDate = placement.expectedDepartureDate,
+        addressLine1 = premisesEntity.addressLine1,
+        addressLine2 = premisesEntity.addressLine2,
+        town = premisesEntity.town,
+        postcode = premisesEntity.postcode,
+      )
+
+      val expected = Cas1PlacementPairDto(
+        requestForPlacement = Cas1ExternalRequestForPlacementDto(
+          status = requestForPlacement.status,
+          decision = requestForPlacement.decision,
+          rejectionReason = rejectionReason,
+          submittedBy = requestSubmittedBy,
+          submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
+          withdrawalReason = requestForPlacement.withdrawalReason,
+          withdrawalDate = withdrawalDate,
+          expectedArrivalDate = placement.expectedArrivalDate,
+          durationDays = duration,
+        ),
+
+        placement = Cas1ExternalPlacementDto(
+          actualArrivalDate = placement.actualArrivalDate,
+          actualDepartureDate = placement.actualDepartureDate,
+          cancellationReason = placement.cancellation?.reason?.name,
+          status = placement.status,
+          premises = premises,
+        ),
+        dateApplied = placement.statusSetDate!!,
+      )
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns requestSubmittedBy
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement, rejectionReason, withdrawalDate, placement, premisesEntity)
+
+      assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Transforms to placement history that is withdrawn`() {
+      val duration = 12
+      val expectedArrivalDate = LocalDate.now().minusDays(100)
+      val actualArrivalDate = null
+      val expectedDepartureDate = expectedArrivalDate.plusWeeks(duration.toLong())
+      val actualDepartureDate = null
+      val canonicalPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = expectedArrivalDate,
+        arrivalFlexible = false,
+        duration = duration,
+      )
+      val rejectionReason = null
+      val withdrawalDate = expectedArrivalDate.minusDays(1)
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Bob")
+        .produce()
+      val requestSubmittedBy = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+      val requestForPlacement = RequestForPlacementFactory()
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
+        .withStatus(RequestForPlacementStatus.requestWithdrawn)
+        .withSubmittedBy(requestSubmittedBy)
+        .withSubmittedAt(Instant.now().minusDays(110))
+        .withIsWithdrawn(true)
+        .withWithdrawalReason(WithdrawPlacementRequestReason.noCapacityDueToLostBed)
+        .withCanonicalPlacementPeriod(canonicalPlacementPeriod)
+        .produce()
+      val reason = CancellationReason(
+        id = UUID.randomUUID(),
+        name = "Oops",
+        isActive = true,
+        serviceScope = "approved-premises",
+      )
+      val cancellation = Cas1SpaceBookingCancellation(
+        occurredAt = expectedArrivalDate.minusDays(1),
+        recordedAt = Instant.now(),
+        reason = reason,
+        reasonNotes = "Because",
+      )
+      val placement = Cas1SpaceBookingShortSummaryFactory()
+        .withStatus(Cas1SpaceBookingStatus.ARRIVED)
+        .withStatusSetDate(withdrawalDate)
+        .withExpectedArrivalDate(expectedArrivalDate)
+        .withActualArrivalDate(actualArrivalDate)
+        .withExpectedDepartureDate(expectedDepartureDate)
+        .withActualDepartureDate(actualDepartureDate)
+        .withCancellation(cancellation)
+        .produce()
+      val premisesEntity = ApprovedPremisesEntityFactory()
+        .withAddressLine1("Test House")
+        .withAddressLine2("Test Lane")
+        .withTown("Test Town")
+        .withPostcode("TE57 8PP")
+        .withDefaults()
+        .produce()
+
+      val premises = Cas1ExternalPremisesDto(
+        startDate = placement.expectedArrivalDate,
+        endDate = placement.expectedDepartureDate,
+        addressLine1 = premisesEntity.addressLine1,
+        addressLine2 = premisesEntity.addressLine2,
+        town = premisesEntity.town,
+        postcode = premisesEntity.postcode,
+      )
+
+      val expected = Cas1PlacementPairDto(
+        requestForPlacement = Cas1ExternalRequestForPlacementDto(
+          status = requestForPlacement.status,
+          decision = requestForPlacement.decision,
+          rejectionReason = rejectionReason,
+          submittedBy = requestSubmittedBy,
+          submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
+          withdrawalReason = requestForPlacement.withdrawalReason,
+          withdrawalDate = withdrawalDate,
+          expectedArrivalDate = placement.expectedArrivalDate,
+          durationDays = duration,
+        ),
+
+        placement = Cas1ExternalPlacementDto(
+          actualArrivalDate = placement.actualArrivalDate,
+          actualDepartureDate = placement.actualDepartureDate,
+          cancellationReason = placement.cancellation?.reason?.name,
+          status = placement.status,
+          premises = premises,
+        ),
+        dateApplied = placement.statusSetDate!!,
+      )
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns requestSubmittedBy
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement, rejectionReason, withdrawalDate, placement, premisesEntity)
+
+      assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Transforms to placement history that is withdrawn with Other reason`() {
+      val duration = 12
+      val expectedArrivalDate = LocalDate.now().minusDays(100)
+      val actualArrivalDate = null
+      val expectedDepartureDate = expectedArrivalDate.plusWeeks(duration.toLong())
+      val actualDepartureDate = null
+      val canonicalPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = expectedArrivalDate,
+        arrivalFlexible = false,
+        duration = duration,
+      )
+      val rejectionReason = null
+      val withdrawalDate = expectedArrivalDate.minusDays(1)
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Bob")
+        .produce()
+      val requestSubmittedBy = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+      val requestForPlacement = RequestForPlacementFactory()
+        .withDecision(PlacementApplicationDecision.ACCEPTED)
+        .withStatus(RequestForPlacementStatus.requestWithdrawn)
+        .withSubmittedBy(requestSubmittedBy)
+        .withSubmittedAt(Instant.now().minusDays(110))
+        .withIsWithdrawn(true)
+        .withWithdrawalReason(WithdrawPlacementRequestReason.noCapacityDueToLostBed)
+        .withCanonicalPlacementPeriod(canonicalPlacementPeriod)
+        .produce()
+      val reason = CancellationReason(
+        id = UUID.randomUUID(),
+        name = "Other",
+        isActive = true,
+        serviceScope = "approved-premises",
+      )
+      val cancellation = Cas1SpaceBookingCancellation(
+        occurredAt = expectedArrivalDate.minusDays(1),
+        recordedAt = Instant.now(),
+        reason = reason,
+        reasonNotes = "Because",
+      )
+      val placement = Cas1SpaceBookingShortSummaryFactory()
+        .withStatus(Cas1SpaceBookingStatus.ARRIVED)
+        .withStatusSetDate(withdrawalDate)
+        .withExpectedArrivalDate(expectedArrivalDate)
+        .withActualArrivalDate(actualArrivalDate)
+        .withExpectedDepartureDate(expectedDepartureDate)
+        .withActualDepartureDate(actualDepartureDate)
+        .withCancellation(cancellation)
+        .produce()
+      val premisesEntity = ApprovedPremisesEntityFactory()
+        .withAddressLine1("Test House")
+        .withAddressLine2("Test Lane")
+        .withTown("Test Town")
+        .withPostcode("TE57 8PP")
+        .withDefaults()
+        .produce()
+
+      val premises = Cas1ExternalPremisesDto(
+        startDate = placement.expectedArrivalDate,
+        endDate = placement.expectedDepartureDate,
+        addressLine1 = premisesEntity.addressLine1,
+        addressLine2 = premisesEntity.addressLine2,
+        town = premisesEntity.town,
+        postcode = premisesEntity.postcode,
+      )
+
+      val expected = Cas1PlacementPairDto(
+        requestForPlacement = Cas1ExternalRequestForPlacementDto(
+          decision = requestForPlacement.decision,
+          rejectionReason = rejectionReason,
+          submittedBy = requestSubmittedBy,
+          submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
+          withdrawalReason = requestForPlacement.withdrawalReason,
+          withdrawalDate = withdrawalDate,
+          expectedArrivalDate = placement.expectedArrivalDate,
+          durationDays = duration,
+          status = requestForPlacement.status,
+        ),
+        placement = Cas1ExternalPlacementDto(
+          status = placement.status,
+          actualArrivalDate = placement.actualArrivalDate,
+          actualDepartureDate = placement.actualDepartureDate,
+          cancellationReason = placement.cancellation?.reasonNotes,
+          premises = premises,
+        ),
+        dateApplied = placement.statusSetDate!!,
+      )
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns requestSubmittedBy
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement, rejectionReason, withdrawalDate, placement, premisesEntity)
+
+      assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Transforms to placement history that's rejected`() {
+      val duration = 12
+      val expectedArrivalDate = LocalDate.now().minusDays(100)
+      val canonicalPlacementPeriod = Cas1RequestedPlacementPeriod(
+        arrival = expectedArrivalDate,
+        arrivalFlexible = false,
+        duration = duration,
+      )
+      val rejectionReason = "Oh no"
+      val withdrawalDate = null
+      val user = UserEntityFactory()
+        .withDefaults()
+        .withName("Bob")
+        .produce()
+      val requestSubmittedBy = Cas1StaffDto(
+        name = user.name,
+        username = user.deliusUsername,
+        staffCode = user.deliusStaffCode,
+      )
+      val requestForPlacement = RequestForPlacementFactory()
+        .withDecision(PlacementApplicationDecision.REJECTED)
+        .withStatus(RequestForPlacementStatus.requestRejected)
+        .withSubmittedBy(requestSubmittedBy)
+        .withSubmittedAt(Instant.now().minusDays(110))
+        .withCanonicalPlacementPeriod(canonicalPlacementPeriod)
+        .withStatusSetDate(expectedArrivalDate)
+        .produce()
+      val expected = Cas1PlacementPairDto(
+        requestForPlacement = Cas1ExternalRequestForPlacementDto(
+          decision = requestForPlacement.decision,
+          rejectionReason = rejectionReason,
+          submittedBy = requestSubmittedBy,
+          submittedAt = requestForPlacement.submittedAt?.toLocalDate(),
+          withdrawalReason = requestForPlacement.withdrawalReason,
+          withdrawalDate = withdrawalDate,
+          expectedArrivalDate = expectedArrivalDate,
+          durationDays = duration,
+          status = requestForPlacement.status,
+        ),
+        placement = null,
+        dateApplied = requestForPlacement.statusSetDate,
+      )
+      every { mockCas1AssessmentTransformer.transformToStaffDto(user) } returns requestSubmittedBy
+
+      val result = cas1ExternalApplicationTransformer.transformToCas1PlacementPair(requestForPlacement, rejectionReason, withdrawalDate, null, null)
+
+      assertThat(result).isEqualTo(expected)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following fields to CAS1Suitable Application and makes sure it gets them from the correct places:

`
  // application info
  val applicationStartedAt: OffsetDateTime?,
  val applicationStartedBy: String?,
  val applicationSubmittedAt: OffsetDateTime?,
  val applicationSubmittedBy: String?,
  val applicationExpiresAt: LocalDate?,

  // assessment info
  val assessmentDecision: String?,
  val assessmentRejectionRationale: String?,

  // request for placement info
  val requestForPlacementDecision: String?,
  val requestForPlacementRejectionReason: String?,
  val requestSubmittedBy: String?,
  val requestSubmittedAt: LocalDate?,
  val withdrawalReason: String?,
  val withdrawalDate: LocalDate?,

  // placement info
  val actualArrivalDate: LocalDate?,
  val actualDepartureDate: LocalDate?,
  val cancellationReason: String?,

// multiple
  val expectedArrivalDate: LocalDate?,
  val duration: Int?,
`