### PR TITLE
Fm 927 include milliseconds to migration names and add check

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,8 +8,24 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  verify_migration_scripts:
+    name: Check migration script filenames
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: 'false'
+          fetch-depth: 0
+
+      - name: Validate migration script filenames
+        run: sh ./script/verify_migration_scripts
+
   gradle_build:
     name: Gradle Build
+    needs: verify_migration_scripts
     permissions:
       contents: read
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION

--- a/script/generate_migration
+++ b/script/generate_migration
@@ -18,7 +18,7 @@ else
     exit 1
 fi
 
-timestamp=`date "+%Y%m%d%H%M%S"`
+timestamp=`date "+%Y%m%d%H%M%S000"`
 migration_name=`echo "$2" | awk '{print tolower($0)}' | tr ' ' '_'`
 filename="$(echo ${timestamp}__${migration_name}).sql"
 echo "Creating migration: $filename"

--- a/script/verify_migration_scripts
+++ b/script/verify_migration_scripts
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+cutoff_date="20260804"
+migration_dir="src/main/resources/db/migration/all"
+
+for file in "$migration_dir"/*.sql; do
+  filename="$(basename "$file")"
+  file_date_prefix="$(echo "$filename" | cut -c1-8)"
+
+  [ "$file_date_prefix" \> "20260804" ] || continue
+
+  case "$filename" in
+    20261021113642__add_cohort_to_cas_2_application_summary_views.sql) continue ;;
+  esac
+
+  if ! echo "$filename" | grep -Eq '^[0-9]{14}000__.+\.sql$'; then
+    echo "Invalid migration filename: $filename"
+    echo "Expected pattern: ^[0-9]{14}000__.+\\.sql$"
+    echo "Use the generate_migration.sh script to create a new migration"
+    exit 1
+  fi
+done
+
+echo "Migration filename check passed for files after $cutoff_date"


### PR DESCRIPTION
Ref: https://dsdmoj.atlassian.net/browse/FM-927

**Changes:**
- Updated `script/generate_migration` to generate migration filenames with an extra `000` suffix after the seconds component.
- Added `script/check_migration_script_filenames` and wired it into CI to validate migration filename format after a cutoff date.
- Updated `.github/workflows/verify.yml` to run the new validation job before the Gradle build.

A previous workflow included a test file which would trigger the PR pipeline to fail, this was tested and the failure was verified, and the test migration script removed before force pushing:

<img width="1976" height="1304" alt="image" src="https://github.com/user-attachments/assets/c27bef9a-8f3d-4475-b55f-ca06203bc848" />
