### PR TITLE
Upgrade SAR Test Library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
   testImplementation("org.wiremock.integrations:wiremock-spring-boot:4.2.2")
 
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:$hmppsSpringBootStarterVersion")
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.4.3")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.8.0")
   // Used directly in our tests for JSON response assertions.
   // Also aligned with the approach used in the SAR team's tests.
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:5.1.1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/sar/CasSarFixtureAsserter.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/sar/CasSarFixtureAsserter.kt
@@ -41,13 +41,17 @@ class CasSarFixtureAsserter(
   private val generatedReportFilename: String,
 ) {
 
+  companion object {
+    val DEFAULT_CONTENT_TYPE = Any::class.java
+  }
+
   fun assertApiDataMatchesFixture(
     prn: String? = null,
     crn: String? = null,
     fromDate: LocalDate? = null,
     toDate: LocalDate? = null,
   ) {
-    val response = sarHelper.requestSarData(prn, crn, fromDate, toDate, webTestClient)
+    val response = sarHelper.requestSarData(prn, crn, fromDate, toDate, webTestClient, DEFAULT_CONTENT_TYPE)
     val actualJson = sarHelper.toJson(response)
 
     if (generateActual()) {
@@ -73,7 +77,7 @@ class CasSarFixtureAsserter(
     sarHelper.stubFindLocationNameByNomisIdWith("PROPERTY BOX 1")
     sarHelper.stubFindLocationNameByDpsIdWith("PROPERTY BOX 2")
 
-    val dataResponse = sarHelper.requestSarData(prn, crn, fromDate, toDate, webTestClient)
+    val dataResponse = sarHelper.requestSarData(prn, crn, fromDate, toDate, webTestClient, DEFAULT_CONTENT_TYPE)
     val templateResponse = sarHelper.requestSarTemplate(webTestClient)
 
     val renderResult = sarHelper.renderServiceReport(


### PR DESCRIPTION
The new library needs us to pass a content type when requesting SAR Data. I’ve used the same default content type used by the default tests defined by the test library.