### PR TITLE
FM-864-V3-tiers-added-to'tiers'-reference-data-endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/controller/ReferenceDataController.kt
@@ -43,6 +43,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeli
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.cas1.Cas1CharacteristicRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService.Companion.FEATURE_FLAG_USE_TIER_V3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
@@ -84,6 +86,8 @@ class ReferenceDataController(
   private val apAreaRepository: ApAreaRepository,
   private val apAreaTransformer: ApAreaTransformer,
   private val tierService: TierService,
+  private val featureFlagService: FeatureFlagService,
+
 ) {
 
   @Operation(
@@ -400,5 +404,15 @@ class ReferenceDataController(
     value = ["/reference-data/tiers"],
     produces = ["application/json"],
   )
-  fun referenceDataTiersGet(): ResponseEntity<List<AvailableTierDto>> = ResponseEntity.ok(tierService.getAvailableTiers())
+  fun referenceDataTiersGet(): ResponseEntity<List<AvailableTierDto>> {
+    val useTierV3 = featureFlagService.getBooleanFlag(FEATURE_FLAG_USE_TIER_V3)
+
+    return ResponseEntity.ok(
+      if (useTierV3) {
+        tierService.getAvailableTiersV3()
+      } else {
+        tierService.getAvailableTiersV2()
+      },
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/TierService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/TierService.kt
@@ -7,13 +7,27 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.AvailableTier
 class TierService {
 
   companion object {
-    val TIERS = listOf(
+    private val TIERS_V2 = listOf(
       "D0", "D1", "D2", "D3",
       "C0", "C1", "C2", "C3",
       "B0", "B1", "B2", "B3",
       "A0", "A1", "A2", "A3",
     ).map { AvailableTierDto(it) }
+
+    private val TIERS_V3 = listOf(
+      "A",
+      "B",
+      "C",
+      "D",
+      "E",
+      "F",
+      "G",
+      "MISSING",
+      "NOT_SUPERVISED",
+    ).map { AvailableTierDto(it) }
   }
 
-  fun getAvailableTiers(): List<AvailableTierDto> = TIERS
+  fun getAvailableTiersV2(): List<AvailableTierDto> = TIERS_V2
+
+  fun getAvailableTiersV3(): List<AvailableTierDto> = TIERS_V3
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/ReferenceDataTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.common.dto.AvailableTier
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnApArea
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.ApAreaTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.CancellationReasonTransformer
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.DepartureReasonTransformer
@@ -955,7 +956,8 @@ class ReferenceDataTest : IntegrationTestBase() {
   @Nested
   inner class GetAvailableTiers {
     @Test
-    fun `Get Available Tiers returns 200 with correct body`() {
+    fun `Get Available Tiers returns v2 tiers`() {
+      mockFeatureFlagService.setFlag(FeatureFlagService.FEATURE_FLAG_USE_TIER_V3, false)
       val expectedJson = jsonMapper.writeValueAsString(
         listOf(
           AvailableTierDto("D0"),
@@ -974,6 +976,35 @@ class ReferenceDataTest : IntegrationTestBase() {
           AvailableTierDto("A1"),
           AvailableTierDto("A2"),
           AvailableTierDto("A3"),
+        ),
+      )
+
+      val jwt = jwtAuthHelper.createValidAuthorizationCodeJwt()
+
+      webTestClient.get()
+        .uri("/reference-data/tiers")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .json(expectedJson)
+    }
+
+    @Test
+    fun `Get Available Tiers returns v3 tiers`() {
+      mockFeatureFlagService.setFlag(FeatureFlagService.FEATURE_FLAG_USE_TIER_V3, true)
+      val expectedJson = jsonMapper.writeValueAsString(
+        listOf(
+          AvailableTierDto("A"),
+          AvailableTierDto("B"),
+          AvailableTierDto("C"),
+          AvailableTierDto("D"),
+          AvailableTierDto("E"),
+          AvailableTierDto("F"),
+          AvailableTierDto("G"),
+          AvailableTierDto("MISSING"),
+          AvailableTierDto("NOT_SUPERVISED"),
         ),
       )
 


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-864

# Changes in this PR
Updated reference data endpoint to return V3 tiers when feature flag is enabled. 

## Integration Test
Added test that V3 tiers were being returned when feature flag is enabled. 
Added test to ensure behaviour remains unchanged when feature flag is disabled. 