### PR TITLE
SAS 883: filter default rejection rationale

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.Tem
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.cas3.model.generated.TemporaryAccommodationUser
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummary
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainAssessmentSummaryStatus
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
@@ -96,7 +97,7 @@ class Cas3AssessmentTransformer(
       applicationStatus = application.getStatus(),
       assessmentStatus = a.deriveAssessmentStatus(),
       type = ServiceType.CAS3,
-      referralRejectionReason = a.referralRejectionReason?.name ?: a.rejectionRationale?.takeUnless { it == "default" },
+      referralRejectionReason = a.referralRejectionReason?.takeUnless { it.isDefault() }?.name ?: a.rejectionRationale?.takeUnless { it == ReferralRejectionReasonRepository.DEFAULT_NAME },
       referralRejectionReasonDetail = a.referralRejectionReasonDetail,
       localAuthorityArea = application.dutyToReferLocalAuthorityAreaName,
       pdu = application.probationDeliveryUnit?.name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/transformer/Cas3AssessmentTransformer.kt
@@ -96,7 +96,7 @@ class Cas3AssessmentTransformer(
       applicationStatus = application.getStatus(),
       assessmentStatus = a.deriveAssessmentStatus(),
       type = ServiceType.CAS3,
-      referralRejectionReason = a.referralRejectionReason?.name ?: a.rejectionRationale,
+      referralRejectionReason = a.referralRejectionReason?.name ?: a.rejectionRationale?.takeUnless { it == "default" },
       referralRejectionReasonDetail = a.referralRejectionReasonDetail,
       localAuthorityArea = application.dutyToReferLocalAuthorityAreaName,
       pdu = application.probationDeliveryUnit?.name,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReferralRejectionReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/ReferralRejectionReasonEntity.kt
@@ -12,6 +12,10 @@ import java.util.UUID
 
 @Repository
 interface ReferralRejectionReasonRepository : JpaRepository<ReferralRejectionReasonEntity, UUID> {
+  companion object Constants {
+    const val DEFAULT_NAME = "default"
+  }
+
   @Query("SELECT rr FROM ReferralRejectionReasonEntity rr WHERE rr.name = :name AND rr.isActive = true")
   fun findByNameAndActive(name: String): ReferralRejectionReasonEntity?
 
@@ -29,5 +33,7 @@ data class ReferralRejectionReasonEntity(
   val name: String,
   val isActive: Boolean,
 ) {
+  fun isDefault() = name == ReferralRejectionReasonRepository.DEFAULT_NAME
+
   override fun toString() = "ReferralRejectionReasonEntity:$id"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/integration/external/Cas3ExternalReferralTest.kt
@@ -68,6 +68,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
           val assessment3 = createAssessment(user, AssessmentDecision.ACCEPTED, OffsetDateTime.now(), premises = premises)
           val assessment4 = createAssessment(user, null, null, user, premises = premises)
           val assessment5 = createAssessment(user, premises = premises)
+          val assessment6 = createAssessment(user, AssessmentDecision.REJECTED, premises = premises, rejectionRationale = "default")
 
           val expectedReferrals = listOf(
             Cas3ReferralHistory(
@@ -150,6 +151,22 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
               bookingStatus = Cas3BookingStatus.provisional,
               uiUrl = "http://frontend.cas3/referrals/${assessment5.application.id}/full",
             ),
+            Cas3ReferralHistory(
+              id = assessment6.id,
+              applicationId = assessment6.application.id,
+              date = assessment6.createdAt.toLocalDate(),
+              applicationStatus = ApplicationStatus.submitted,
+              assessmentStatus = assessment6.deriveAssessmentStatus(),
+              type = ServiceType.CAS3,
+              referralRejectionReason = null,
+              referralRejectionReasonDetail = null,
+              localAuthorityArea = (assessment6.application as TemporaryAccommodationApplicationEntity).dutyToReferLocalAuthorityAreaName,
+              pdu = (assessment6.application as TemporaryAccommodationApplicationEntity).probationDeliveryUnit?.name,
+              referredBy = createStaffDto(user),
+              placementAddress = "10 Test Street, London, SW1A 1AA",
+              bookingStatus = Cas3BookingStatus.provisional,
+              uiUrl = "http://frontend.cas3/referrals/${assessment6.application.id}/full",
+            ),
           )
 
           val response = webTestClient.get()
@@ -180,6 +197,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
     premises: Cas3PremisesEntity? = null,
     referralRejectionReason: String? = null,
     referralRejectionReasonDetail: String? = null,
+    rejectionRationale: String? = null,
   ): TemporaryAccommodationAssessmentEntity {
     val application = temporaryAccommodationApplicationEntityFactory.produceAndPersist {
       withCrn(crn)
@@ -193,6 +211,7 @@ class Cas3ExternalReferralTest : Cas3IntegrationTestBase() {
       withDecision(decision)
       withCompletedAt(completedAt)
       withAllocatedToUser(allocated)
+      withRejectionRationale(rejectionRationale)
       if (referralRejectionReason != null) withReferralRejectionReason(referralRejectionReasonEntityFactory.produceAndPersist { withName(referralRejectionReason) })
       if (referralRejectionReasonDetail != null) withReferralRejectionReasonDetail(referralRejectionReasonDetail)
     }


### PR DESCRIPTION
[This](https://dsdmoj.atlassian.net/browse/SAS-883) filters out 'default" rejection rationale.

FE was displaying "default" for rejection reason when there wasn't a `referralRejectionReason` and the fallback `rejectionRationale` was just "default"