### PR TITLE
Suppress case not found alerts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ApplicationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/controller/Cas3ApplicationsController.kt
@@ -83,7 +83,7 @@ class Cas3ApplicationsController(
     val user = userService.getUserForRequest()
 
     val personInfo =
-      when (val personInfoResult = offenderDetailService.getPersonInfoResult(body.crn, user.cas3LaoStrategy())) {
+      when (val personInfoResult = offenderDetailService.getPersonInfoResult(body.crn, user.cas3LaoStrategy(), includeTier = false)) {
         is PersonInfoResult.NotFound -> throw NotFoundProblem(
           personInfoResult.crn,
           "Offender",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3ApplicationService.kt
@@ -126,7 +126,7 @@ class Cas3ApplicationService(
     return validatedCasResult {
       val caseSummary =
         when (
-          val personSummaryInfoResult = offenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy())
+          val personSummaryInfoResult = offenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false)
         ) {
           is PersonSummaryInfoResult.NotFound -> return@validatedCasResult "$.crn" hasSingleValidationError "doesNotExist"
           is PersonSummaryInfoResult.Success.Restricted ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/service/Cas3BookingService.kt
@@ -143,6 +143,8 @@ class Cas3BookingService(
       return@validatedCasResult fieldValidationError
     }
 
+    caseService.ensureCaseExists(crn)
+
     val personResult = offenderService.getPersonSummaryInfoResult(crn, LaoStrategy.NeverRestricted)
     val offenderName = personResult.getPersonName()
 
@@ -177,8 +179,6 @@ class Cas3BookingService(
         offenderName = offenderName,
       ),
     )
-
-    caseService.ensureCaseExists(crn)
 
     val turnaround = cas3TurnaroundRepository.save(
       Cas3TurnaroundEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/common/service/CaseService.kt
@@ -160,6 +160,13 @@ class CaseService(
     is ClientResult.Failure -> caseSummariesResponse.throwException()
   }
 
+  /**
+   * This alert is a temporary measure whilst we introduce tiers across the
+   * service. The intention is to help us detect if there are any routes in
+   * the system where tier is required but a case does not yet exist for the CRN
+   *
+   * These paths may be legitimate (in which case a tier should not be requested)
+   */
   private fun alertCaseNotFound(crn: String) {
     sentryService.captureException(CaseNotFound("Case with CRN $crn not found"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3ApplicationServiceTest.kt
@@ -1017,7 +1017,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.NotFound(crn)
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.NotFound(crn)
 
       val result = cas3ApplicationService.createApplication(
         crn,
@@ -1054,7 +1054,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.Success.Restricted(crn, "noms123", TierDtoFactory().produce())
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.Success.Restricted(crn, "noms123", TierDtoFactory().produce())
 
       val result = cas3ApplicationService.createApplication(
         crn,
@@ -1091,7 +1091,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.Success.Full(
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.Success.Full(
         crn = crn,
         summary = CaseSummaryFactory().produce(),
         tier = TierDtoFactory().produce(),
@@ -1135,7 +1135,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.Success.Full(
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.Success.Full(
         crn = crn,
         summary = CaseSummaryFactory()
           .withName(NameFactory().withForename("John").withSurname("Jonson").produce())
@@ -1223,7 +1223,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.Success.Full(
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.Success.Full(
         crn = crn,
         summary = CaseSummaryFactory().produce(),
         tier = TierDtoFactory().produce(),
@@ -1305,7 +1305,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.Success.Full(
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.Success.Full(
         crn = crn,
         summary = CaseSummaryFactory().produce(),
         tier = TierDtoFactory().produce(),
@@ -1388,7 +1388,7 @@ class Cas3ApplicationServiceTest {
         )
       }
 
-      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy()) } returns PersonSummaryInfoResult.Success.Full(
+      every { mockOffenderService.getPersonSummaryInfoResult(crn, user.cas3LaoStrategy(), includeTier = false) } returns PersonSummaryInfoResult.Success.Full(
         crn = crn,
         summary = CaseSummaryFactory().produce(),
         tier = TierDtoFactory().produce(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/cas3/unit/service/Cas3BookingServiceTest.kt
@@ -1087,6 +1087,8 @@ class Cas3BookingServiceTest {
 
       every { mockCas3DomainEventService.saveBookingProvisionallyMadeEvent(any(), user) } just Runs
 
+      every { mockCaseService.ensureCaseExists(crn) } returns CaseDtoFactory().withCrn(crn).produce()
+
       assertThatExceptionOfType(RuntimeException::class.java)
         .isThrownBy {
           cas3BookingService.createBooking(
@@ -1128,7 +1130,7 @@ class Cas3BookingServiceTest {
         )
       }
 
-      verify(exactly = 0) {
+      verify(exactly = 1) {
         mockCaseService.ensureCaseExists(crn)
       }
     }


### PR DESCRIPTION
The ‘CaseNotFound’ alert is generated when person information is required for a CRN that has not yet been registered in the cases table (i.e. before an application has been created for that application). the alert occurs when an attempt is made to resolve the tier for that CRN.

This alert was added as a temporary measure whilst we introduce tiers across the service. The intention is help us detect if there are any routes in the system where tier is required but a case does not yet exist for the CRN

This PR suppresses the alert for routes where we know the calls are legitimate and tier isn't required
