### PR TITLE
FM-982 Use Cohort in CAS2 Bail Contact Log Entries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas2/model/Cas2ApplicationStatusUpdatedEventDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas2/model/Cas2ApplicationStatusUpdatedEventDetails.kt
@@ -19,4 +19,6 @@ data class Cas2ApplicationStatusUpdatedEventDetails(
   @get:JsonProperty("updatedAt", required = true) val updatedAt: java.time.Instant,
 
   @get:JsonProperty("applicationOrigin", required = true) val applicationOrigin: String = "homeDetentionCurfew",
+
+  val cohort: Cas2EventCohort? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas2/model/Cas2ApplicationSubmittedEventDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas2/model/Cas2ApplicationSubmittedEventDetails.kt
@@ -18,6 +18,8 @@ data class Cas2ApplicationSubmittedEventDetails(
 
   @get:JsonProperty("applicationOrigin", required = true) val applicationOrigin: String = "homeDetentionCurfew",
 
+  val cohort: Cas2EventCohort? = null,
+
   @Schema(example = "Thu Mar 30 01:00:00 BST 2023", description = "")
   @get:JsonProperty("bailHearingDate") val bailHearingDate: java.time.LocalDate? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas2/model/Cas2EventCohort.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/events/cas2/model/Cas2EventCohort.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Cas2EventCohort(
+
+  @Schema(example = "HDC", required = true, description = "The machine readable code identifying the cohort")
+  val code: String,
+
+  @Schema(example = "Home Detention Curfew", required = true, description = "The human readable name of the cohort")
+  val longDisplayName: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApplicationOrigin.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApplicationOrigin.kt
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonValue
  * The Application Origin is a misnomer as it doesn't identify the 'origin' of the application
  * in all cases. It can be thought of as the application's type
  */
+@Deprecated(
+  "ApplicationOrigin does not reliably identify the origin of an application use Cas2Cohort instead.",
+)
 @Suppress("ktlint:standard:enum-entry-name-case", "EnumNaming")
 enum class ApplicationOrigin(@get:JsonValue val value: String) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2ApplicationService.kt
@@ -8,6 +8,7 @@ import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEventDetailsSubmittedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2EventCohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
@@ -365,6 +366,9 @@ class Cas2ApplicationService(
               ),
             ),
             applicationOrigin = application.applicationOrigin.toString(),
+            cohort = application.cohort?.let {
+              Cas2EventCohort(code = it.name, longDisplayName = it.longDisplayName)
+            },
           ),
         ),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2StatusUpdateService.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEventDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2EventCohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2Status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.ExternalUser
@@ -143,6 +144,9 @@ class Cas2StatusUpdateService(
             applicationId = application.id,
             applicationUrl = applicationUrlTemplate.replace("#id", application.id.toString()),
             applicationOrigin = application.applicationOrigin.toString(),
+            cohort = application.cohort?.let {
+              Cas2EventCohort(code = it.name, longDisplayName = it.longDisplayName)
+            },
             personReference = PersonReference(
               crn = application.crn,
               noms = application.nomsNumber.toString(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcApplicationService.kt
@@ -7,6 +7,7 @@ import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEventDetailsSubmittedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2EventCohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
@@ -328,6 +329,9 @@ class Cas2HdcApplicationService(
               ),
             ),
             applicationOrigin = ApplicationOrigin.homeDetentionCurfew.toString(),
+            cohort = application.cohort?.let {
+              Cas2EventCohort(code = it.name, longDisplayName = it.longDisplayName)
+            },
           ),
         ),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcStatusUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcStatusUpdateService.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEventDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2EventCohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2Status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.EventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.ExternalUser
@@ -151,6 +152,9 @@ class Cas2HdcStatusUpdateService(
           eventDetails = Cas2ApplicationStatusUpdatedEventDetails(
             applicationId = application.id,
             applicationUrl = applicationUrlTemplate.replace("#id", application.id.toString()),
+            cohort = application.cohort?.let {
+              Cas2EventCohort(code = it.name, longDisplayName = it.longDisplayName)
+            },
             personReference = PersonReference(
               crn = application.crn,
               noms = application.nomsNumber.toString(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ApplicationSubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2ApplicationSubmissionTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEvent
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ApplicationOrigin
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
@@ -953,6 +954,16 @@ class Cas2v2ApplicationSubmissionTest : IntegrationTestBase() {
             .isOk
 
           Assertions.assertThat(domainEventRepository.count()).isEqualTo(1)
+
+          val domainEventFromJson = jsonMapper.readValue(
+            domainEventRepository.findFirstByOrderByCreatedAtDesc()!!.data,
+            Cas2ApplicationSubmittedEvent::class.java,
+          )
+          Assertions.assertThat(domainEventFromJson.eventDetails.cohort?.code)
+            .isEqualTo(Cas2Cohort.COURT_BAIL.name)
+          Assertions.assertThat(domainEventFromJson.eventDetails.cohort?.longDisplayName)
+            .isEqualTo(Cas2Cohort.COURT_BAIL.longDisplayName)
+
           Assertions.assertThat(cas2RealAssessmentRepository.count()).isEqualTo(1)
           Assertions.assertThat(cas2RealApplicationRepository.findByIdAndServiceOrigin(applicationId, Cas2ServiceOrigin.BAIL)!!.submittedAt).isNotNull()
           Assertions.assertThat(emailAsserter.assertEmailsRequestedCount(2))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2StatusUpdateTest.kt
@@ -137,6 +137,10 @@ class Cas2v2StatusUpdateTest(
           )
           assertThat(domainEventFromJson.eventDetails.applicationUrl)
             .isEqualTo(expectedFrontEndUrl)
+          assertThat(domainEventFromJson.eventDetails.cohort?.code)
+            .isEqualTo(Cas2Cohort.COURT_BAIL.name)
+          assertThat(domainEventFromJson.eventDetails.cohort?.longDisplayName)
+            .isEqualTo(Cas2Cohort.COURT_BAIL.longDisplayName)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/factory/events/Cas2ApplicationStatusUpdatedEventDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/factory/events/Cas2ApplicationStatusUpdatedEventDetailsFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.factory.events
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationStatusUpdatedEventDetails
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2EventCohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2Status
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.ExternalUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
@@ -19,6 +20,7 @@ class Cas2ApplicationStatusUpdatedEventDetailsFactory : Factory<Cas2ApplicationS
   private var newStatus: Yielded<Cas2Status> = { Cas2StatusFactory().produce() }
   private var updatedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
   private var updatedBy: Yielded<ExternalUser> = { ExternalUserFactory().produce() }
+  private var cohort: Yielded<Cas2EventCohort?> = { null }
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
@@ -44,6 +46,10 @@ class Cas2ApplicationStatusUpdatedEventDetailsFactory : Factory<Cas2ApplicationS
     this.updatedBy = { externalUser }
   }
 
+  fun withCohort(cohort: Cas2EventCohort?) = apply {
+    this.cohort = { cohort }
+  }
+
   override fun produce(): Cas2ApplicationStatusUpdatedEventDetails = Cas2ApplicationStatusUpdatedEventDetails(
     applicationId = this.applicationId(),
     applicationUrl = this.applicationUrl(),
@@ -51,5 +57,6 @@ class Cas2ApplicationStatusUpdatedEventDetailsFactory : Factory<Cas2ApplicationS
     newStatus = this.newStatus(),
     updatedAt = this.updatedAt(),
     updatedBy = this.updatedBy(),
+    cohort = this.cohort(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/factory/events/Cas2ApplicationSubmittedEventDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/factory/events/Cas2ApplicationSubmittedEventDetailsFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEventDetails
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2ApplicationSubmittedEventDetailsSubmittedBy
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2EventCohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Cas2StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.PersonReference
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomDateTimeBefore
@@ -23,6 +24,7 @@ class Cas2ApplicationSubmittedEventDetailsFactory : Factory<Cas2ApplicationSubmi
   private var conditionalReleaseDate: Yielded<LocalDate?> = { LocalDate.parse("2023-04-29") }
   private var submittedAt: Yielded<Instant> = { Instant.now().randomDateTimeBefore(7) }
   private var submittedByStaffMember: Yielded<Cas2StaffMember> = { StaffMemberFactory().produce() }
+  private var cohort: Yielded<Cas2EventCohort?> = { null }
 
   fun withApplicationId(applicationId: UUID) = apply {
     this.applicationId = { applicationId }
@@ -60,6 +62,10 @@ class Cas2ApplicationSubmittedEventDetailsFactory : Factory<Cas2ApplicationSubmi
     this.submittedByStaffMember = { staffMember }
   }
 
+  fun withCohort(cohort: Cas2EventCohort?) = apply {
+    this.cohort = { cohort }
+  }
+
   override fun produce() = Cas2ApplicationSubmittedEventDetails(
     applicationId = this.applicationId(),
     applicationUrl = this.applicationUrl(),
@@ -72,5 +78,6 @@ class Cas2ApplicationSubmittedEventDetailsFactory : Factory<Cas2ApplicationSubmi
     submittedBy = Cas2ApplicationSubmittedEventDetailsSubmittedBy(
       staffMember = this.submittedByStaffMember(),
     ),
+    cohort = this.cohort(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2StatusUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2StatusUpdateTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.events.cas2.model.Ca
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ApplicationStatusSeeding
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.dto.Cas2HdcAssessmentStatusUpdate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
@@ -87,6 +88,7 @@ class Cas2StatusUpdateTest(
           val application = cas2ApplicationEntityFactory.produceAndPersist {
             withCreatedByUser(applicant)
             withSubmittedAt(OffsetDateTime.now())
+            withCohort(Cas2Cohort.HDC)
           }
 
           cas2AssessmentEntityFactory.produceAndPersist {
@@ -128,6 +130,10 @@ class Cas2StatusUpdateTest(
           )
           assertThat(domainEventFromJson.eventDetails.applicationUrl)
             .isEqualTo(expectedFrontEndUrl)
+          assertThat(domainEventFromJson.eventDetails.cohort?.code)
+            .isEqualTo(Cas2Cohort.HDC.name)
+          assertThat(domainEventFromJson.eventDetails.cohort?.longDisplayName)
+            .isEqualTo(Cas2Cohort.HDC.longDisplayName)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2SubmissionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/Cas2SubmissionTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2A
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2ApplicationRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2AssessmentRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2Cohort
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateDetailEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateDetailRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2StatusUpdateRepository
@@ -731,6 +732,7 @@ class Cas2SubmissionTest(
             withNomsNumber(offenderDetails.otherIds.nomsNumber.toString())
             withId(applicationId)
             withCreatedByUser(submittingUser)
+            withCohort(Cas2Cohort.HDC)
             withData(
               """
                         {
@@ -774,6 +776,8 @@ class Cas2SubmissionTest(
         )
         assertThat(domainEventFromJson.eventDetails.applicationUrl)
           .isEqualTo(expectedFrontEndUrl)
+        assertThat(domainEventFromJson.eventDetails.cohort?.code).isEqualTo(Cas2Cohort.HDC.name)
+        assertThat(domainEventFromJson.eventDetails.cohort?.longDisplayName).isEqualTo(Cas2Cohort.HDC.longDisplayName)
 
         val persistedAssessment = realAssessmentRepository.findByServiceOrigin(Cas2ServiceOrigin.HDC).first()
         assertThat(persistedAssessment.application.id).isEqualTo(applicationId)


### PR DESCRIPTION
This [PR FM-982](https://dsdmoj.atlassian.net/browse/FM-982) is to use cohort in CAS2 Bail contact log entries