### PR TITLE
FM-1000 Remove PersonInfoResult and PersonSummaryInfoResult Unknown

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
@@ -485,7 +485,7 @@ class Cas1ApplicationsController(
       val crn = it.getCrn()
       applicationsTransformer.transformDomainToCas1ApplicationSummary(
         it,
-        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.Unknown(crn),
+        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.NotFound(crn),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1ApplicationsController.kt
@@ -209,7 +209,7 @@ class Cas1ApplicationsController(
 
     val personInfo =
       when (val personInfoResult = offenderDetailService.getPersonInfoResult(body.crn, user.cas1CreateApplicationLaoStrategy())) {
-        is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(
+        is PersonInfoResult.NotFound -> throw NotFoundProblem(
           personInfoResult.crn,
           "Offender",
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1AssessmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1AssessmentsController.kt
@@ -297,7 +297,7 @@ class Cas1AssessmentsController(
       val crn = it.crn
       cas1AssessmentTransformer.transformDomainToCas1AssessmentSummary(
         it,
-        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.Unknown(crn),
+        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.NotFound(crn),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/controller/Cas1PeopleController.kt
@@ -61,7 +61,6 @@ class Cas1PeopleController(
 
     val timeline = when (val personInfoResult = offenderDetailService.getPersonInfoResult(crn, user.cas1LaoStrategy())) {
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
-      is PersonInfoResult.Unknown -> throw personInfoResult.throwable ?: RuntimeException("Could not retrieve person info for CRN: $crn")
       is PersonInfoResult.Success.Full -> buildPersonInfoWithTimeline(personInfoResult, crn)
       is PersonInfoResult.Success.Restricted -> buildPersonInfoWithoutTimeline(personInfoResult)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1ApplicationSeedService.kt
@@ -421,7 +421,7 @@ class Cas1ApplicationSeedServiceCaches(
           laoStrategy = LaoStrategy.NeverRestricted,
         )
       ) {
-        is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(
+        is PersonInfoResult.NotFound -> throw NotFoundProblem(
           personInfoResult.crn,
           "Offender",
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1DuplicateApplicationSeedJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/seed/Cas1DuplicateApplicationSeedJob.kt
@@ -69,7 +69,7 @@ class Cas1DuplicateApplicationSeedJob(
           laoStrategy = LaoStrategy.NeverRestricted,
         )
       ) {
-        is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(
+        is PersonInfoResult.NotFound -> throw NotFoundProblem(
           personInfoResult.crn,
           "Offender",
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcOffenderService.kt
@@ -180,7 +180,7 @@ class Cas2HdcOffenderService(
 
   fun getFullInfoForPersonOrThrow(crn: String): PersonInfoResult.Success.Full {
     when (val personInfo = getInfoForPerson(crn)) {
-      is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(crn, "Offender")
+      is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
       is PersonInfoResult.Success.Restricted -> throw ForbiddenProblem("Offender $crn is Restricted.")
       is PersonInfoResult.Success.Full -> return personInfo
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcOffenderService.kt
@@ -149,10 +149,14 @@ class Cas2HdcOffenderService(
       is ClientResult.Failure.StatusCode -> if (offenderResponse.status.value() == HttpStatus.NOT_FOUND.value()) {
         return PersonInfoResult.NotFound(crn)
       } else {
-        return PersonInfoResult.Unknown(crn, offenderResponse.toException())
+        log.warn("error fetching crn $crn", offenderResponse.toException())
+        return PersonInfoResult.NotFound(crn)
       }
 
-      is ClientResult.Failure -> return PersonInfoResult.Unknown(crn, offenderResponse.toException())
+      is ClientResult.Failure -> {
+        log.warn("error fetching crn $crn", offenderResponse.toException())
+        return PersonInfoResult.NotFound(crn)
+      }
     }
 
     val inmateDetails = offender.otherIds.nomsNumber?.let { nomsNumber ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ApplicationsController.kt
@@ -84,7 +84,7 @@ class Cas3ApplicationsController(
 
     val personInfo =
       when (val personInfoResult = offenderDetailService.getPersonInfoResult(body.crn, user.cas3LaoStrategy())) {
-        is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> throw NotFoundProblem(
+        is PersonInfoResult.NotFound -> throw NotFoundProblem(
           personInfoResult.crn,
           "Offender",
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ApplicationsController.kt
@@ -171,7 +171,7 @@ class Cas3ApplicationsController(
       val crn = it.getCrn()
       cas3ApplicationTransformer.transformDomainToCas3ApplicationSummary(
         it,
-        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.Unknown(crn),
+        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.NotFound(crn),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3AssessmentController.kt
@@ -220,7 +220,7 @@ class Cas3AssessmentController(
       val crn = it.crn
       cas3AssessmentTransformer.transformDomainToApiSummary(
         it,
-        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.Unknown(crn),
+        personInfoResults.firstOrNull { it.crn == crn } ?: PersonInfoResult.NotFound(crn),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BookingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3v2BookingController.kt
@@ -145,7 +145,7 @@ class Cas3v2BookingController(
         bookingTransformer.transformJpaToApi(
           jpa = booking,
           personInfo = personInfoResults.firstOrNull { pi -> pi.crn == booking.crn }
-            ?: PersonInfoResult.Unknown(booking.crn),
+            ?: PersonInfoResult.NotFound(booking.crn),
         )
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateApplicationOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateApplicationOffenderNameJob.kt
@@ -40,7 +40,7 @@ class Cas3UpdateApplicationOffenderNameJob(
         val personInfos = splitAndRetrievePersonInfo(pageSize, offendersCrn)
 
         slice.content.forEach {
-          val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
+          val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.NotFound(it.crn)
           updateApplication(personInfo, it)
         }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateApplicationOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateApplicationOffenderNameJob.kt
@@ -58,7 +58,7 @@ class Cas3UpdateApplicationOffenderNameJob(
     try {
       val offenderName = when (personInfo) {
         is PersonSummaryInfoResult.Success.Full -> "${personInfo.summary.name.forename} ${personInfo.summary.name.surname}"
-        is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> throw Exception("Offender not found")
+        is PersonSummaryInfoResult.NotFound -> throw Exception("Offender not found")
         is PersonSummaryInfoResult.Success.Restricted -> throw Exception("You are not authorized")
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateBookingOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateBookingOffenderNameJob.kt
@@ -40,7 +40,7 @@ class Cas3UpdateBookingOffenderNameJob(
         val personInfos = splitAndRetrievePersonInfo(pageSize, offendersCrn)
 
         slice.content.forEach {
-          val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
+          val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.NotFound(it.crn)
           updateBooking(personInfo, it)
         }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateBookingOffenderNameJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/migration/Cas3UpdateBookingOffenderNameJob.kt
@@ -58,7 +58,7 @@ class Cas3UpdateBookingOffenderNameJob(
     try {
       val offenderName = when (personInfo) {
         is PersonSummaryInfoResult.Success.Full -> "${personInfo.summary.name.forename} ${personInfo.summary.name.surname}"
-        is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> throw Exception("Offender not found for crn ${it.crn}")
+        is PersonSummaryInfoResult.NotFound -> throw Exception("Offender not found for crn ${it.crn}")
         is PersonSummaryInfoResult.Success.Restricted -> throw Exception("You are not authorized")
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3BedspaceSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3BedspaceSearchService.kt
@@ -198,7 +198,7 @@ class Cas3BedspaceSearchService(
   ): PersonType = when (personSummaryInfo) {
     is PersonSummaryInfoResult.Success.Full -> PersonType.fullPerson
     is PersonSummaryInfoResult.Success.Restricted -> PersonType.restrictedPerson
-    is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> PersonType.unknownPerson
+    is PersonSummaryInfoResult.NotFound -> PersonType.unknownPerson
   }
 
   private fun Cas3BedspaceSearchParameters.calculateEndDate(): LocalDate {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ReportService.kt
@@ -85,7 +85,7 @@ class Cas3ReportService(
     val personInfos = splitAndRetrievePersonInfo(crns)
     log.info("Person info retrieved")
     val reportData = referralsInScope.map {
-      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
+      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.NotFound(it.crn)
       TransitionalAccommodationReferralReportDataAndPersonInfo(it, personInfo)
     }
     log.info("Creating report")
@@ -245,7 +245,7 @@ class Cas3ReportService(
     val crns = bookingsInScope.map { it.crn }.distinct().toSet()
     val personInfos = splitAndRetrievePersonInfo(crns)
     val reportData = bookingsInScope.map {
-      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
+      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.NotFound(it.crn)
       FutureBookingsReportDataAndPersonInfo(it, personInfo)
     }
 
@@ -271,7 +271,7 @@ class Cas3ReportService(
     val crns = bookingsInScope.map { it.crn }.distinct().toSet()
     val personInfos = splitAndRetrievePersonInfo(crns)
     val reportData = bookingsInScope.map {
-      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.Unknown(it.crn)
+      val personInfo = personInfos[it.crn] ?: PersonSummaryInfoResult.NotFound(it.crn)
       FutureBookingsCsvReportGenerator().convert(it, personInfo)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/PeopleController.kt
@@ -84,7 +84,6 @@ class PeopleController(
 
     when (val personInfo = offenderDetailService.getPersonInfoResult(crn, user.cas1LaoStrategy())) {
       is PersonInfoResult.NotFound -> throw NotFoundProblem(crn, "Offender")
-      is PersonInfoResult.Unknown -> throw personInfo.throwable ?: RuntimeException("Could not retrieve person info for CRN: $crn")
       is PersonInfoResult.Success -> return ResponseEntity.ok(
         personTransformer.personInfoResultToPerson(personInfo),
       )
@@ -292,7 +291,6 @@ class PeopleController(
       is PersonSummaryInfoResult.Success.Full -> personSummaryInfoResult.summary.nomsId
       is PersonSummaryInfoResult.Success.Restricted -> throw ForbiddenProblem()
       is PersonSummaryInfoResult.NotFound -> throw NotFoundProblem(crn, "Person")
-      is PersonSummaryInfoResult.Unknown -> throw NotFoundProblem(crn, "Person")
     }
 
     if (nomsNumber == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonInfoResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonInfoResult.kt
@@ -21,5 +21,4 @@ sealed interface PersonInfoResult {
   }
 
   data class NotFound(override val crn: String) : PersonInfoResult
-  data class Unknown(override val crn: String, val throwable: Throwable? = null) : PersonInfoResult
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonSummaryInfoResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/PersonSummaryInfoResult.kt
@@ -20,7 +20,6 @@ sealed interface PersonSummaryInfoResult {
   }
 
   data class NotFound(override val crn: String) : PersonSummaryInfoResult
-  data class Unknown(override val crn: String, val throwable: Throwable? = null) : PersonSummaryInfoResult
 }
 
 fun List<PersonSummaryInfoResult>.forCrn(crn: String) = this.first { it.crn == crn }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderDetailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderDetailService.kt
@@ -51,7 +51,6 @@ class OffenderDetailService(
 
         is PersonSummaryInfoResult.Success.Restricted,
         is PersonSummaryInfoResult.NotFound,
-        is PersonSummaryInfoResult.Unknown,
         ->
           personTransformer.personSummaryInfoResultToPersonInfoResult(it, null)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt
@@ -408,7 +408,6 @@ class OffenderService(
 
     is PersonSummaryInfoResult.Success.Restricted -> CasResult.Unauthorised()
     is PersonSummaryInfoResult.NotFound -> CasResult.NotFound("Person", crn)
-    is PersonSummaryInfoResult.Unknown -> CasResult.NotFound("Person", crn)
   }
 
   fun getOffenderBookingDetails(crn: String): CasResult<BookingDetails> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/PersonTransformer.kt
@@ -41,11 +41,6 @@ class PersonTransformer {
       nomsNumber = personSummaryInfoResult.nomsNumber,
       tier = personSummaryInfoResult.tier,
     )
-
-    is PersonSummaryInfoResult.Unknown -> PersonInfoResult.Unknown(
-      crn = personSummaryInfoResult.crn,
-      throwable = personSummaryInfoResult.throwable,
-    )
   }
 
   fun personInfoResultToPersonSummaryInfoResult(
@@ -65,10 +60,6 @@ class PersonTransformer {
       crn = personInfo.crn,
       nomsNumber = personInfo.nomsNumber,
       tier = personInfo.tier,
-    )
-
-    is PersonInfoResult.Unknown -> PersonSummaryInfoResult.Unknown(
-      crn = personInfo.crn,
     )
   }
 
@@ -94,7 +85,7 @@ class PersonTransformer {
         )
       }
 
-      is PersonSummaryInfoResult.NotFound, is PersonSummaryInfoResult.Unknown -> {
+      is PersonSummaryInfoResult.NotFound -> {
         return UnknownPersonSummary(
           crn = personSummaryInfo.crn,
           personType = PersonSummaryDiscriminator.unknownPersonSummary,
@@ -140,7 +131,7 @@ class PersonTransformer {
       tier = personInfoResult.tier,
     )
 
-    is PersonInfoResult.NotFound, is PersonInfoResult.Unknown -> UnknownPerson(
+    is PersonInfoResult.NotFound -> UnknownPerson(
       type = PersonType.unknownPerson,
       crn = personInfoResult.crn,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/util/OffenderDetailsUtils.kt
@@ -27,9 +27,6 @@ fun getNameFromPersonSummaryInfoResult(result: PersonSummaryInfoResult): String 
   is PersonSummaryInfoResult.NotFound -> {
     "Unknown"
   }
-  is PersonSummaryInfoResult.Unknown -> {
-    "Unknown"
-  }
 }
 
 fun <V> PersonSummaryInfoResult.tryGetDetails(value: (CaseSummary) -> V): V? = when (this) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderDetailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/OffenderDetailServiceTest.kt
@@ -280,35 +280,6 @@ class OffenderDetailServiceTest {
     }
 
     @Test
-    fun `If offender unknown don't fetch inmate details and return unknown`() {
-      val personSummaryInfoResult = PersonSummaryInfoResult.Unknown(CRN1)
-
-      every {
-        mockOffenderService.getPersonSummaryInfoResults(
-          crns = setOf(CRN1),
-          laoStrategy = CheckUserAccess(DELIUS_USERNAME),
-        )
-      } returns listOf(personSummaryInfoResult)
-
-      every {
-        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
-          personSummaryInfoResult = personSummaryInfoResult,
-          inmateStatus = null,
-        )
-      } returns mockPersonInfoResult1
-
-      val result = service.getPersonInfoResults(
-        crns = setOf(CRN1),
-        laoStrategy = CheckUserAccess(DELIUS_USERNAME),
-      )
-
-      assertThat(result).hasSize(1)
-      assertThat(result[0]).isEqualTo(mockPersonInfoResult1)
-
-      verify { mockPrisonsApiClient wasNot Called }
-    }
-
-    @Test
     fun `If offender not found don't fetch inmate details`() {
       val personSummaryInfoResult = PersonSummaryInfoResult.NotFound(CRN1)
 
@@ -442,34 +413,6 @@ class OffenderDetailServiceTest {
       )
 
       assertThat(result).isEqualTo(mockPersonInfoResult1)
-    }
-
-    @Test
-    fun `If offender unknown don't fetch inmate details and return unknown`() {
-      val personSummaryInfoResult = PersonSummaryInfoResult.Unknown(CRN1)
-
-      every {
-        mockOffenderService.getPersonSummaryInfoResults(
-          crns = setOf(CRN1),
-          laoStrategy = CheckUserAccess(DELIUS_USERNAME),
-        )
-      } returns listOf(personSummaryInfoResult)
-
-      every {
-        mockPersonTransformer.personSummaryInfoResultToPersonInfoResult(
-          personSummaryInfoResult = personSummaryInfoResult,
-          inmateStatus = null,
-        )
-      } returns mockPersonInfoResult1
-
-      val result = service.getPersonInfoResult(
-        crn = CRN1,
-        laoStrategy = CheckUserAccess(DELIUS_USERNAME),
-      )
-
-      assertThat(result).isEqualTo(mockPersonInfoResult1)
-
-      verify { mockPrisonsApiClient wasNot Called }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/PersonTransformerTest.kt
@@ -56,20 +56,6 @@ class PersonTransformerTest {
     }
 
     @Test
-    fun unknown() {
-      val result = personTransformer.personInfoResultToPersonSummaryInfoResult(
-        PersonInfoResult.Unknown(
-          crn = "CRN123",
-        ),
-      )
-
-      assertThat(result).isInstanceOf(PersonSummaryInfoResult.Unknown::class.java)
-      val unknown = result as PersonSummaryInfoResult.Unknown
-
-      assertThat(unknown.crn).isEqualTo("CRN123")
-    }
-
-    @Test
     fun restricted() {
       val result = personTransformer.personInfoResultToPersonSummaryInfoResult(
         PersonInfoResult.Success.Restricted(
@@ -185,19 +171,6 @@ class PersonTransformerTest {
       assertThat(result.personType).isEqualTo(PersonSummaryDiscriminator.unknownPersonSummary)
       assertThat(result).isInstanceOf(UnknownPersonSummary::class.java)
     }
-
-    @Test
-    fun `map unknown person`() {
-      val result = personTransformer.personSummaryInfoResultToPersonSummary(
-        PersonSummaryInfoResult.Unknown(
-          crn = "the crn",
-        ),
-      )
-
-      assertThat(result.crn).isEqualTo("the crn")
-      assertThat(result.personType).isEqualTo(PersonSummaryDiscriminator.unknownPersonSummary)
-      assertThat(result).isInstanceOf(UnknownPersonSummary::class.java)
-    }
   }
 
   @Nested
@@ -223,18 +196,6 @@ class PersonTransformerTest {
       val crn = "CRN123"
 
       val personInfoResult = PersonInfoResult.NotFound(crn)
-
-      val result = personTransformer.personInfoResultToPerson(personInfoResult)
-
-      assertThat(result is UnknownPerson).isTrue
-      assertThat(result.crn).isEqualTo(crn)
-    }
-
-    @Test
-    fun `transforms correctly for an unknown person info`() {
-      val crn = "CRN123"
-
-      val personInfoResult = PersonInfoResult.Unknown(crn)
 
       val result = personTransformer.personInfoResultToPerson(personInfoResult)
 
@@ -820,20 +781,6 @@ class PersonTransformerTest {
       assertThat(result is PersonInfoResult.NotFound).isTrue
       assertThat(result.crn).isEqualTo(crn)
       assertThat(result).isEqualTo(PersonInfoResult.NotFound(crn))
-    }
-
-    @Test
-    fun `transformPersonSummaryInfoToPersonInfo transforms correctly for an unknown person info`() {
-      val crn = randomStringMultiCaseWithNumbers(10)
-      val throwable = Throwable("Exception message")
-
-      val personSummaryInfoResult = PersonSummaryInfoResult.Unknown(crn, throwable)
-
-      val result = personTransformer.personSummaryInfoResultToPersonInfoResult(personSummaryInfoResult, null)
-
-      assertThat(result is PersonInfoResult.Unknown).isTrue
-      assertThat(result.crn).isEqualTo(crn)
-      assertThat(result).isEqualTo(PersonInfoResult.Unknown(crn, throwable))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/transformer/TaskTransformerTest.kt
@@ -139,7 +139,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.id).isEqualTo(assessment.id)
@@ -168,7 +168,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.status).isEqualTo(TaskStatus.inProgress)
@@ -189,7 +189,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.status).isEqualTo(TaskStatus.complete)
@@ -210,7 +210,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.status).isEqualTo(TaskStatus.infoRequested)
@@ -227,7 +227,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.apArea).isEqualTo(mockApArea)
@@ -244,7 +244,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.createdFromAppeal).isEqualTo(createdFromAppeal)
@@ -262,7 +262,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformAssessmentToTask(
         assessment,
-        getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.createdFromAppeal).isEqualTo(false)
@@ -291,7 +291,7 @@ class TaskTransformerTest {
       placementApplication.requestedDuration = 12
       val result = taskTransformer.transformPlacementApplicationToTask(
         placementApplication,
-        getOffenderSummariesWithDiscriminator(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.status).isEqualTo(TaskStatus.notStarted)
@@ -328,7 +328,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformPlacementApplicationToTask(
         placementApplication,
-        getOffenderSummariesWithDiscriminator(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       if (placementType === JpaPlacementType.ROTL) {
@@ -352,7 +352,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformPlacementApplicationToTask(
         placementApplication,
-        getOffenderSummariesWithDiscriminator(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.status).isEqualTo(TaskStatus.inProgress)
@@ -375,7 +375,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformPlacementApplicationToTask(
         placementApplication,
-        getOffenderSummariesWithDiscriminator(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.status).isEqualTo(TaskStatus.complete)
@@ -396,7 +396,7 @@ class TaskTransformerTest {
 
       val result = taskTransformer.transformPlacementApplicationToTask(
         placementApplication,
-        getOffenderSummariesWithDiscriminator(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
+        getPersonSummaryInfoResultForDiscriminatorType(placementApplication.application.crn, PersonSummaryDiscriminator.fullPersonSummary),
       )
 
       assertThat(result.apArea).isEqualTo(mockApArea)
@@ -413,7 +413,7 @@ class TaskTransformerTest {
 
     val result = taskTransformer.transformAssessmentToTask(
       assessment,
-      getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.restrictedPersonSummary),
+      getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.restrictedPersonSummary),
     )
 
     assertThat(result.personSummary is RestrictedPersonSummary).isTrue()
@@ -426,35 +426,32 @@ class TaskTransformerTest {
 
     val result = taskTransformer.transformAssessmentToTask(
       assessment,
-      getOffenderSummariesWithDiscriminator(assessment.application.crn, PersonSummaryDiscriminator.unknownPersonSummary),
+      getPersonSummaryInfoResultForDiscriminatorType(assessment.application.crn, PersonSummaryDiscriminator.unknownPersonSummary),
     )
 
     assertThat(result.personSummary is UnknownPersonSummary).isTrue()
     assertThat(result.personSummary.crn).isEqualTo(assessment.application.crn)
   }
 
-  fun getOffenderSummariesWithDiscriminator(crn: String, discriminator: PersonSummaryDiscriminator): List<PersonSummaryInfoResult> {
-    PersonSummaryDiscriminator.fullPersonSummary
-    when (discriminator) {
-      PersonSummaryDiscriminator.fullPersonSummary ->
-        return listOf(
-          PersonSummaryInfoResult.Success.Full(
-            crn,
-            CaseSummaryFactory().withName(NameFactory().withForename("First").withSurname("Last").produce())
-              .produce(),
-            tier = null,
-          ),
-        )
-      PersonSummaryDiscriminator.restrictedPersonSummary -> {
-        return listOf(
-          PersonSummaryInfoResult.Success.Restricted(crn, "nomsNumber", tier = null),
-        )
-      }
-      PersonSummaryDiscriminator.unknownPersonSummary -> {
-        return listOf(
-          PersonSummaryInfoResult.Unknown(crn),
-        )
-      }
+  fun getPersonSummaryInfoResultForDiscriminatorType(crn: String, discriminator: PersonSummaryDiscriminator): List<PersonSummaryInfoResult> = when (discriminator) {
+    PersonSummaryDiscriminator.fullPersonSummary ->
+      return listOf(
+        PersonSummaryInfoResult.Success.Full(
+          crn,
+          CaseSummaryFactory().withName(NameFactory().withForename("First").withSurname("Last").produce())
+            .produce(),
+          tier = null,
+        ),
+      )
+    PersonSummaryDiscriminator.restrictedPersonSummary -> {
+      return listOf(
+        PersonSummaryInfoResult.Success.Restricted(crn, "nomsNumber", tier = null),
+      )
+    }
+    PersonSummaryDiscriminator.unknownPersonSummary -> {
+      return listOf(
+        PersonSummaryInfoResult.NotFound(crn),
+      )
     }
   }
 }


### PR DESCRIPTION
We want to remove `PersonSummaryInfoResult.Unknown()` and `PersonInfoResult.Unknown()` as these types are poorly defined and never actually returned by the `OffenderService` and `OffenderDetailService`, which is the primary service responsible for returning `PersonSummaryInfoResult` and `PersonInfoResult` (in potential 'unknown' scenarios these services instead throw an exception)

In all cases where `Unknown` was replaced with `NotFound`,  the code receiving the resultant `PersonSummaryInfoResult`or `PersonInfoResult` was treating Unknown the same as NotFound, so there’s no change in logic required