### PR TITLE
FM-956-support-live-tiering-sorting-for-cas1-applications/all

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApplicationSortField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/api/model/ApplicationSortField.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 enum class ApplicationSortField(@get:JsonValue val value: String) {
 
   tier("tier"),
+  personTier("personTier"),
   createdAt("createdAt"),
   arrivalDate("arrivalDate"),
   releaseType("releaseType"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ApplicationEntity.kt
@@ -66,6 +66,8 @@ SELECT
     CAST(apa.risk_ratings AS TEXT) as riskRatings,
     apa.status as status,
     apa.risk_ratings -> 'tier' -> 'value' ->> 'level' as tier,
+    (cases.tier_v2->>'tierScore')::text AS personTierV2Score,
+    (cases.tier_v3->>'tierScore')::text AS personTierV3Score,
     apa.is_withdrawn as isWithdrawn,
     apa.release_type as releaseType,
     (
@@ -75,6 +77,7 @@ SELECT
 FROM approved_premises_applications apa
 LEFT JOIN applications a ON a.id = apa.id
 LEFT JOIN users u on u.id = a.created_by_user_id
+LEFT OUTER JOIN cases ON cases.crn = a.crn
 WHERE apa.is_inapplicable IS NOT TRUE 
 AND (
       :crnOrName IS NULL OR 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas1/Cas1ApplicationService.kt
@@ -19,6 +19,8 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserPermission
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService.Companion.FEATURE_FLAG_USE_TIER_V3
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.getMetadata
@@ -39,6 +41,7 @@ class Cas1ApplicationService(
   private val cas1UserAccessService: Cas1UserAccessService,
   private val userAccessService: UserAccessService,
   private val offenderService: OffenderService,
+  private val featureFlagService: FeatureFlagService,
 ) {
   fun getApplication(applicationId: UUID) = approvedPremisesApplicationRepository.findByIdOrNull(applicationId)
 
@@ -95,10 +98,18 @@ class Cas1ApplicationService(
     pageSize: Int? = 10,
     createdByUserId: UUID? = null,
   ): Pair<List<ApprovedPremisesApplicationSummary>, PaginationMetadata?> {
+    val useTierV3 = featureFlagService.getBooleanFlag(FEATURE_FLAG_USE_TIER_V3)
+
     val sortField = when (sortBy) {
       ApplicationSortField.arrivalDate -> "arrivalDate"
       ApplicationSortField.createdAt -> "a.created_at"
       ApplicationSortField.tier -> "tier"
+      ApplicationSortField.personTier ->
+        if (useTierV3) {
+          "personTierV3Score"
+        } else {
+          "personTierV2Score"
+        }
       ApplicationSortField.releaseType -> "releaseType"
       else -> "a.created_at"
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas1/Cas1ApplicationTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NamedId
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewApplication
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewWithdrawal
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.OfflineApplication
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Person
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.PersonStatus
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ReleaseTypeOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.RequestForPlacement
@@ -772,6 +773,162 @@ class Cas1ApplicationTest : IntegrationTestBase() {
           assertThat(responseBody[2].tier).isEqualTo("M1")
         }
       }
+    }
+
+    @Test
+    fun `Get applications all returns 200 correct body and sorted by person tier v2 desc`() {
+      mockFeatureFlagService.setFlag(FEATURE_FLAG_USE_TIER_V3, false)
+
+      givenAUser { userEntity, jwt ->
+        givenAnOffender { offender1, _ ->
+          givenAnOffender { offender2, _ ->
+            givenAnOffender { offender3, _ ->
+
+              val crn1 = offender1.otherIds.crn
+              val crn2 = offender2.otherIds.crn
+              val crn3 = offender3.otherIds.crn
+
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withCrn(crn1)
+                withCreatedByUser(userEntity)
+              }
+
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withCrn(crn2)
+                withCreatedByUser(userEntity)
+              }
+
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withCrn(crn3)
+                withCreatedByUser(userEntity)
+              }
+
+              caseEntityFactory.produceAndPersist {
+                withCrn(crn1)
+                withTierV2(
+                  TierFactory()
+                    .withTierScore("A")
+                    .produce(),
+                )
+              }
+
+              caseEntityFactory.produceAndPersist {
+                withCrn(crn2)
+                withTierV2(
+                  TierFactory()
+                    .withTierScore("Z")
+                    .produce(),
+                )
+              }
+
+              caseEntityFactory.produceAndPersist {
+                withCrn(crn3)
+                withTierV2(
+                  TierFactory()
+                    .withTierScore("M")
+                    .produce(),
+                )
+              }
+
+              val responseBody = webTestClient.get()
+                .uri("/cas1/applications/all?page=1&sortDirection=desc&sortBy=personTier")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .bodyAsListOfObjects<Cas1ApplicationSummary>()
+
+              assertThat(responseBody).hasSize(3)
+
+              assertThat(responseBody[0].person.crn).isEqualTo(crn2)
+              assertThat(responseBody[0].person.personTierScore()).isEqualTo("Z")
+
+              assertThat(responseBody[1].person.crn).isEqualTo(crn3)
+              assertThat(responseBody[1].person.personTierScore()).isEqualTo("M")
+
+              assertThat(responseBody[2].person.crn).isEqualTo(crn1)
+              assertThat(responseBody[2].person.personTierScore()).isEqualTo("A")
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `Get applications all returns 200 correct body and sorted by person tier v3 desc`() {
+      mockFeatureFlagService.setFlag(FEATURE_FLAG_USE_TIER_V3, true)
+
+      givenAUser { userEntity, jwt ->
+        givenAnOffender { offender1, _ ->
+          givenAnOffender { offender2, _ ->
+            givenAnOffender { offender3, _ ->
+
+              val crn1 = offender1.otherIds.crn
+              val crn2 = offender2.otherIds.crn
+              val crn3 = offender3.otherIds.crn
+
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withCrn(crn1)
+                withCreatedByUser(userEntity)
+              }
+
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withCrn(crn2)
+                withCreatedByUser(userEntity)
+              }
+
+              approvedPremisesApplicationEntityFactory.produceAndPersist {
+                withCrn(crn3)
+                withCreatedByUser(userEntity)
+              }
+
+              caseEntityFactory.produceAndPersist {
+                withCrn(crn1)
+                withTierV2(TierFactory().withTierScore("A").produce())
+                withTierV3(TierFactory().withTierScore("Z").produce())
+              }
+
+              caseEntityFactory.produceAndPersist {
+                withCrn(crn2)
+                withTierV2(TierFactory().withTierScore("Z").produce())
+                withTierV3(TierFactory().withTierScore("A").produce())
+              }
+
+              caseEntityFactory.produceAndPersist {
+                withCrn(crn3)
+                withTierV2(TierFactory().withTierScore("M").produce())
+                withTierV3(TierFactory().withTierScore("M").produce())
+              }
+
+              val responseBody = webTestClient.get()
+                .uri("/cas1/applications/all?page=1&sortDirection=desc&sortBy=personTier")
+                .header("Authorization", "Bearer $jwt")
+                .header("X-Service-Name", ServiceName.approvedPremises.value)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .bodyAsListOfObjects<Cas1ApplicationSummary>()
+
+              assertThat(responseBody).hasSize(3)
+
+              assertThat(responseBody[0].person.crn).isEqualTo(crn1)
+              assertThat(responseBody[0].person.personTierScore()).isEqualTo("Z")
+
+              assertThat(responseBody[1].person.crn).isEqualTo(crn3)
+              assertThat(responseBody[1].person.personTierScore()).isEqualTo("M")
+
+              assertThat(responseBody[2].person.crn).isEqualTo(crn2)
+              assertThat(responseBody[2].person.personTierScore()).isEqualTo("A")
+            }
+          }
+        }
+      }
+    }
+    private fun Person.personTierScore() = when (this) {
+      is FullPerson -> this.tier?.tierScore
+      is RestrictedPerson -> this.tier?.tierScore
+      else -> null
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/service/GetAllApprovedPremisesApplicationsTest.kt
@@ -359,7 +359,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   }
 
   @ParameterizedTest
-  @EnumSource(ApplicationSortField::class)
+  @EnumSource(ApplicationSortField::class, names = ["personTier"], mode = EnumSource.Mode.EXCLUDE)
   fun `findAllApprovedPremisesSummaries sorts by a given field in ascending order`(sortField: ApplicationSortField) {
     allApplications.sort(SortDirection.asc, sortField)
     val chunkedApplications = allApplications.chunked(10)
@@ -388,7 +388,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
   }
 
   @ParameterizedTest
-  @EnumSource(ApplicationSortField::class)
+  @EnumSource(ApplicationSortField::class, names = ["personTier"], mode = EnumSource.Mode.EXCLUDE)
   fun `findAllApprovedPremisesSummaries sorts by a given field in descending order`(sortField: ApplicationSortField) {
     allApplications.sort(SortDirection.desc, sortField)
     val chunkedApplications = allApplications.chunked(10)
@@ -451,6 +451,7 @@ class GetAllApprovedPremisesApplicationsTest : InitialiseDatabasePerClassTestBas
         ApplicationSortField.createdAt -> compareValues(a.createdAt, b.createdAt)
         ApplicationSortField.arrivalDate -> compareValues(a.arrivalDate, b.arrivalDate)
         ApplicationSortField.tier -> compareValues(a.riskRatings?.tier?.status, b.riskRatings?.tier?.status)
+        ApplicationSortField.personTier -> error("personTier uses dedicated integration tests")
         ApplicationSortField.releaseType -> compareValues(a.releaseType, b.releaseType)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/unit/service/cas1/Cas1ApplicationServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplic
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRole
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesApplicationStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.FeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.UserAccessService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas1.Cas1ApplicationDomainEventService
@@ -76,6 +77,9 @@ class Cas1ApplicationServiceTest {
 
   @MockK
   private lateinit var userRepository: UserRepository
+
+  @MockK
+  private lateinit var featureFlagService: FeatureFlagService
 
   @InjectMockKs
   private lateinit var service: Cas1ApplicationService


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-956

# Changes in this PR
Adds support for sorting CAS1 applications by a person's live tier:

Added `ApplicationSortField.personTier`
Updated the SQL that backs `GET /cas1/applications/all` to define tierScore as follows. Whether tier_v2 or tier_v3 is used depend on the value of FEATURE-FLAGS_USE-TIER-V3

cases.tier_v2 → tierScore

cases.tier_v3 → tierScore

# Tests
Added integration tests covering sorting by live tier for both V2 and V3 feature flag states
Excluded personTier from generic service-level sort parameterisation, as behaviour is covered by dedicated integration tests