### PR TITLE
Run inbox event dispatcher more often

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -368,8 +368,8 @@ domain-events:
     enabled: true
   inbox:
     dispatcher:
-      # every 5 seconds
-      cron: '*/5 * * * * *'
+      # every 1 second
+      cron: '*/1 * * * * *'
       max-events-per-batch: 10
       max-concurrent-events: 4
       shedlock:


### PR DESCRIPTION
This is help quickly recover from batch recalculation of tiers, as observed in pre-prod