### PR TITLE
Split Sar Data Service into CAS specific Services

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/service/Cas1SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/service/Cas1SubjectAccessRequestService.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CAS1SubjectAccessRequestRepository
+import java.time.LocalDateTime
+
+@Service
+class Cas1SubjectAccessRequestService(
+  val cas1SubjectAccessRequestRepository: CAS1SubjectAccessRequestRepository,
+) {
+
+  @SuppressWarnings("CyclomaticComplexMethod")
+  fun getSarResult(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
+    val approvedPremisesApplicationsJson = cas1SubjectAccessRequestRepository.getApprovedPremisesApplicationsJson(crn, nomsNumber, startDate, endDate)
+    val apApplicationTimelineJson = cas1SubjectAccessRequestRepository.getApprovedPremisesApplicationTimeLineJson(crn, nomsNumber, startDate, endDate)
+    val apAssessmentsJson = cas1SubjectAccessRequestRepository.getApprovedPremisesAssessments(crn, nomsNumber, startDate, endDate)
+    val apAssessmentClarificationNotesJson = cas1SubjectAccessRequestRepository.getApprovedPremisesAssessmentClarificationNotes(crn, nomsNumber, startDate, endDate)
+
+    val apSpaceBookingsJson = cas1SubjectAccessRequestRepository.spaceBookings(crn, nomsNumber, startDate, endDate)
+    val domainEventsJson = cas1SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate)
+    val domainEventMetaDataJson = cas1SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate)
+
+    val placementApplicationsJson = cas1SubjectAccessRequestRepository.placementApplications(crn, nomsNumber, startDate, endDate)
+    val placementRequestsJson = cas1SubjectAccessRequestRepository.placementRequests(crn, nomsNumber, startDate, endDate)
+    val placementRequirementsJson = cas1SubjectAccessRequestRepository.placementRequirements(crn, nomsNumber, startDate, endDate)
+    val placementRequirementCriteriaJson = cas1SubjectAccessRequestRepository.placementRequirementsCriteria(crn, nomsNumber, startDate, endDate)
+    val offlineApplicationsJson = cas1SubjectAccessRequestRepository.offlineApplications(crn, nomsNumber, startDate, endDate)
+    val bookingNotMadesJson = cas1SubjectAccessRequestRepository.bookingNotMades(crn, nomsNumber, startDate, endDate)
+    val appealsJson = cas1SubjectAccessRequestRepository.appeals(crn, nomsNumber, startDate, endDate)
+
+    if (listOf(
+        approvedPremisesApplicationsJson,
+        apApplicationTimelineJson,
+        apAssessmentsJson,
+        apAssessmentClarificationNotesJson,
+        apSpaceBookingsJson,
+        domainEventsJson,
+        domainEventMetaDataJson,
+        placementApplicationsJson,
+        placementRequestsJson,
+        placementRequirementsJson,
+        placementRequirementCriteriaJson,
+        offlineApplicationsJson,
+        bookingNotMadesJson,
+        appealsJson,
+      ).all { it == null }
+    ) {
+      return null
+    }
+
+    val result = """
+      {
+         "Applications": ${ approvedPremisesApplicationsJson ?: "[]"},
+         "ApplicationTimeline": ${ apApplicationTimelineJson ?: "[]"},
+         "Assessments": ${ apAssessmentsJson ?: "[]"},
+         "AssessmentClarificationNotes": ${ apAssessmentClarificationNotesJson ?: "[]"},
+         "SpaceBookings": ${ apSpaceBookingsJson ?: "[]"},
+         "OfflineApplications": ${ offlineApplicationsJson ?: "[]"},
+         "Appeals": ${ appealsJson ?: "[]"},
+         "PlacementApplications": ${ placementApplicationsJson ?: "[]"},
+         "PlacementRequests": ${ placementRequestsJson ?: "[]"},
+         "PlacementRequirements": ${ placementRequirementsJson ?: "[]"},
+         "PlacementRequirementCriteria": ${ placementRequirementCriteriaJson ?: "[]"},
+         "BookingNotMades": ${ bookingNotMadesJson ?: "[]"},
+         "DomainEvents": ${ domainEventsJson ?: "[]"},
+         "DomainEventsMetadata": ${ domainEventMetaDataJson ?: "[]"}
+      }
+    """.trimIndent()
+
+    return result
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2/service/Cas2SubjectAccessRequestService.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2SubjectAccessRequestRepository
+import java.time.LocalDateTime
+
+@Service
+class Cas2SubjectAccessRequestService(
+  val cas2v2SubjectAccessRequestRepository: Cas2v2SubjectAccessRequestRepository,
+) {
+
+  fun getSarResult(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
+    val applicationsJson = cas2v2SubjectAccessRequestRepository.getApplicationsJson(crn, nomsNumber, startDate, endDate)
+    val applicationNotesJson = cas2v2SubjectAccessRequestRepository.getApplicationNotes(crn, nomsNumber, startDate, endDate)
+    val statusUpdatesJson = cas2v2SubjectAccessRequestRepository.getStatusUpdates(crn, nomsNumber, startDate, endDate)
+    val statusUpdateDetailsJson =
+      cas2v2SubjectAccessRequestRepository.getStatusUpdateDetails(crn, nomsNumber, startDate, endDate)
+    val assessmentsJson = cas2v2SubjectAccessRequestRepository.getAssessments(crn, nomsNumber, startDate, endDate)
+    val domainEventsJson = cas2v2SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate, "CAS2V2")
+    val domainEventsMetaDataJson =
+      cas2v2SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate, "CAS2V2")
+
+    if (listOf(
+        applicationsJson,
+        applicationNotesJson,
+        statusUpdatesJson,
+        statusUpdateDetailsJson,
+        assessmentsJson,
+        domainEventsJson,
+        domainEventsMetaDataJson,
+
+      ).all { it == null }
+    ) {
+      return null
+    }
+
+    val result = """
+      {
+         "Applications": ${ applicationsJson ?: "[]"},
+         "ApplicationNotes": ${ applicationNotesJson ?: "[]"},
+         "Assessments": ${ assessmentsJson ?: "[]"},
+         "StatusUpdates": ${ statusUpdatesJson ?: "[]"},
+         "StatusUpdateDetails": ${ statusUpdateDetailsJson ?: "[]"},
+         "DomainEvents": ${ domainEventsJson ?: "[]"},
+         "DomainEventsMetadata": ${ domainEventsMetaDataJson ?: "[]"}
+      }
+    """.trimIndent()
+
+    return result
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcSubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/service/Cas2HdcSubjectAccessRequestService.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2SubjectAccessRequestRepository
+import java.time.LocalDateTime
+
+@Service
+class Cas2HdcSubjectAccessRequestService(
+  val cas2SubjectAccessRequestRepository: Cas2SubjectAccessRequestRepository,
+) {
+
+  fun getSarResult(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
+    val applicationsJson = cas2SubjectAccessRequestRepository.getApplicationsJson(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
+    val applicationNotesJson =
+      cas2SubjectAccessRequestRepository.getApplicationNotes(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
+    val statusUpdatesJson = cas2SubjectAccessRequestRepository.getStatusUpdates(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
+    val statusUpdateDetailsJson =
+      cas2SubjectAccessRequestRepository.getStatusUpdateDetails(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
+    val assessmentsJson = cas2SubjectAccessRequestRepository.getAssessments(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
+    val domainEventsJson = cas2SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate, "CAS2")
+    val domainEventsMetaDataJson =
+      cas2SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate, "CAS2")
+
+    if (listOf(
+        applicationsJson,
+        applicationNotesJson,
+        statusUpdatesJson,
+        statusUpdateDetailsJson,
+        assessmentsJson,
+        domainEventsJson,
+        domainEventsMetaDataJson,
+
+      ).all { it == null }
+    ) {
+      return null
+    }
+
+    val result = """
+      {
+         "Applications": ${ applicationsJson ?: "[]"},
+         "ApplicationNotes": ${ applicationNotesJson ?: "[]"},
+         "Assessments": ${ assessmentsJson ?: "[]"},
+         "StatusUpdates": ${ statusUpdatesJson ?: "[]"},
+         "StatusUpdateDetails": ${ statusUpdateDetailsJson ?: "[]"},
+         "DomainEvents": ${ domainEventsJson ?: "[]"},
+         "DomainEventsMetadata": ${ domainEventsMetaDataJson ?: "[]"}
+      }
+    """.trimIndent()
+
+    return result
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3SubjectAccessRequestService.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.CAS3SubjectAccessRequestRepository
+import java.time.LocalDateTime
+
+@Service
+class Cas3SubjectAccessRequestService(
+  val cas3SubjectAccessRequestRepository: CAS3SubjectAccessRequestRepository,
+) {
+
+  fun getSarResult(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
+    val temporaryAccommodationApplicationsJson = cas3SubjectAccessRequestRepository.temporaryAccommodationApplications(crn, nomsNumber, startDate, endDate)
+    val temporaryAccommodationAssessmentsJson = cas3SubjectAccessRequestRepository.temporaryAccommodationAssessments(crn, nomsNumber, startDate, endDate)
+    val assessmentReferralHistoryNotesJson = cas3SubjectAccessRequestRepository.assessmentReferralHistoryNotes(crn, nomsNumber, startDate, endDate)
+    val bookingsJson = cas3SubjectAccessRequestRepository.temporaryAccommodationBookings(crn, nomsNumber, startDate, endDate)
+    val bookingExtensionsJson = cas3SubjectAccessRequestRepository.bookingExtensions(crn, nomsNumber, startDate, endDate)
+    val cancellationsJson = cas3SubjectAccessRequestRepository.cancellations(crn, nomsNumber, startDate, endDate)
+    val domainEventsJson = cas3SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate, "CAS3")
+    val domainEventsMetaDataJson = cas3SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate, "CAS3")
+
+    if (listOf(
+        temporaryAccommodationApplicationsJson,
+        temporaryAccommodationAssessmentsJson,
+        assessmentReferralHistoryNotesJson,
+        bookingsJson,
+        bookingExtensionsJson,
+        cancellationsJson,
+        domainEventsJson,
+        domainEventsMetaDataJson,
+      ).all { it == null }
+    ) {
+      return null
+    }
+
+    val result = """
+      {
+         "Applications": ${ temporaryAccommodationApplicationsJson ?: "[]"},
+         "Assessments": ${ temporaryAccommodationAssessmentsJson ?: "[]"},
+         "AssessmentReferralHistoryNotes": ${ assessmentReferralHistoryNotesJson ?: "[]"},
+         "Bookings": ${ bookingsJson ?: "[]"},
+         "BookingExtensions": ${ bookingExtensionsJson ?: "[]"},
+         "Cancellations": ${ cancellationsJson ?: "[]"},
+         "DomainEvents": ${ domainEventsJson ?: "[]"},
+         "DomainEventsMetadata": ${ domainEventsMetaDataJson ?: "[]"}
+      }
+    """.trimIndent()
+
+    return result
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/subjectaccessrequests/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/subjectaccessrequests/SubjectAccessRequestService.kt
@@ -1,15 +1,11 @@
 package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.subjectaccessrequests
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import org.json.JSONObject
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.jpa.entity.Cas2v2SubjectAccessRequestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.jpa.entity.Cas2SubjectAccessRequestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.jpa.entity.CAS3SubjectAccessRequestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CAS1SubjectAccessRequestRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.service.Cas1SubjectAccessRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2SubjectAccessRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcSubjectAccessRequestService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3SubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonProbationSubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
 import java.time.LocalDate
@@ -18,206 +14,17 @@ import java.time.LocalTime
 
 @Service
 class SubjectAccessRequestService(
-  val jsonMapper: JsonMapper,
-  val cas1SubjectAccessRequestRepository: CAS1SubjectAccessRequestRepository,
-  val cas2SubjectAccessRequestRepository: Cas2SubjectAccessRequestRepository,
-  val cas3SubjectAccessRequestRepository: CAS3SubjectAccessRequestRepository,
-  val cas2v2SubjectAccessRequestRepository: Cas2v2SubjectAccessRequestRepository,
+  val cas1SubjectAccessRequestService: Cas1SubjectAccessRequestService,
+  val cas2SubjectAccessRequestService: Cas2SubjectAccessRequestService,
+  val cas2HdcSubjectAccessRequestService: Cas2HdcSubjectAccessRequestService,
+  val cas3SubjectAccessRequestService: Cas3SubjectAccessRequestService,
 ) : HmppsPrisonProbationSubjectAccessRequestService {
 
-  private val log = LoggerFactory.getLogger(this::class.java)
-
-  @SuppressWarnings("CyclomaticComplexMethod")
-  fun getCAS1Result(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
-    val approvedPremisesApplicationsJson = cas1SubjectAccessRequestRepository.getApprovedPremisesApplicationsJson(crn, nomsNumber, startDate, endDate)
-    val apApplicationTimelineJson = cas1SubjectAccessRequestRepository.getApprovedPremisesApplicationTimeLineJson(crn, nomsNumber, startDate, endDate)
-    val apAssessmentsJson = cas1SubjectAccessRequestRepository.getApprovedPremisesAssessments(crn, nomsNumber, startDate, endDate)
-    val apAssessmentClarificationNotesJson = cas1SubjectAccessRequestRepository.getApprovedPremisesAssessmentClarificationNotes(crn, nomsNumber, startDate, endDate)
-
-    val apSpaceBookingsJson = cas1SubjectAccessRequestRepository.spaceBookings(crn, nomsNumber, startDate, endDate)
-    val domainEventsJson = cas1SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate)
-    val domainEventMetaDataJson = cas1SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate)
-
-    val placementApplicationsJson = cas1SubjectAccessRequestRepository.placementApplications(crn, nomsNumber, startDate, endDate)
-    val placementRequestsJson = cas1SubjectAccessRequestRepository.placementRequests(crn, nomsNumber, startDate, endDate)
-    val placementRequirementsJson = cas1SubjectAccessRequestRepository.placementRequirements(crn, nomsNumber, startDate, endDate)
-    val placementRequirementCriteriaJson = cas1SubjectAccessRequestRepository.placementRequirementsCriteria(crn, nomsNumber, startDate, endDate)
-    val offlineApplicationsJson = cas1SubjectAccessRequestRepository.offlineApplications(crn, nomsNumber, startDate, endDate)
-    val bookingNotMadesJson = cas1SubjectAccessRequestRepository.bookingNotMades(crn, nomsNumber, startDate, endDate)
-    val appealsJson = cas1SubjectAccessRequestRepository.appeals(crn, nomsNumber, startDate, endDate)
-
-    if (listOf(
-        approvedPremisesApplicationsJson,
-        apApplicationTimelineJson,
-        apAssessmentsJson,
-        apAssessmentClarificationNotesJson,
-        apSpaceBookingsJson,
-        domainEventsJson,
-        domainEventMetaDataJson,
-        placementApplicationsJson,
-        placementRequestsJson,
-        placementRequirementsJson,
-        placementRequirementCriteriaJson,
-        offlineApplicationsJson,
-        bookingNotMadesJson,
-        appealsJson,
-      ).all { it == null }
-    ) {
-      return null
-    }
-
-    val result = """
-      {
-         "Applications": ${ approvedPremisesApplicationsJson ?: "[]"},
-         "ApplicationTimeline": ${ apApplicationTimelineJson ?: "[]"},
-         "Assessments": ${ apAssessmentsJson ?: "[]"},
-         "AssessmentClarificationNotes": ${ apAssessmentClarificationNotesJson ?: "[]"},
-         "SpaceBookings": ${ apSpaceBookingsJson ?: "[]"},
-         "OfflineApplications": ${ offlineApplicationsJson ?: "[]"},
-         "Appeals": ${ appealsJson ?: "[]"},
-         "PlacementApplications": ${ placementApplicationsJson ?: "[]"},
-         "PlacementRequests": ${ placementRequestsJson ?: "[]"},
-         "PlacementRequirements": ${ placementRequirementsJson ?: "[]"},
-         "PlacementRequirementCriteria": ${ placementRequirementCriteriaJson ?: "[]"},
-         "BookingNotMades": ${ bookingNotMadesJson ?: "[]"},
-         "DomainEvents": ${ domainEventsJson ?: "[]"},
-         "DomainEventsMetadata": ${ domainEventMetaDataJson ?: "[]"}
-      }
-    """.trimIndent()
-    log.logDebugMessage("CAS1", result)
-
-    return result
-  }
-
-  fun getCAS3Result(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
-    val temporaryAccommodationApplicationsJson = cas3SubjectAccessRequestRepository.temporaryAccommodationApplications(crn, nomsNumber, startDate, endDate)
-    val temporaryAccommodationAssessmentsJson = cas3SubjectAccessRequestRepository.temporaryAccommodationAssessments(crn, nomsNumber, startDate, endDate)
-    val assessmentReferralHistoryNotesJson = cas3SubjectAccessRequestRepository.assessmentReferralHistoryNotes(crn, nomsNumber, startDate, endDate)
-    val bookingsJson = cas3SubjectAccessRequestRepository.temporaryAccommodationBookings(crn, nomsNumber, startDate, endDate)
-    val bookingExtensionsJson = cas3SubjectAccessRequestRepository.bookingExtensions(crn, nomsNumber, startDate, endDate)
-    val cancellationsJson = cas3SubjectAccessRequestRepository.cancellations(crn, nomsNumber, startDate, endDate)
-    val domainEventsJson = cas3SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate, "CAS3")
-    val domainEventsMetaDataJson = cas3SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate, "CAS3")
-
-    if (listOf(
-        temporaryAccommodationApplicationsJson,
-        temporaryAccommodationAssessmentsJson,
-        assessmentReferralHistoryNotesJson,
-        bookingsJson,
-        bookingExtensionsJson,
-        cancellationsJson,
-        domainEventsJson,
-        domainEventsMetaDataJson,
-      ).all { it == null }
-    ) {
-      return null
-    }
-
-    val result = """
-      {
-         "Applications": ${ temporaryAccommodationApplicationsJson ?: "[]"},
-         "Assessments": ${ temporaryAccommodationAssessmentsJson ?: "[]"},
-         "AssessmentReferralHistoryNotes": ${ assessmentReferralHistoryNotesJson ?: "[]"},
-         "Bookings": ${ bookingsJson ?: "[]"},
-         "BookingExtensions": ${ bookingExtensionsJson ?: "[]"},
-         "Cancellations": ${ cancellationsJson ?: "[]"},
-         "DomainEvents": ${ domainEventsJson ?: "[]"},
-         "DomainEventsMetadata": ${ domainEventsMetaDataJson ?: "[]"}
-      }
-    """.trimIndent()
-
-    log.logDebugMessage("CAS3", result)
-    return result
-  }
-
-  fun getCAS2Result(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
-    val applicationsJson = cas2SubjectAccessRequestRepository.getApplicationsJson(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
-    val applicationNotesJson =
-      cas2SubjectAccessRequestRepository.getApplicationNotes(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
-    val statusUpdatesJson = cas2SubjectAccessRequestRepository.getStatusUpdates(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
-    val statusUpdateDetailsJson =
-      cas2SubjectAccessRequestRepository.getStatusUpdateDetails(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
-    val assessmentsJson = cas2SubjectAccessRequestRepository.getAssessments(crn, nomsNumber, startDate, endDate, Cas2ServiceOrigin.HDC.toString())
-    val domainEventsJson = cas2SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate, "CAS2")
-    val domainEventsMetaDataJson =
-      cas2SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate, "CAS2")
-
-    if (listOf(
-        applicationsJson,
-        applicationNotesJson,
-        statusUpdatesJson,
-        statusUpdateDetailsJson,
-        assessmentsJson,
-        domainEventsJson,
-        domainEventsMetaDataJson,
-
-      ).all { it == null }
-    ) {
-      return null
-    }
-
-    val result = """
-      {
-         "Applications": ${ applicationsJson ?: "[]"},
-         "ApplicationNotes": ${ applicationNotesJson ?: "[]"},
-         "Assessments": ${ assessmentsJson ?: "[]"},
-         "StatusUpdates": ${ statusUpdatesJson ?: "[]"},
-         "StatusUpdateDetails": ${ statusUpdateDetailsJson ?: "[]"},
-         "DomainEvents": ${ domainEventsJson ?: "[]"},
-         "DomainEventsMetadata": ${ domainEventsMetaDataJson ?: "[]"}
-      }
-    """.trimIndent()
-    log.logDebugMessage("CAS2", result)
-
-    return result
-  }
-
-  fun getCAS2v2Result(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
-    val applicationsJson = cas2v2SubjectAccessRequestRepository.getApplicationsJson(crn, nomsNumber, startDate, endDate)
-    val applicationNotesJson = cas2v2SubjectAccessRequestRepository.getApplicationNotes(crn, nomsNumber, startDate, endDate)
-    val statusUpdatesJson = cas2v2SubjectAccessRequestRepository.getStatusUpdates(crn, nomsNumber, startDate, endDate)
-    val statusUpdateDetailsJson =
-      cas2v2SubjectAccessRequestRepository.getStatusUpdateDetails(crn, nomsNumber, startDate, endDate)
-    val assessmentsJson = cas2v2SubjectAccessRequestRepository.getAssessments(crn, nomsNumber, startDate, endDate)
-    val domainEventsJson = cas2v2SubjectAccessRequestRepository.domainEvents(crn, nomsNumber, startDate, endDate, "CAS2V2")
-    val domainEventsMetaDataJson =
-      cas2v2SubjectAccessRequestRepository.domainEventMetadata(crn, nomsNumber, startDate, endDate, "CAS2V2")
-
-    if (listOf(
-        applicationsJson,
-        applicationNotesJson,
-        statusUpdatesJson,
-        statusUpdateDetailsJson,
-        assessmentsJson,
-        domainEventsJson,
-        domainEventsMetaDataJson,
-
-      ).all { it == null }
-    ) {
-      return null
-    }
-
-    val result = """
-      {
-         "Applications": ${ applicationsJson ?: "[]"},
-         "ApplicationNotes": ${ applicationNotesJson ?: "[]"},
-         "Assessments": ${ assessmentsJson ?: "[]"},
-         "StatusUpdates": ${ statusUpdatesJson ?: "[]"},
-         "StatusUpdateDetails": ${ statusUpdateDetailsJson ?: "[]"},
-         "DomainEvents": ${ domainEventsJson ?: "[]"},
-         "DomainEventsMetadata": ${ domainEventsMetaDataJson ?: "[]"}
-      }
-    """.trimIndent()
-    log.logDebugMessage("CAS2v2", result)
-
-    return result
-  }
-
   fun getSarResult(crn: String?, nomsNumber: String?, startDate: LocalDateTime?, endDate: LocalDateTime?): String? {
-    val approvedPremises = getCAS1Result(crn, nomsNumber, startDate, endDate)
-    val temporaryAccommodation = getCAS3Result(crn, nomsNumber, startDate, endDate)
-    val shortTermAccommodation = getCAS2Result(crn, nomsNumber, startDate, endDate)
-    val bailAccommodation = getCAS2v2Result(crn, nomsNumber, startDate, endDate)
+    val approvedPremises = cas1SubjectAccessRequestService.getSarResult(crn, nomsNumber, startDate, endDate)
+    val temporaryAccommodation = cas3SubjectAccessRequestService.getSarResult(crn, nomsNumber, startDate, endDate)
+    val shortTermAccommodation = cas2HdcSubjectAccessRequestService.getSarResult(crn, nomsNumber, startDate, endDate)
+    val bailAccommodation = cas2SubjectAccessRequestService.getSarResult(crn, nomsNumber, startDate, endDate)
 
     if (listOf(approvedPremises, temporaryAccommodation, shortTermAccommodation, bailAccommodation).all { it == null }) {
       return null
@@ -253,13 +60,5 @@ class SubjectAccessRequestService(
       content = JSONObject(sarResults)
         .toMap().entries,
     )
-  }
-  private fun Logger.logDebugMessage(service: String, result: String) {
-    if (this.isDebugEnabled) {
-      val prettyPrintJson = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(
-        jsonMapper.readValue(result, Any::class.java),
-      )
-      log.debug("$service SAR Result is $prettyPrintJson")
-    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/sar/Cas1SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas1/integration/sar/Cas1SubjectAccessRequestServiceTest.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.integration.sar
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.SituationOption
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.dto.Cas1ApplicationTimelinessCategory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas1.service.Cas1SubjectAccessRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.community.OffenderDetailSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
@@ -25,13 +27,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.ApprovedPremisesTy
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.assertJsonEquals
 
 @SuppressWarnings("LargeClass")
-class CAS1SarServiceTest : Cas1SarTestBase() {
+class Cas1SubjectAccessRequestServiceTest : Cas1SarTestBase() {
+
+  @Autowired
+  lateinit var cas1SarService: Cas1SubjectAccessRequestService
 
   @Test
   fun `Get CAS1 Information - No Results`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS1Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNull(result)
   }
@@ -40,7 +45,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
   fun `Get CAS1 Information - Test Null Dates`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS1Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
+      cas1SarService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
 
     assertNull(result)
   }
@@ -52,7 +57,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val application = approvedPremisesApplicationEntity(offenderDetails)
 
     val result =
-      sarService.getCAS1Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
     assertNotNull(result)
 
     val expectedJson = """
@@ -87,7 +92,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
 
     val timelineNotes = applicationTimelineNoteEntity(application)
 
-    val result = sarService.getCAS1Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+    val result = cas1SarService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -124,7 +129,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val assessment = approvedPremisesAssessmentEntity(application)
 
     val result =
-      sarService.getCAS1Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -157,7 +162,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val clarificationNote = approvedPremisesAssessmentClarificationNoteEntity(assessment)
 
     val result =
-      sarService.getCAS1Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -207,7 +212,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     )
 
     val result =
-      sarService.getCAS1Result(
+      cas1SarService.getSarResult(
         offenderDetails.otherIds.crn,
         offenderDetails.otherIds.nomsNumber,
         START_DATE,
@@ -248,7 +253,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     )
 
     val result =
-      sarService.getCAS1Result(
+      cas1SarService.getSarResult(
         offenderDetails.otherIds.crn,
         offenderDetails.otherIds.nomsNumber,
         START_DATE,
@@ -285,7 +290,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val application = approvedPremisesApplicationEntity(offenderDetails)
 
     val result =
-      sarService.getCAS1Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -319,7 +324,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val appeal = appealEntity(application, assessment)
 
     val result =
-      sarService.getCAS1Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -352,7 +357,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
 
     val placementApplication = placementApplicationEntity(application)
     val result =
-      sarService.getCAS1Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -387,7 +392,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
 
     val placementRequest = placementRequestEntity(assessment, application, placementApplication)
     val result =
-      sarService.getCAS1Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -423,7 +428,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val bookingNotMade = bookingNotMadeEntity(placementRequest)
 
     val result =
-      sarService.getCAS1Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas1SarService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -457,7 +462,7 @@ class CAS1SarServiceTest : Cas1SarTestBase() {
     val assessment = approvedPremisesAssessmentEntity(application)
     val user = userEntity()
     val domainEvent = domainEventEntity(offender, application.id, assessment.id, user.id, DomainEventType.APPROVED_PREMISES_ASSESSMENT_INFO_REQUESTED)
-    val result = sarService.getCAS1Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+    val result = cas1SarService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/sar/Cas2HdcSubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2hdc/integration/sar/Cas2HdcSubjectAccessRequestServiceTest.kt
@@ -3,18 +3,23 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.integration.sar
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.service.Cas2HdcSubjectAccessRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.assertJsonEquals
 
-class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
+class Cas2HdcSubjectAccessRequestServiceTest : Cas2SarTestBase() {
+
+  @Autowired
+  lateinit var cas2HdcSubjectAccessRequestService: Cas2HdcSubjectAccessRequestService
 
   @Test
   fun `Get CAS2 Information - No Results`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS2Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas2HdcSubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNull(result)
   }
@@ -23,7 +28,7 @@ class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
   fun `Get CAS2 Information - null date Check`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS2Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
+      cas2HdcSubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
 
     assertNull(result)
   }
@@ -35,7 +40,7 @@ class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
 
     val application = cas2ApplicationEntity(offenderDetails, user)
 
-    val result = sarService.getCAS2Result(
+    val result = cas2HdcSubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -66,7 +71,7 @@ class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
     val application = cas2ApplicationEntity(offenderDetails, user)
     val assessment = cas2AssessmentEntity(application)
 
-    val result = sarService.getCAS2Result(
+    val result = cas2HdcSubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -99,7 +104,7 @@ class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
 
     val applicationNotes = cas2ApplicationNoteEntity(application, assessment, user)
 
-    val result = sarService.getCAS2Result(
+    val result = cas2HdcSubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -135,7 +140,7 @@ class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
     val statusUpdate = cas2StatusUpdateEntity(application, assessment, assessor)
     val statusUpdateDetail = cas2StatusUpdateDetailEntity(statusUpdate)
 
-    val result = sarService.getCAS2Result(
+    val result = cas2HdcSubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -172,7 +177,7 @@ class CAS2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
     val statusUpdateDetail = cas2StatusUpdateDetailEntity(statusUpdate)
     val domainEvent = domainEventEntity(offenderDetails, application.id, assessment.id, null, DomainEventType.CAS2_APPLICATION_SUBMITTED, ServiceName.cas2)
 
-    val result = sarService.getCAS2Result(
+    val result = cas2HdcSubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/sar/Cas2v2SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas2v2/integration/sar/Cas2v2SubjectAccessRequestServiceTest.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2v2.integration.sar
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.model.Cas2ServiceOrigin
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2.service.Cas2SubjectAccessRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas2hdc.integration.sar.Cas2SarTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventType
@@ -12,11 +14,14 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.assertJsonEquals
 
 class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
 
+  @Autowired
+  lateinit var cas2SubjectAccessRequestService: Cas2SubjectAccessRequestService
+
   @Test
   fun `Get CAS2 v2 Information - No Results`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS2v2Result(
+      cas2SubjectAccessRequestService.getSarResult(
         offenderDetails.otherIds.crn,
         offenderDetails.otherIds.nomsNumber,
         START_DATE,
@@ -30,7 +35,7 @@ class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
   fun `Get CAS2 v2 Information - null date Check`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS2Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
+      cas2SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
 
     assertNull(result)
   }
@@ -42,7 +47,7 @@ class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
 
     val application = cas2ApplicationEntity(offenderDetails, user, Cas2ServiceOrigin.BAIL)
 
-    val result = sarService.getCAS2v2Result(
+    val result = cas2SubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -73,7 +78,7 @@ class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
     val application = cas2ApplicationEntity(offenderDetails, user, Cas2ServiceOrigin.BAIL)
     val assessment = cas2AssessmentEntity(application, Cas2ServiceOrigin.BAIL)
 
-    val result = sarService.getCAS2v2Result(
+    val result = cas2SubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -106,7 +111,7 @@ class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
 
     val applicationNotes = cas2ApplicationNoteEntity(application, assessment, user)
 
-    val result = sarService.getCAS2v2Result(
+    val result = cas2SubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -142,7 +147,7 @@ class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
     val statusUpdate = cas2StatusUpdateEntity(application, assessment, user)
     val statusUpdateDetail = cas2StatusUpdateDetailEntity(statusUpdate)
 
-    val result = sarService.getCAS2v2Result(
+    val result = cas2SubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,
@@ -178,7 +183,7 @@ class Cas2v2SubjectAccessRequestServiceTest : Cas2SarTestBase() {
     val statusUpdateDetail = cas2StatusUpdateDetailEntity(statusUpdate)
     val domainEvent = domainEventEntity(offenderDetails, application.id, assessment.id, null, DomainEventType.CAS2_APPLICATION_SUBMITTED, ServiceName.cas2v2)
 
-    val result = sarService.getCAS2v2Result(
+    val result = cas2SubjectAccessRequestService.getSarResult(
       offenderDetails.otherIds.crn,
       offenderDetails.otherIds.nomsNumber,
       START_DATE,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/sar/Cas3SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/sar/Cas3SubjectAccessRequestServiceTest.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.integration.sar
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.ServiceName
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.service.Cas3SubjectAccessRequestService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.SubjectAccessRequestServiceTestBase
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.givens.givenAnOffender
@@ -19,13 +21,16 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.assertJsonEquals
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.util.randomStringMultiCaseWithNumbers
 import java.time.OffsetDateTime
 
-class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase() {
+class Cas3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase() {
+
+  @Autowired
+  lateinit var cas3SubjectAccessRequestService: Cas3SubjectAccessRequestService
 
   @Test
   fun `Get CAS3 Information - No Results`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNull(result)
   }
@@ -34,7 +39,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
   fun `Get CAS3 Information - Null dates check`() {
     val (offenderDetails, _) = givenAnOffender()
     val result =
-      sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
+      cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, null, null)
 
     assertNull(result)
   }
@@ -44,7 +49,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val (offenderDetails, _) = givenAnOffender()
     val (user, _) = givenAUser()
     val temporaryAccommodationApplication = temporaryAccommodationApplicationEntity(offenderDetails, user)
-    val result = sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+    val result = cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
     assertNotNull(result)
 
     val expectedJson = """
@@ -69,7 +74,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val (user, _) = givenAUser()
     val temporaryAccommodationApplication = temporaryAccommodationApplicationEntity(offenderDetails, user)
     val temporaryAccomodationAssessment = temporaryAccommodationAssessmentEntity(temporaryAccommodationApplication)
-    val result = sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+    val result = cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -98,7 +103,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val assessmentReferralHistoryNoteSystem =
       assessmentReferralHistorySystemNoteEntity(temporaryAccomodationAssessment, user)
     val assessmentReferralHistoryNoteUser = assessmentReferralHistoryUserNoteEntity(temporaryAccomodationAssessment, user)
-    val result = sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+    val result = cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -127,7 +132,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val booking = bookingEntity(offenderDetails, application)
 
     val result =
-      sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -157,7 +162,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val bookingExtension = bookingExtensionEntity(booking)
 
     val result =
-      sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -186,7 +191,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val cancellation = cancellationEntity(booking)
 
     val result =
-      sarService.getCAS3Result(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
+      cas3SubjectAccessRequestService.getSarResult(offenderDetails.otherIds.crn, offenderDetails.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 
@@ -214,7 +219,7 @@ class CAS3SubjectAccessRequestServiceTest : SubjectAccessRequestServiceTestBase(
     val assessment = temporaryAccommodationAssessmentEntity(application)
 
     val domainEvent = domainEventEntity(offender, application.id, assessment.id, user.id, DomainEventType.CAS3_REFERRAL_SUBMITTED, ServiceName.temporaryAccommodation)
-    val result = sarService.getCAS3Result(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
+    val result = cas3SubjectAccessRequestService.getSarResult(offender.otherIds.crn, offender.otherIds.nomsNumber, START_DATE, END_DATE)
 
     assertNotNull(result)
 


### PR DESCRIPTION
This change moves the logic that provides the raw data for SAR reports into a separate service for each CAS. This better aligns with the existing integration tests that are broken down by CAS. It also makes the code more manageable