### PR TITLE
Minimise likelyhood of cases race conditions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.common.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ApDeliusContextApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.HMPPSTierApiClient
@@ -53,6 +55,7 @@ class CaseService(
   private val useTierV3: Boolean
     get() = featureFlagService.getBooleanFlag(FEATURE_FLAG_USE_TIER_V3)
 
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun ensureCaseExists(crn: String): CaseDto {
     val normalizedCrn = crn.uppercase()
     val caseSummary = getCaseSummary(normalizedCrn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationCreationService.kt
@@ -68,13 +68,14 @@ class Cas1ApplicationCreationService(
   private val offenderDetailService: OffenderDetailService,
 ) {
 
+  @Transactional
   fun createApprovedPremisesApplication(
     offenderDetails: OffenderDetailSummary,
     user: UserEntity,
     convictionId: Long?,
     deliusEventNumber: String?,
     offenceId: String?,
-  ) = validatedCasResult {
+  ): CasResult<ApprovedPremisesApplicationEntity> = validatedCasResult {
     val crn = offenderDetails.otherIds.crn
 
     val managingTeamCodes = when (val managingTeamsResult = apDeliusContextApiClient.getTeamsManagingCase(crn)) {
@@ -114,8 +115,6 @@ class Cas1ApplicationCreationService(
       ),
     )
 
-    caseService.ensureCaseExists(crn)
-
     managingTeamCodes.forEach {
       createdApplication.teamCodes += applicationTeamCodeRepository.save(
         ApplicationTeamCodeEntity(
@@ -129,6 +128,7 @@ class Cas1ApplicationCreationService(
     return success(createdApplication)
   }
 
+  @Transactional
   fun createApplication(
     crn: String,
     user: UserEntity,


### PR DESCRIPTION
**Remove duplicate ensureCaseExists calls**
The legacy CAS1 create application function calls ‘ensureCaseExists’ twice which leads to uneccessary upstream calls
This commit also adds @transactional to the create application functions

**'Ensure case exists' should commit immediately**
We have observed some race conditions where multiple threads call `ensureCaseExists` for the same CRN, leading to a unique constraint error. This commit reduces (but does not eliminate) the likelyhood of this issue by ensuring any new (or updated) case is committed immediately instead of waiting on the calling thread’s transaction