### PR TITLE
Add RiskLevel to Cas2OasysRiskLevel mapping to fix RiskLevel bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OASysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/transformer/Cas2OASysTransformer.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OAsysRisk
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OAsysRoshRatingsDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OAsysRoshSummaryDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.OASysAssessmentSummary
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RisksToTheIndividual
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshRatings
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RoshSummary
@@ -34,10 +35,18 @@ class Cas2OASysTransformer {
 
   fun toOASysRoshRatingsDto(roshRatings: RoshRatings?) = Cas2OAsysRoshRatingsDto(
     metadata = Cas2OASysAssessmentInfoTransformer().toAssessmentMetadata(roshRatings),
-    overallRisk = Cas2OASysRiskLevel.forValue(roshRatings?.rosh?.determineOverallRiskLevel()?.name),
-    riskToChildren = Cas2OASysRiskLevel.forValue(roshRatings?.rosh?.riskChildrenCommunity?.name),
-    riskToPublic = Cas2OASysRiskLevel.forValue(roshRatings?.rosh?.riskPublicCommunity?.name),
-    riskToKnownAdult = Cas2OASysRiskLevel.forValue(roshRatings?.rosh?.riskKnownAdultCommunity?.name),
-    riskToStaff = Cas2OASysRiskLevel.forValue(roshRatings?.rosh?.riskStaffCommunity?.name),
+    overallRisk = roshRatings?.rosh?.determineOverallRiskLevel().toCas2OASysRiskLevel(),
+    riskToChildren = roshRatings?.rosh?.riskChildrenCommunity.toCas2OASysRiskLevel(),
+    riskToPublic = roshRatings?.rosh?.riskPublicCommunity.toCas2OASysRiskLevel(),
+    riskToKnownAdult = roshRatings?.rosh?.riskKnownAdultCommunity.toCas2OASysRiskLevel(),
+    riskToStaff = roshRatings?.rosh?.riskStaffCommunity.toCas2OASysRiskLevel(),
   )
+}
+
+fun RiskLevel?.toCas2OASysRiskLevel() = when (this) {
+  RiskLevel.VERY_HIGH -> Cas2OASysRiskLevel.VERY_HIGH
+  RiskLevel.HIGH -> Cas2OASysRiskLevel.HIGH
+  RiskLevel.MEDIUM -> Cas2OASysRiskLevel.MEDIUM
+  RiskLevel.LOW -> Cas2OASysRiskLevel.LOW
+  null -> null
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2OASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/integration/Cas2v2OASysTest.kt
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OASysAssessmentMetadataDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OASysRiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OAsysRiskToSelfDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OAsysRoshRatingsDto
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2OAsysRoshSummaryDto
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.apandoasys.RiskLevel
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RisksToTheIndividualFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshRatingsFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoshSummaryFactory
@@ -250,7 +252,12 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
     fun `Assessment available`(role: RoleAndAuthSource) {
       apAndOASysMockSuccessfulRoshRatingsCall(
         crn = "CRN123",
-        response = RoshRatingsFactory().produce(),
+        response = RoshRatingsFactory()
+          .withRiskStaffCommunity(RiskLevel.LOW)
+          .withRiskChildrenCommunity(RiskLevel.MEDIUM)
+          .withRiskKnownAdultCommunity(RiskLevel.VERY_HIGH)
+          .withRiskPublicCommunity(RiskLevel.LOW)
+          .produce(),
       )
 
       val result = webTestClient.get()
@@ -262,6 +269,11 @@ class Cas2v2OASysTest : Cas2v2IntegrationTestBase() {
         .bodyAsObject<Cas2OAsysRoshRatingsDto>()
 
       assertThat(result.metadata.hasApplicableAssessment).isTrue
+      assertThat(result.riskToStaff).isEqualTo(Cas2OASysRiskLevel.LOW)
+      assertThat(result.riskToChildren).isEqualTo(Cas2OASysRiskLevel.MEDIUM)
+      assertThat(result.overallRisk).isEqualTo(Cas2OASysRiskLevel.VERY_HIGH)
+      assertThat(result.riskToKnownAdult).isEqualTo(Cas2OASysRiskLevel.VERY_HIGH)
+      assertThat(result.riskToPublic).isEqualTo(Cas2OASysRiskLevel.LOW)
     }
   }
 }


### PR DESCRIPTION
`Cas2OASysTransformer.toOASysRoshRatingsDto()`  calls `Cas2OASysRiskLevel.forValue` and passes in `RoshRatings.RiskLevel` names (i.e. `VERY_HIGH`, `HIGH`, `MEDIUM`, `LOW`) and since `forValue()` is matching on snake case values (`very_high`, `high`, `medium`, `low`) this is currently returning null risk ratings in the `Cas2OAsysRoshRatingsDto`.

This PR adds a mapping from RiskLevel to Cas2OasysRiskLevel.